### PR TITLE
Update test suite documentation for clarity and structure

### DIFF
--- a/suites/README.md
+++ b/suites/README.md
@@ -15,40 +15,40 @@ This directory contains four main categories of test suites:
 
 Tests that run automatically on CI/CD pipelines to monitor production systems.
 
-| Test Suite | Purpose                                      | Status    | Documentation                                    |
-| ---------- | -------------------------------------------- | --------- | ------------------------------------------------ |
-| **agents** | Health monitoring of production XMTP agents  | ✅ Active | [agents/README.md](./automated/agents/README.md) |
-| **gm**     | Validation of GM bot and browser integration | ✅ Active | [gm/README.md](./automated/gm/README.md)         |
+| Test Suite       | Purpose                                             | Documentation                                                |
+| ---------------- | --------------------------------------------------- | ------------------------------------------------------------ |
+| **agents**       | Health monitoring of production XMTP agents         | [agents/README.md](./automated/agents/README.md)             |
+| **gm**           | Validation of GM bot and browser integration        | [gm/README.md](./automated/gm/README.md)                     |
+| **group-stress** | Group membership and message forking stress testing | [group-stress/README.md](./automated/group-stress/README.md) |
 
 ## 🔧 Manual Test Suites
 
 Human-operated tests for investigating specific issues or running regression tests.
 
-| Test Suite        | Purpose                                      | Status    | Documentation                                               |
-| ----------------- | -------------------------------------------- | --------- | ----------------------------------------------------------- |
-| **notifications** | Push notification functionality validation   | ⚠️ Manual | [notifications/README.md](./manual/notifications/README.md) |
-| **regression**    | Historical bug reproduction and verification | ⚠️ Manual | [regression/README.md](./manual/regression/README.md)       |
+| Test Suite        | Purpose                                      | Documentation                                               |
+| ----------------- | -------------------------------------------- | ----------------------------------------------------------- |
+| **notifications** | Push notification functionality validation   | [notifications/README.md](./manual/notifications/README.md) |
+| **regression**    | Historical bug reproduction and verification | [regression/README.md](./manual/regression/README.md)       |
 
 ## 📊 Metrics Test Suites
 
 Performance measurement and reliability testing with detailed metrics collection.
 
-| Test Suite      | Purpose                                   | Status     | Documentation                                            |
-| --------------- | ----------------------------------------- | ---------- | -------------------------------------------------------- |
-| **delivery**    | Message delivery reliability and ordering | 📈 Metrics | [delivery/README.md](./metrics/delivery/README.md)       |
-| **large**       | Large-scale group operations performance  | 📈 Metrics | [large/README.md](./metrics/large/README.md)             |
-| **performance** | End-to-end operational performance        | 📈 Metrics | [performance/README.md](./metrics/performance/README.md) |
+| Test Suite      | Purpose                                   | Documentation                                            |
+| --------------- | ----------------------------------------- | -------------------------------------------------------- |
+| **delivery**    | Message delivery reliability and ordering | [delivery/README.md](./metrics/delivery/README.md)       |
+| **large**       | Large-scale group operations performance  | [large/README.md](./metrics/large/README.md)             |
+| **performance** | End-to-end operational performance        | [performance/README.md](./metrics/performance/README.md) |
 
 ## 🚨 Stress Test Suites
 
 High-load testing and edge-case scenario validation.
 
-| Test Suite       | Purpose                                             | Status    | Documentation                                                    |
-| ---------------- | --------------------------------------------------- | --------- | ---------------------------------------------------------------- |
-| **group-stress** | Group membership and message forking stress testing | 🔥 Stress | [stress/group-stress/README.md](./stress/group-stress/README.md) |
-| **rate-limited** | Rate limiting behavior validation                   | 🔥 Stress | Direct test file                                                 |
-| **bot-stress**   | Bot performance under high load                     | 🔥 Stress | Direct test file                                                 |
-| **large-group**  | 200+ member group operations                        | 🔥 Stress | Direct test file                                                 |
+| Test Suite       | Purpose                           | Documentation    |
+| ---------------- | --------------------------------- | ---------------- |
+| **rate-limited** | Rate limiting behavior validation | Direct test file |
+| **bot-stress**   | Bot performance under high load   | Direct test file |
+| **large-group**  | 200+ member group operations      | Direct test file |
 
 ## 🏃‍♂️ Quick Start
 

--- a/suites/automated/group-stress/README.md
+++ b/suites/automated/group-stress/README.md
@@ -2,7 +2,7 @@
 
 > For details see deployment: https://railway.com/project/cc97c743-1be5-4ca3-a41d-0109e41ca1fd/service/d92446b3-7ee4-43c9-a2ec-ceac87082970?environmentId=2d2be2e3-6f54-452c-a33c-522bcdef7792
 
-- [x] Time factor (30 min recurring)
+- [x] Time factor (30 min recurring)
 - [x] Old packages
 - [x] Multi-sdk
 - [x] 10 second sync strategy
@@ -14,6 +14,33 @@
 This test suite reproduces group conversation forking issues in XMTP by simulating high-frequency membership changes and message exchanges.
 
 https://github.com/user-attachments/assets/e4842b28-e1c4-4a6c-87ac-2e11651b2939
+
+## Test Overview
+
+The stress test creates a group with **14 multi-version workers** and performs:
+
+1. **Fork-free message delivery** - Verifies messages reach all participants without conversation forks
+2. **Fork-free membership delivery** - Tests member addition/removal propagation across clients
+3. **Fork-free metadata delivery** - Validates group name and metadata updates sync correctly
+4. **Membership change cycles** - Performs 10 epochs of rapid member remove/add operations per worker
+5. **Final state consistency** - Confirms all workers maintain synchronized group state
+
+### Worker Configuration
+
+- **Total workers**: 14 (multi-version XMTP clients)
+- **Test workers**: 7 (perform membership changes)
+- **Check workers**: 6 (verify message/membership delivery)
+- **Creator**: 1 bot (group admin)
+
+### Test Cycles
+
+Each test worker undergoes **10 membership cycles** where they are:
+
+- Removed from the group
+- Re-added to the group
+- Group state is synced
+
+This simulates real-world scenarios where users frequently join/leave groups.
 
 ## Setup
 
@@ -38,9 +65,6 @@ GROUP_ID=""
 # WORKERS
 # where rest of workers will be saved
 ```
-
-> [!TIP]
-> To find your InboxID, message `key-check.eth` with `/kc address`
 
 ## Test Execution
 


### PR DESCRIPTION
### Reorganize test suite documentation by removing status columns and moving group-stress test suite from stress to automated category
The changes reorganize test suite documentation structure across two files:
- Removes the 'Status' column from all documentation tables in [suites/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/351/files#diff-5762ed4d5d7990eaec92cd3b240359fe7e25e1425fd259386f2ba4c2b8eebbb5) and moves the `group-stress` test suite from the 'Stress Test Suites' section to the 'Automated Test Suites' section with updated documentation path
- Expands the [suites/automated/group-stress/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/351/files#diff-79ff4c48f25477b00d5c3400aa6957bc122a4d4a28d2211b1f37a7abca545d7e) with detailed test overview, worker configuration specifying 14 multi-version workers (7 test workers, 6 check workers, 1 creator bot), and test cycle information describing 10 membership cycles per test worker

#### 📍Where to Start
Start with the main documentation structure changes in [suites/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/351/files#diff-5762ed4d5d7990eaec92cd3b240359fe7e25e1425fd259386f2ba4c2b8eebbb5) to understand the reorganization of test suite categories.

----

_[Macroscope](https://app.macroscope.com) summarized 48f56aa._