### PR TITLE
bump version to address recent updates and improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
### Bump version from 0.0.32 to 0.0.33 in package.json to address recent updates and improvements
The version number in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/346/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) is incremented from "0.0.32" to "0.0.33".

#### 📍Where to Start
Start with the version field in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/346/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized df77bde._