### PR TITLE
Add deployment details to group stress testing README

### DIFF
--- a/suites/automated/group-stress/README.md
+++ b/suites/automated/group-stress/README.md
@@ -1,5 +1,7 @@
 # XMTP Group Stress Testing Suite
 
+> For details see deployment: https://railway.com/project/cc97c743-1be5-4ca3-a41d-0109e41ca1fd/service/d92446b3-7ee4-43c9-a2ec-ceac87082970?environmentId=2d2be2e3-6f54-452c-a33c-522bcdef7792
+
 - [x] Time factor (30 min recurring)
 - [x] Old packages
 - [x] Multi-sdk

--- a/suites/automated/group-stress/group-stress.test.ts
+++ b/suites/automated/group-stress/group-stress.test.ts
@@ -27,7 +27,7 @@ const WORKER_NAMES = getMultiVersion(14);
 const testConfig = {
   testName: TEST_NAME,
   groupName: `NotForked ${getTime()}`,
-  epochs: 4,
+  epochs: 10,
   network: "production",
   totalWorkers: 14,
   allWorkersNames: WORKER_NAMES,


### PR DESCRIPTION
### Add deployment details to group stress testing README
Adds a note with a Railway.com deployment link to the [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/350/files#diff-79ff4c48f25477b00d5c3400aa6957bc122a4d4a28d2211b1f37a7abca545d7e) file for the XMTP Group Stress Testing Suite, pointing to a specific project, service, and environment ID.

#### 📍Where to Start
Start with the updated documentation in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/350/files#diff-79ff4c48f25477b00d5c3400aa6957bc122a4d4a28d2211b1f37a7abca545d7e).

----

_[Macroscope](https://app.macroscope.com) summarized b8b031f._