### PR TITLE
Import crypto libs in `xmtp-gen.ts`

### DIFF
--- a/scripts/xmtp-gen.ts
+++ b/scripts/xmtp-gen.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as crypto from "crypto";
 import * as readline from "readline";
 import {
   createSigner,


### PR DESCRIPTION
Running the `scripts/xmtp-gen.ts` using a command found in docs:

`npx tsx scripts/xmtp-gen.ts --mode generate-inboxes --count 10 --envs local`

Fails with:

```ReferenceError: crypto is not defined
    at generateInboxes (scripts/xmtp-gen.ts:110:41)```

This PR just adds the `crypto` import to the top of the script, which solves the problem. Let me know if there's another way I should be using this which might make the change unnecessary! 