### PR TITLE
Refactor group creation to improve member handling

### DIFF
--- a/.github/workflows/AgentExamplesRepo.yml
+++ b/.github/workflows/AgentExamplesRepo.yml
@@ -2,7 +2,7 @@ name: Check agent-examples
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 * * * *" # every hour
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/StressGroup.yml
+++ b/.github/workflows/StressGroup.yml
@@ -2,6 +2,8 @@ name: GroupStress
 description: Check that group stress testing is working correctly. If it fails notify the team.
 
 on:
+  schedule:
+    - cron: "0 * * * *" # every hour
   pull_request:
     branches:
       - main

--- a/.github/workflows/StressGroup.yml
+++ b/.github/workflows/StressGroup.yml
@@ -69,12 +69,6 @@ jobs:
             .data
             logs
           key: stress-group-data-${{ matrix.environment }}
-
-      - name: Send Slack notification
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-        run: npx tsx helpers/slack.ts
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -1,9 +1,5 @@
 name: Validate code quality
 
-on:
-  push:
-    branches-ignore: [main]
-
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/bots/stress/index.ts
+++ b/bots/stress/index.ts
@@ -7,7 +7,7 @@ import {
   type StressTestConfig,
 } from "@helpers/groups";
 import { getFixedNames, logAndSend, validateEnvironment } from "@helpers/tests";
-import { typeOfResponse, typeofStream } from "@workers/main";
+import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import {
   type Client,
@@ -163,6 +163,7 @@ const main = async () => {
     "stressbot",
     typeofStream.None,
     typeOfResponse.None,
+    typeOfSync.None,
     "dev",
   );
 
@@ -171,6 +172,7 @@ const main = async () => {
     "stressbot",
     typeofStream.None,
     typeOfResponse.None,
+    typeOfSync.None,
     "production",
   );
 

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -170,13 +170,6 @@ try {
           fs.mkdirSync(logsDir, { recursive: true });
         }
 
-        // Generate log file name
-        const timestamp = new Date()
-          .toISOString()
-          .replace(/[:.]/g, "-")
-          .replace("T", "-")
-          .split(".")[0];
-
         // Extract clean test name for log file (remove path and extension)
         let logFileName: string;
         if (customLogFile) {
@@ -218,14 +211,11 @@ try {
             shell: true,
           });
 
-          let hasOutput = false;
-
           const processOutput = (data: Buffer, isError = false) => {
             const text = data.toString();
             const filtered = filterOutput(text);
 
             if (filtered.trim()) {
-              hasOutput = true;
               // Write to console
               if (isError) {
                 process.stderr.write(filtered);

--- a/suites/automated/Agents/agents.test.ts
+++ b/suites/automated/Agents/agents.test.ts
@@ -2,7 +2,7 @@ import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
-import { typeOfResponse, typeofStream } from "@workers/main";
+import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { IdentifierKind } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -29,6 +29,7 @@ describe(testName, () => {
       testName,
       typeofStream.Message,
       typeOfResponse.None,
+      typeOfSync.None,
       "production",
     );
   });

--- a/suites/automated/Gm/gm.test.ts
+++ b/suites/automated/Gm/gm.test.ts
@@ -4,7 +4,7 @@ import { playwright } from "@helpers/playwright";
 import { verifyMessageStream } from "@helpers/streams";
 import { getAddresses, GM_BOT_ADDRESS } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
-import { typeOfResponse, typeofStream } from "@workers/main";
+import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { IdentifierKind } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -25,6 +25,7 @@ describe(testName, () => {
       testName,
       typeofStream.Message,
       typeOfResponse.None,
+      typeOfSync.None,
       "production",
     );
   });

--- a/suites/manual/notifications/notifications.test.ts
+++ b/suites/manual/notifications/notifications.test.ts
@@ -1,5 +1,5 @@
 import { loadEnv } from "@helpers/client";
-import { typeOfResponse, typeofStream } from "@workers/main";
+import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Conversation, Group } from "@xmtp/node-sdk";
 import { describe, it } from "vitest";
@@ -19,6 +19,7 @@ describe(testName, () => {
         testName,
         typeofStream.Message,
         typeOfResponse.Gm,
+        typeOfSync.None,
         receiver.network as "production" | "dev" | "local",
       );
       group = await workers.createGroup();

--- a/suites/stress/group-stress/group-stress.test.ts
+++ b/suites/stress/group-stress/group-stress.test.ts
@@ -35,7 +35,7 @@ const testConfig = {
   syncInterval: 10000,
   testWorkers: WORKER_NAMES.slice(1, 10), // Workers to test membership changes
   checkWorkers: WORKER_NAMES.slice(10, 14), // Workers to verify message delivery
-  groupId: process.env.GROUP_ID,
+  groupId: process.env.GROUP_ID as string,
 } as const;
 
 loadEnv(TEST_NAME);
@@ -79,13 +79,11 @@ describe(TEST_NAME, () => {
       // Create or get the global test group
       globalGroup = await createOrGetNewGroup(
         creator,
-        [
-          ...manualUsers
-            .filter((user) => user.network === "production")
-            .map((user) => user.inboxId),
-          ...workers.getAllButCreator().map((w) => w.client.inboxId),
-        ],
-        testConfig.groupId as string,
+        manualUsers
+          .filter((user) => user.network === "production")
+          .map((user) => user.inboxId),
+        workers.getAllButCreator().map((w) => w.client.inboxId),
+        testConfig.groupId,
         TEST_NAME,
       );
 

--- a/suites/stress/group-stress/group-stress.test.ts
+++ b/suites/stress/group-stress/group-stress.test.ts
@@ -48,7 +48,6 @@ describe(TEST_NAME, () => {
   let creator: Worker;
   let globalGroup: Group;
   let allWorkers: Worker[] = [];
-  let syncIntervalId: NodeJS.Timeout;
   let testStartTime: number;
 
   // ============================================================
@@ -104,11 +103,6 @@ describe(TEST_NAME, () => {
 
   afterAll(async () => {
     try {
-      // Clean up periodic sync interval
-      if (syncIntervalId) {
-        clearInterval(syncIntervalId);
-      }
-
       // Send final test completion message
       if (globalGroup?.id) {
         await globalGroup.send(`Test completed: ${testConfig.groupName}`);
@@ -218,7 +212,7 @@ describe(TEST_NAME, () => {
           )) as Group;
 
         if (workerGroup) {
-          await workerGroup.send(`${worker.name}: pre-membership-test`);
+          await workerGroup.send(`${worker.name}: sup`);
         }
 
         // Perform multiple cycles of membership changes

--- a/suites/stress/group-stress/group-stress.test.ts
+++ b/suites/stress/group-stress/group-stress.test.ts
@@ -10,7 +10,6 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import manualUsers from "../../../helpers/manualusers.json";
 import {
   createOrGetNewGroup,
-  syncAllWorkers,
   testMembershipChanges,
   verifyGroupConsistency,
 } from "./helper";
@@ -67,7 +66,7 @@ describe(TEST_NAME, () => {
         TEST_NAME,
         typeofStream.Message,
         typeOfResponse.Gm,
-        typeOfSync.None,
+        typeOfSync.Both,
         testConfig.network,
       );
 
@@ -136,12 +135,6 @@ describe(TEST_NAME, () => {
         throw new Error("No workers available for testing");
       }
 
-      // Start periodic synchronization of all workers
-      syncIntervalId = setInterval(
-        () => void syncAllWorkers(allWorkers),
-        testConfig.syncInterval,
-      );
-
       console.log(`Test environment setup complete:
         - Creator: ${creator.name}
         - Test workers: ${allWorkers.length}
@@ -158,9 +151,6 @@ describe(TEST_NAME, () => {
       if (!globalGroup?.id) {
         throw new Error("Global group is not initialized");
       }
-
-      // Ensure all workers are synchronized
-      await syncAllWorkers(allWorkers);
 
       // Get workers designated for checking message delivery
       const checkWorkers = allWorkers.filter((worker) =>
@@ -239,9 +229,6 @@ describe(TEST_NAME, () => {
           testConfig.epochs,
         );
 
-        // Sync all workers after membership changes
-        await syncAllWorkers(allWorkers);
-
         console.log(
           `✓ Completed ${testConfig.epochs} membership cycles for ${worker.name}`,
         );
@@ -259,9 +246,6 @@ describe(TEST_NAME, () => {
       }
 
       console.log("Verifying final state consistency...");
-
-      // Final sync of all workers
-      await syncAllWorkers(allWorkers);
 
       // Verify final message delivery across all workers
       await verifyMessageStream(

--- a/suites/stress/group-stress/group-stress.test.ts
+++ b/suites/stress/group-stress/group-stress.test.ts
@@ -3,7 +3,7 @@ import { logError } from "@helpers/logger";
 import { verifyMessageStream } from "@helpers/streams";
 import { getFixedNames } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
-import { typeOfResponse, typeofStream } from "@workers/main";
+import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
@@ -67,6 +67,7 @@ describe(TEST_NAME, () => {
         TEST_NAME,
         typeofStream.Message,
         typeOfResponse.Gm,
+        typeOfSync.None,
         testConfig.network,
       );
 

--- a/suites/stress/group-stress/helper.ts
+++ b/suites/stress/group-stress/helper.ts
@@ -4,16 +4,6 @@ import { type Worker } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
 
 // ============================================================
-// Worker Synchronization
-// ============================================================
-
-export async function syncAllWorkers(workers: Worker[]): Promise<void> {
-  for (const worker of workers) {
-    await worker.client.conversations.syncAll();
-  }
-}
-
-// ============================================================
 // Group Management
 // ============================================================
 

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -291,7 +291,9 @@ export class WorkerClient extends Worker {
     if (this.typeofSync !== typeOfSync.None) {
       void (async () => {
         while (this.activeStreams) {
-          console.debug(`[${this.nameId}] Syncing all conversations`);
+          console.debug(
+            `[${this.nameId}] Syncing ${this.typeofSync} every ${interval}ms`,
+          );
           if (this.typeofSync === typeOfSync.SyncAll) {
             await this.client.conversations.syncAll();
           } else if (this.typeofSync === typeOfSync.Sync) {

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -23,7 +23,12 @@ export enum typeOfResponse {
   Gpt = "gpt",
   None = "none",
 }
-
+export enum typeOfSync {
+  SyncAll = "sync_all",
+  Sync = "sync_conversation",
+  Both = "both",
+  None = "none",
+}
 export enum typeofStream {
   Message = "message",
   GroupUpdated = "group_updated",
@@ -145,6 +150,7 @@ export class WorkerClient extends Worker {
   private walletKey: string;
   private encryptionKeyHex: string;
   private typeofStream: typeofStream;
+  private typeofSync: typeOfSync;
   private typeOfResponse: typeOfResponse;
   private folder: string;
   private sdkVersion: string;
@@ -158,6 +164,7 @@ export class WorkerClient extends Worker {
     worker: WorkerBase,
     typeofStream: typeofStream,
     typeOfResponse: typeOfResponse,
+    typeofSync: typeOfSync,
     env: XmtpEnv,
     options: WorkerOptions = {},
   ) {
@@ -166,7 +173,7 @@ export class WorkerClient extends Worker {
     };
 
     super(new URL(`data:text/javascript,${workerBootstrap}`), options);
-
+    this.typeofSync = typeofSync;
     this.typeOfResponse = typeOfResponse;
     this.typeofStream = typeofStream;
     this.name = worker.name;
@@ -264,6 +271,7 @@ export class WorkerClient extends Worker {
     this.address = address;
 
     this.startStream();
+    this.startSyncs();
 
     const installationId = this.client.installationId;
 
@@ -273,6 +281,30 @@ export class WorkerClient extends Worker {
       address: address,
       installationId,
     };
+  }
+
+  /**
+   * Starts a periodic sync of all conversations
+   * @param interval - The interval in milliseconds to sync
+   */
+  private startSyncs(interval: number = 10000) {
+    if (this.typeofSync !== typeOfSync.None) {
+      void (async () => {
+        while (this.activeStreams) {
+          console.debug(`[${this.nameId}] Syncing all conversations`);
+          if (this.typeofSync === typeOfSync.SyncAll) {
+            await this.client.conversations.syncAll();
+          } else if (this.typeofSync === typeOfSync.Sync) {
+            await this.client.conversations.sync();
+          } else if (this.typeofSync === typeOfSync.Both) {
+            await this.client.conversations.syncAll();
+            await this.client.conversations.sync();
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, interval));
+        }
+      })();
+    }
   }
 
   /**

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -5,7 +5,7 @@ import { generateEncryptionKeyHex } from "@helpers/client";
 import { sdkVersionOptions, sdkVersions, sleep } from "@helpers/tests";
 import { type Client, type Group, type XmtpEnv } from "@xmtp/node-sdk";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
-import { typeOfResponse, typeofStream, WorkerClient } from "./main";
+import { typeOfResponse, typeofStream, typeOfSync, WorkerClient } from "./main";
 
 export interface WorkerBase {
   name: string;
@@ -40,6 +40,7 @@ export class WorkerManager {
   private activeWorkers: WorkerClient[] = [];
   private typeofStream: typeofStream = typeofStream.Message;
   private typeOfResponse: typeOfResponse = typeOfResponse.Gm;
+  private typeOfSync: typeOfSync = typeOfSync.None;
   private env: XmtpEnv;
   private keysCache: Record<
     string,
@@ -53,11 +54,13 @@ export class WorkerManager {
     testName: string,
     typeofStreamType: typeofStream = typeofStream.Message,
     typeOfResponseType: typeOfResponse = typeOfResponse.Gm,
+    typeOfSyncType: typeOfSync = typeOfSync.None,
     env: XmtpEnv,
   ) {
     this.testName = testName;
     this.typeofStream = typeofStreamType;
     this.typeOfResponse = typeOfResponseType;
+    this.typeOfSync = typeOfSyncType;
     this.env = env;
     this.workers = {};
   }
@@ -312,6 +315,7 @@ export class WorkerManager {
       workerData,
       this.typeofStream,
       this.typeOfResponse,
+      this.typeOfSync,
       this.env,
     );
 
@@ -377,12 +381,14 @@ export async function getWorkers(
   testName: string,
   typeofStreamType: typeofStream = typeofStream.None,
   typeOfResponseType: typeOfResponse = typeOfResponse.None,
+  typeOfSyncType: typeOfSync = typeOfSync.None,
   env: XmtpEnv = process.env.XMTP_ENV as XmtpEnv,
 ): Promise<WorkerManager> {
   const manager = new WorkerManager(
     testName,
     typeofStreamType,
     typeOfResponseType,
+    typeOfSyncType,
     env,
   );
   await manager.createWorkers(descriptors);


### PR DESCRIPTION
### Implement automatic worker synchronization and refactor group creation to improve member handling in WorkerClient and WorkerManager classes
* Introduces new `typeOfSync` enum in [main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/325/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) with four synchronization options and adds automatic synchronization mechanism to `WorkerClient` class
* Modifies [manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/325/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) to support configurable synchronization types through `WorkerManager` class
* Updates group creation logic in [helper.ts](https://github.com/xmtp/xmtp-qa-tools/pull/325/files#diff-6f74d772e847c87229118ad61b7164b9ec201336e79e87b14c6123cb55321543) to handle worker and manual user inboxes separately
* Removes manual worker synchronization code from stress tests and updates workflow triggers in GitHub Actions
* Adds `typeOfSync.None` parameter to `getWorkers()` calls across multiple test suites

#### 📍Where to Start
Start with the `typeOfSync` enum and `startSyncs` method implementation in [main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/325/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1), which defines the core synchronization functionality that propagates through the rest of the changes.

----

_[Macroscope](https://app.macroscope.com) summarized d06e9c7._