### PR TITLE
Include environment in log file naming convention

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -2,6 +2,9 @@ name: Performance
 description: "should verify performance "
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "30 * * * *" # Runs every 30 minutes
   workflow_dispatch:

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -2,9 +2,6 @@ name: Performance
 description: "should verify performance "
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "30 * * * *" # Runs every 30 minutes
   workflow_dispatch:

--- a/.github/workflows/StressGroup.yml
+++ b/.github/workflows/StressGroup.yml
@@ -4,9 +4,6 @@ description: Check that group stress testing is working correctly. If it fails n
 on:
   schedule:
     - cron: "*/30 * * * *" # Runs every 30 minutes
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -224,7 +224,7 @@ export const createTestLogger = (options: TestLogOptions) => {
       const cleanTestName = path
         .basename(options.testName)
         .replace(/\.test\.ts$/, "");
-      logFileName = `raw-${cleanTestName}-${getTime()}.log`;
+      logFileName = `raw-${process.env.XMTP_ENV}-${cleanTestName}-${getTime()}.log`;
     }
     const logPath = path.join(logsDir, logFileName);
 
@@ -267,7 +267,7 @@ export const addFileLogging = (filename: string) => {
   const logPath = path.join(
     process.cwd(),
     "logs",
-    filename + getTime() + ".log",
+    filename + "-" + String(process.env.XMTP_ENV) + "-" + getTime() + ".log",
   );
   const dir = path.dirname(logPath);
 


### PR DESCRIPTION
### Include environment in log file naming convention by modifying `createTestLogger` and `addFileLogging` functions in helpers/logger.ts
Modifies log file naming to include the `XMTP_ENV` environment variable in filenames across two functions in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/340/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597). The changes also update GitHub workflow triggers:
• Updates `createTestLogger` function to change filename format from `raw-${cleanTestName}-${getTime()}.log` to `raw-${process.env.XMTP_ENV}-${cleanTestName}-${getTime()}.log`
• Updates `addFileLogging` function to change filename format from `filename + getTime() + ".log"` to `filename + "-" + String(process.env.XMTP_ENV) + "-" + getTime() + ".log"`
• Adds pull request trigger to Performance workflow in [.github/workflows/Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/340/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3)
• Removes pull request trigger from StressGroup workflow in [.github/workflows/StressGroup.yml](https://github.com/xmtp/xmtp-qa-tools/pull/340/files#diff-e880e9cbcc44dcb8b3fb400ded98d132621dd921313ae528a40e49aa432cfe4d)

#### 📍Where to Start
Start with the `createTestLogger` function in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/340/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) to see the primary log filename changes.

----

_[Macroscope](https://app.macroscope.com) summarized 604c12a._