### PR TITLE
Update inbox import for consistency in tests

### DIFF
--- a/bugs/README.md
+++ b/bugs/README.md
@@ -9,6 +9,7 @@ This repository contains documentation for known bugs and their solutions.
 | [📦 Stitch issues](./bug_stitch/README.md)        | Problems during setup and installation |
 | [💥 Panic errors](./bug_panic/README.md)          | Runtime crashes and panic situations   |
 | [💥 Large group sync](./bug_largegroup/README.md) | Large group Max issues                 |
+| [💥 Welcome](./bug_welcome/README.md)             | Welcome issues                         |
 
 ## Contributing
 

--- a/bugs/bug_welcome/welcome.test.ts
+++ b/bugs/bug_welcome/welcome.test.ts
@@ -1,5 +1,5 @@
 import { loadEnv } from "@helpers/client";
-import { getFixedNames, sleep } from "@helpers/tests";
+import { getFixedNames } from "@helpers/tests";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";

--- a/dashboard.json
+++ b/dashboard.json
@@ -383,6 +383,7 @@
               }
             ],
             "response_format": "timeseries",
+            "on_right_yaxis": true,
             "style": {
               "palette": "dog_classic",
               "line_type": "solid",
@@ -401,9 +402,10 @@
             ],
             "response_format": "timeseries",
             "style": {
-              "palette": "dog_classic",
-              "line_type": "dashed",
-              "line_width": "normal"
+              "palette": "blue",
+              "order_reverse": true,
+              "line_type": "solid",
+              "line_width": "thick"
             },
             "display_type": "line"
           }
@@ -417,13 +419,8 @@
         },
         "markers": [
           {
-            "label": "Target Order Correlation",
+            "label": " Tresshold ",
             "value": "y = 99",
-            "display_type": "info dashed"
-          },
-          {
-            "label": "Target Delivery Rate",
-            "value": "y = 98",
             "display_type": "warning dashed"
           }
         ]

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -505,10 +505,10 @@ export const simulateMissingCursorMessage = async (
 export const getFixedNames = (count: number): string[] => {
   return [...defaultNames].slice(0, count);
 };
-export function removeDataFolder(): void {
+export async function removeDataFolder(): Promise<void> {
   const dataPath = path.join(process.cwd(), ".data");
   if (fs.existsSync(dataPath)) {
-    fs.rmSync(dataPath, { recursive: true, force: true });
+    await fs.promises.rm(dataPath, { recursive: true, force: true });
   }
 }
 export function getMultiVersion(count: number): string[] {

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import oldInboxes from "@helpers/inboxes.json";
+import newInboxes from "@helpers/inboxes.json";
 import type { Worker, WorkerManager } from "@workers/manager";
 import { type Client, type Conversation, type Group } from "@xmtp/node-sdk";
 import {
@@ -441,10 +441,10 @@ export const sleep = (ms: number = 1000): Promise<void> => {
 };
 
 export function getInboxIds(count: number) {
-  return oldInboxes.slice(0, count).map((inbox) => inbox.inboxId);
+  return newInboxes.slice(0, count).map((inbox) => inbox.inboxId);
 }
 export function getAddresses(count: number) {
-  return oldInboxes.slice(0, count).map((inbox) => inbox.accountAddress);
+  return newInboxes.slice(0, count).map((inbox) => inbox.accountAddress);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import { appendFile } from "fs/promises";
 import path from "path";
 import { generateEncryptionKeyHex } from "@helpers/client";
-import { sdkVersionOptions, sdkVersions, sleep } from "@helpers/tests";
+import { sdkVersions, sleep } from "@helpers/tests";
 import { type Client, type Group, type XmtpEnv } from "@xmtp/node-sdk";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { typeOfResponse, typeofStream, typeOfSync, WorkerClient } from "./main";


### PR DESCRIPTION
### Update inbox import naming from `oldInboxes` to `newInboxes` and remove unused imports for consistency in test files
Changes the import name from `oldInboxes` to `newInboxes` in [helpers/tests.ts](https://github.com/xmtp/xmtp-qa-tools/pull/343/files#diff-d0765ec47b88b04ac5639d5e41ed13b9cf1e7f55ad28f1ea37951a668f33c626) and updates all references in the `getInboxIds` and `getAddresses` functions. The `removeDataFolder` function is converted from synchronous to asynchronous using `fs.promises.rm`. Removes unused imports including `sleep` from [bugs/bug_welcome/welcome.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/343/files#diff-77834405eccd631cead97fd393eac52769d9fd5af9292ff6d173b25e787553e7) and `sdkVersionOptions` from both [helpers/tests.ts](https://github.com/xmtp/xmtp-qa-tools/pull/343/files#diff-d0765ec47b88b04ac5639d5e41ed13b9cf1e7f55ad28f1ea37951a668f33c626) and [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/343/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42).

#### 📍Where to Start
Start with the import changes and function updates in [helpers/tests.ts](https://github.com/xmtp/xmtp-qa-tools/pull/343/files#diff-d0765ec47b88b04ac5639d5e41ed13b9cf1e7f55ad28f1ea37951a668f33c626) where the main data source naming change occurs.

----

_[Macroscope](https://app.macroscope.com) summarized b14c968._