### PR TITLE
Add no-fail option to prevent CI failures on tests

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -22,7 +22,7 @@ jobs:
       WALLET_KEY: ${{ secrets.WALLET_KEY }}
       DEFAULT_STREAM_TIMEOUT_MS: 8000
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn retry agents
+        run: yarn retry agents --no-fail
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/Delivery.yml
+++ b/.github/workflows/Delivery.yml
@@ -20,7 +20,7 @@ jobs:
       DELIVERY_AMOUNT: 100
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -23,7 +23,7 @@ jobs:
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -22,7 +22,7 @@ jobs:
       MAX_GROUP_SIZE: 400
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -21,7 +21,7 @@ jobs:
       MAX_GROUP_SIZE: 400
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL || 'xmtp-qa' }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/StressGroup.yml
+++ b/.github/workflows/StressGroup.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test group-stress
+        run: yarn retry group-stress --no-fail
       - name: Save .data cache
         if: always()
         uses: actions/cache/save@v4

--- a/bugs/bug_fork/fork.test.ts
+++ b/bugs/bug_fork/fork.test.ts
@@ -1,77 +1,97 @@
 import { loadEnv } from "@helpers/client";
-import { getTime } from "@helpers/logger";
-import { getManualUsers } from "@helpers/tests";
+import { getManualUsers, sleep } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
-import { createOrGetNewGroup } from "suites/stress/group-stress/helper";
-import { beforeAll, describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const TEST_NAME = "bug_fork";
 loadEnv(TEST_NAME);
 
-const testConfig = {
-  testName: TEST_NAME,
-  groupName: `NotForked ${getTime()}`,
-  epochs: 3,
-  typeofStream: typeofStream.Message,
-  typeOfResponse: typeOfResponse.Gm,
-  typeOfSync: typeOfSync.Both,
-  network: "production",
-  totalWorkers: 5,
-  testWorkers: ["bob", "alice", "dave", "charlie"],
-} as const;
-
 describe(TEST_NAME, () => {
   let workers: WorkerManager;
+  let secondWorkers: WorkerManager;
   let creator: Worker;
-  let allWorkers: Worker[];
   let globalGroup: Group;
 
   setupTestLifecycle({
     expect,
   });
 
-  beforeAll(async () => {
+  it("create group", async () => {
     try {
       // Initialize workers with creator and test workers
       workers = await getWorkers(
-        ["bot", ...testConfig.testWorkers],
-        testConfig.testName,
-        testConfig.typeofStream,
-        testConfig.typeOfResponse,
-        testConfig.typeOfSync,
-        testConfig.network,
-      );
-
-      creator = workers.get("bot") as Worker;
-      allWorkers = workers.getAllBut("bot");
-      if (!creator) {
-        throw new Error(`Creator worker 'bot' not found`);
-      }
-
-      // Create or get the global test group
-      globalGroup = await createOrGetNewGroup(
-        creator,
-        getManualUsers(["fabri"]).map((user) => user.inboxId),
-        allWorkers.map((w) => w.client.inboxId),
-        process.env.GROUP_ID as string,
+        ["bob", "alice", "dave", "charlie"],
         TEST_NAME,
       );
 
+      creator = workers.getCreator();
+      if (!creator) {
+        throw new Error(`Creator worker 'bob' not found`);
+      }
+
+      // Create or get the global test group
+      globalGroup = await workers.createGroup();
       if (!globalGroup?.id) {
         throw new Error("Failed to create or retrieve global group");
       }
+      await sleep(1000);
+      await globalGroup.addMembers(
+        getManualUsers().map((user) => user.inboxId),
+      );
 
       // Send initial test message
-      await globalGroup.send(`Starting stress test: ${testConfig.groupName}`);
-      await globalGroup.updateName(testConfig.groupName);
+      await globalGroup.send(`Starting stress test: ${TEST_NAME}`);
+      await sleep(1000);
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       console.error("Failed to setup test environment:", errorMessage);
       throw error;
     }
+  });
+
+  it("bot B is created and alice syncs and sends messages", async () => {
+    const alice = workers.get("alice");
+    if (!alice) {
+      throw new Error("Alice worker not found");
+    }
+    await alice.client.conversations.syncAll();
+    await alice.client.conversations.sync();
+    const aliceGroup = await alice.client.conversations.getConversationById(
+      globalGroup.id,
+    );
+    if (!aliceGroup) {
+      throw new Error("Alice group not found");
+    }
+    await aliceGroup.send("hi from alice1");
+    await sleep(1000);
+    await aliceGroup.send("hi from alice2");
+    await sleep(1000);
+    await aliceGroup.send("hi from alice3");
+    await sleep(1000);
+  });
+
+  it("bot B is created", async () => {
+    secondWorkers = await getWorkers(["bob-b"], TEST_NAME);
+    const botB = secondWorkers.get("bob-b");
+    if (!botB) {
+      throw new Error("Bot B worker not found");
+    }
+    await sleep(1000);
+    await sleep(1000);
+    await sleep(1000);
+    await botB.client.conversations.syncAll();
+    await botB.client.conversations.sync();
+    const botBGroup = await botB.client.conversations.getConversationById(
+      globalGroup.id,
+    );
+    if (!botBGroup) {
+      throw new Error("Bot B group not found");
+    }
+    const messages = await botBGroup.messages();
+    console.log(messages.map((m) => m.content));
   });
 });

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -414,12 +414,12 @@ export const randomlyRemoveDb = async (
   }
 };
 
-export const getManualUsers = (filterByName: string[]) =>
+export const getManualUsers = (filterByName: string[] = ["fabri"]) =>
   manualUsers.filter(
     (r) =>
       r.app === "convos" &&
       r.network === process.env.XMTP_ENV &&
-      filterByName.includes(r.name),
+      (filterByName?.length === 0 || filterByName?.includes(r.name)),
   );
 /**
  * Sends an initial test message to the bot

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -289,14 +289,9 @@ export class WorkerClient extends Worker {
    */
   private startSyncs(interval: number = 10000) {
     if (this.typeofSync !== typeOfSync.None) {
-      console.debug(
-        `[${this.nameId}] Starting ${this.typeofSync} sync every ${interval}ms`,
-      );
+      console.debug(`[${this.nameId}] Starting ${this.typeofSync} sync`);
       void (async () => {
-        while (this.activeStreams) {
-          console.debug(
-            `[${this.nameId}] Syncing ${this.typeofSync} every ${interval}ms`,
-          );
+        while (true) {
           if (this.typeofSync === typeOfSync.SyncAll) {
             await this.client.conversations.syncAll();
           } else if (this.typeofSync === typeOfSync.Sync) {


### PR DESCRIPTION
### Add `--no-fail` option to CLI retry command to prevent CI pipeline failures while maintaining test failure notifications
Modifies the retry command in [cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/333/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) to support a new command line option that allows the process to exit successfully even when tests fail. The changes include:

* Adding `noFail` boolean property to `RetryOptions` interface
* Implementing `--no-fail` argument parsing in `parseRetryArgs` function
* Updating error handling logic in `runRetryTests` to respect the new option
* Adding documentation and examples for the new option in help text

#### 📍Where to Start
Start with the `parseRetryArgs` function in [cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/333/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) which handles the new command line argument parsing.

----

_[Macroscope](https://app.macroscope.com) summarized 3e2691f._