### PR TITLE
Improved group debugging + retry command is not just 'test'

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test agents --no-fail --log
+        run: yarn test agents --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Delivery.yml
+++ b/.github/workflows/Delivery.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test delivery --no-fail --log
+        run: yarn test delivery --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test gm --no-fail --log
+        run: yarn test gm --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Gm.yml
+++ b/.github/workflows/Gm.yml
@@ -32,7 +32,7 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn
-      - name: Run tests with retry
+      - name: Run tests
         run: yarn test gm --no-fail --log
       - name: Upload test artifacts
         if: always()

--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test large  --no-fail --log
+        run: yarn test large  --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test performance --no-fail --log
+        run: yarn test performance --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -275,19 +275,19 @@ yarn test performance
 
 ```bash
 # Advanced retry mode (when retry options are present)
-yarn cli test functional --max-attempts 3 --log --no-fail
+yarn cli test functional --max-attempts 3 --debug --no-fail
 ```
 
 - `--max-attempts <N>` - Number of retry attempts (default: 3)
 - `--retry-delay <S>` - Delay between retries in seconds (default: 10)
-- `--log` - Enable debug logging and file output
+- `--debug` - Enable debug logging and file output
 - `--no-fail` - Exit successfully even on test failures
-- `--log-file <name>` - Custom log file name
+- `--debug-file <name>` - Custom log file name
 
 ### Logging Behavior
 
-- With `--log`: Sets `LOGGING_LEVEL=debug` and saves logs to `logs/` directory (no terminal verbosity)
-- Without `--log`: Uses `LOGGING_LEVEL` from `.env` file
+- With `--debug`: Sets `LOGGING_LEVEL=debug` and saves logs to `logs/` directory (no terminal verbosity)
+- Without `--debug`: Uses `LOGGING_LEVEL` from `.env` file
 
 ### Resources
 

--- a/bots/gm-bot/scripts/generateKeys.ts
+++ b/bots/gm-bot/scripts/generateKeys.ts
@@ -7,7 +7,7 @@ import { generateEncryptionKeyHex } from "../src/client";
 const nodeVersion = process.versions.node;
 const [major] = nodeVersion.split(".").map(Number);
 if (major < 20) {
-  console.error("Error: Node.js version 20 or higher is required");
+  console.error("Node.js version 20 or higher is required");
   process.exit(1);
 }
 

--- a/bugs/bug_kpke/bug_kpke.test.ts
+++ b/bugs/bug_kpke/bug_kpke.test.ts
@@ -1,11 +1,11 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyMessageStream } from "@helpers/streams";
-import { getFixedNames, getFixedNames } from "@helpers/tests";
+import { getFixedNames } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
-import { IdentifierKind, type Group } from "@xmtp/node-sdk";
+import { IdentifierKind } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
 const testName = "bug_welcome";

--- a/bugs/bug_kpke/bug_kpke.test.ts
+++ b/bugs/bug_kpke/bug_kpke.test.ts
@@ -1,0 +1,61 @@
+import { loadEnv } from "@helpers/client";
+import { logError } from "@helpers/logger";
+import { getFixedNames } from "@helpers/tests";
+import { setupTestLifecycle } from "@helpers/vitest";
+import { typeofStream } from "@workers/main";
+import { getWorkers, type WorkerManager } from "@workers/manager";
+import { IdentifierKind, type Group } from "@xmtp/node-sdk";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const testName = "bug_welcome";
+loadEnv(testName);
+
+describe(testName, () => {
+  let workers: WorkerManager;
+  let group: Group;
+
+  beforeAll(async () => {
+    const names = getFixedNames(10);
+    workers = await getWorkers(names, testName, typeofStream.Message);
+    await getWorkers(names, testName, typeofStream.Conversation);
+  });
+
+  setupTestLifecycle({
+    expect,
+  });
+
+  it("stream: send the stream", async () => {
+    group = await workers.createGroup();
+    console.log("Group created", group.id);
+    expect(group.id).toBeDefined();
+  });
+
+  it("should send message to specific address", async () => {
+    try {
+      const targetAddress = "0x6461bf53ddb33b525c84bf60d6bb31fa10828474";
+
+      const conversation = await workers
+        .getCreator()
+        .client.conversations.newDmWithIdentifier({
+          identifier: targetAddress,
+          identifierKind: IdentifierKind.Ethereum,
+        });
+
+      expect(conversation).toBeDefined();
+      expect(conversation.id).toBeDefined();
+
+      const message = "Test message from hpkey test";
+      await conversation.send(message);
+
+      console.log(`Message sent to ${targetAddress}: ${message}`);
+    } catch (e) {
+      logError(e, expect.getState().currentTestName);
+      throw e;
+    }
+  });
+  it("stream: send the stream", async () => {
+    group = await workers.createGroup();
+    console.log("Group created", group.id);
+    expect(group.id).toBeDefined();
+  });
+});

--- a/bugs/bug_panic/test.test.ts
+++ b/bugs/bug_panic/test.test.ts
@@ -1,5 +1,5 @@
 import { loadEnv } from "@helpers/client";
-import { getRandomNames } from "@helpers/tests";
+import { getFixedNames } from "@helpers/tests";
 import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
@@ -8,7 +8,7 @@ loadEnv(testName);
 
 describe(testName, () => {
   it("newGroupByInboxIds: should measure creating a group with inbox ids", async () => {
-    const workers = await getWorkers(getRandomNames(50), testName);
+    const workers = await getWorkers(getFixedNames(50), testName);
     const workerArray = workers.getAll();
     const groupByInboxIds = await workers.createGroup();
     for (const worker of workerArray) {

--- a/functional/codec.test.ts
+++ b/functional/codec.test.ts
@@ -1,5 +1,5 @@
 import { loadEnv } from "@helpers/client";
-import { getRandomNames } from "@helpers/tests";
+import { getFixedNames } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import {
@@ -13,7 +13,7 @@ loadEnv(testName);
 
 describe(testName, async () => {
   let workers: WorkerManager;
-  workers = await getWorkers(getRandomNames(2), testName);
+  workers = await getWorkers(getFixedNames(2), testName);
 
   setupTestLifecycle({
     expect,

--- a/functional/consent.test.ts
+++ b/functional/consent.test.ts
@@ -1,7 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyConsentStream } from "@helpers/streams";
-import { getRandomNames } from "@helpers/tests";
+import { getFixedNames } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -13,7 +13,7 @@ loadEnv(testName);
 describe(testName, async () => {
   let workers: WorkerManager;
 
-  workers = await getWorkers(getRandomNames(5), testName, typeofStream.Consent);
+  workers = await getWorkers(getFixedNames(5), testName, typeofStream.Consent);
 
   setupTestLifecycle({
     expect,

--- a/functional/order.test.ts
+++ b/functional/order.test.ts
@@ -1,7 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { calculateMessageStats, verifyMessageStream } from "@helpers/streams";
-import { getRandomNames, sleep } from "@helpers/tests";
+import { getFixedNames, sleep } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -15,7 +15,7 @@ describe(testName, async () => {
   const amount = 5; // Number of messages to collect per receiver
   let workers: WorkerManager;
 
-  workers = await getWorkers(getRandomNames(5), testName, typeofStream.Message);
+  workers = await getWorkers(getFixedNames(5), testName, typeofStream.Message);
 
   let group: Group;
   const randomSuffix = Math.random().toString(36).substring(2, 15);

--- a/functional/streams.test.ts
+++ b/functional/streams.test.ts
@@ -8,7 +8,7 @@ import {
   verifyMetadataStream,
   verifyNewConversationStream,
 } from "@helpers/streams";
-import { getInboxIds, getRandomNames } from "@helpers/tests";
+import { getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
@@ -20,7 +20,7 @@ loadEnv(testName);
 
 describe(testName, async () => {
   let group: Conversation;
-  const names = getRandomNames(5);
+  const names = getFixedNames(5);
   let workers = await getWorkers(names, testName);
 
   // Setup test lifecycle

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -101,7 +101,7 @@ export const setupPrettyLogs = () => {
   // Override console.error
   console.error = (...args) => {
     const message = args.join(" ");
-    logger.error("ERROR: " + message);
+    logger.error("ERROR " + message);
   };
 
   // Override console.debug

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -101,7 +101,7 @@ export const setupPrettyLogs = () => {
   // Override console.error
   console.error = (...args) => {
     const message = args.join(" ");
-    logger.error(message);
+    logger.error("ERROR: " + message);
   };
 
   // Override console.debug

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -49,7 +49,7 @@ export const createLogger = () => {
 
 export const logError = (e: unknown, testName: string | undefined): boolean => {
   if (e instanceof Error) {
-    console.error(`[vitest] Test failed in ${testName}`, e.message);
+    console.error(`Test failed in ${testName}`, e.message);
   } else {
     console.error(`Unknown error type:`, typeof e);
   }
@@ -184,7 +184,7 @@ export function extractErrorLogs(testName: string): string {
       const lines = content.split("\n");
 
       for (const line of lines) {
-        if (/ERROR/.test(line) || /vitest/i.test(line)) {
+        if (/ERROR/.test(line)) {
           //remove ansi codes
           const ansiRegex = new RegExp(
             `[${String.fromCharCode(27)}${String.fromCharCode(155)}][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]`,
@@ -192,9 +192,7 @@ export function extractErrorLogs(testName: string): string {
           );
           let cleanLine = line.replace(ansiRegex, "");
           if (cleanLine.includes("ERROR")) {
-            cleanLine = cleanLine.split("ERROR")[1];
-          } else if (cleanLine.includes("[vitest]")) {
-            cleanLine = cleanLine.split("[vitest]")[1];
+            cleanLine = cleanLine.split("ERROR")[1].trim();
           }
 
           if (cleanLine.includes("//")) {

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -249,7 +249,7 @@ export const createTestLogger = (options: TestLogOptions) => {
     console.log(
       "Warning: Logging is disabled. Test output will not be visible anywhere.",
     );
-    console.log("Consider using --log to enable file logging.");
+    console.log("Consider using --debug to enable file logging.");
   }
 
   const processOutput = (data: Buffer) => {

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -522,8 +522,7 @@ export function getMultiVersion(count: number): string[] {
   return descriptors;
 }
 export const getRandomNames = (count: number): string[] => {
-  return [...defaultNames].slice(0, count);
-  //return [...defaultNames].sort(() => Math.random() - 0.5).slice(0, count);
+  return [...defaultNames].sort(() => Math.random() - 0.5).slice(0, count);
 };
 export const GM_BOT_ADDRESS = "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0";
 // Default worker names

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "monitor:dev": "httpstat https://grpc.dev.xmtp.network:443",
     "railway": "railway run yarn test ",
     "record": "npx playwright codegen 'https://xmtp.chat/'",
-    "retry": "yarn cli retry",
     "script": "yarn cli script",
     "start": "vitest --ui --standalone --watch ",
     "test": "yarn cli test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -67,10 +67,10 @@ function showUsageAndExit(): never {
     "      --retry-delay <S>   Delay in seconds between retries (default: 10)",
   );
   console.error(
-    "      --log / --no-log    Enable/disable logging to file (default: enabled)",
+    "      --debug / --no-log    Enable/disable logging to file (default: enabled)",
   );
   console.error(
-    "      --log-file <name>   Custom log file name (default: auto-generated)",
+    "      --debug-file <name>   Custom log file name (default: auto-generated)",
   );
   console.error(
     "      --no-fail           Exit with code 0 even on test failures (still sends Slack notifications)",
@@ -120,9 +120,9 @@ function hasRetryOptions(args: string[]): boolean {
   const retrySpecificOptions = [
     "--max-attempts",
     "--retry-delay",
-    "--log",
+    "--debug",
     "--no-log",
-    "--log-file",
+    "--debug-file",
     "--no-fail",
   ];
 
@@ -133,15 +133,15 @@ function runSimpleVitest(testName: string, args: string[]): void {
   const command = buildTestCommand(testName, args);
   console.log(`Running vitest: ${command}`);
 
-  // Check if --log was explicitly passed
-  const explicitLogFlag = args.includes("--log");
+  // Check if --debug was explicitly passed
+  const explicitLogFlag = args.includes("--debug");
 
   const env: Record<string, string> = {
     ...process.env,
     RUST_BACKTRACE: "1",
   };
 
-  // Only set debug logging if --log was explicitly passed
+  // Only set debug logging if --debug was explicitly passed
   if (explicitLogFlag) {
     env.LOGGING_LEVEL = "debug";
   }
@@ -199,7 +199,7 @@ function parseTestArgs(args: string[]): {
           i++;
         }
         break;
-      case "--log":
+      case "--debug":
         options.enableLogging = true;
         options.explicitLogFlag = true;
         break;
@@ -207,7 +207,7 @@ function parseTestArgs(args: string[]): {
         options.enableLogging = false;
         options.explicitLogFlag = false;
         break;
-      case "--log-file":
+      case "--debug-file":
         if (nextArg) {
           options.customLogFile = nextArg;
           i++;
@@ -319,7 +319,7 @@ async function runRetryTests(
     RUST_BACKTRACE: "1",
   };
 
-  // Only set debug logging if --log was explicitly passed
+  // Only set debug logging if --debug was explicitly passed
   if (options.explicitLogFlag) {
     env.LOGGING_LEVEL = "debug";
   }

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -409,7 +409,7 @@ async function main(): Promise<void> {
     switch (commandType) {
       case "bot": {
         if (!nameOrPath) {
-          console.error("Error: Bot name is required for 'bot' command type.");
+          console.error("bot name is required for 'bot' command type.");
           showUsageAndExit();
         }
         runBot(nameOrPath, additionalArgs);
@@ -418,9 +418,7 @@ async function main(): Promise<void> {
 
       case "script": {
         if (!nameOrPath) {
-          console.error(
-            "Error: Script name is required for 'script' command type.",
-          );
+          console.error("Script name is required for 'script' command type.");
           showUsageAndExit();
         }
         runScript(nameOrPath, additionalArgs);
@@ -446,7 +444,7 @@ async function main(): Promise<void> {
       }
 
       default: {
-        console.error(`Error: Unknown command type "${commandType}"`);
+        console.error(`Unknown command type "${commandType}"`);
         showUsageAndExit();
       }
     }

--- a/scripts/gen.ts
+++ b/scripts/gen.ts
@@ -163,11 +163,11 @@ async function localUpdate(opts: { input?: string; env?: XmtpEnv }) {
     generatedInboxes = JSON.parse(fs.readFileSync(inputFile, "utf8"));
   } catch (e) {
     console.log(e);
-    console.error(`Error: Could not read input file: ${inputFile}`);
+    console.error(`Could not read input file: ${inputFile}`);
     return;
   }
   if (!generatedInboxes || generatedInboxes.length === 0) {
-    console.error("Error: No generated inboxes found in input file");
+    console.error("No generated inboxes found in input file");
     return;
   }
   const folderName = `db-generated-${generatedInboxes.length}-${ENV}`;

--- a/suites/manual/stress-bot/stress-bot.test.ts
+++ b/suites/manual/stress-bot/stress-bot.test.ts
@@ -1,6 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
-import { getInboxIds, getRandomNames, sleep } from "@helpers/tests";
+import { getFixedNames, getInboxIds, sleep } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import type { Client, Conversation, Group } from "@xmtp/node-sdk";
@@ -37,7 +37,7 @@ describe(testName, async () => {
       bot = workers.get("bot")!;
       client = bot.client;
       conversation = await client.conversations.newDm(receiverInboxId);
-      workers = await getWorkers(getRandomNames(config.workerCount), testName);
+      workers = await getWorkers(getFixedNames(config.workerCount), testName);
       expect(workers).toBeDefined();
       expect(workers.getAll().length).toBe(config.workerCount);
     } catch (e) {

--- a/suites/metrics/Delivery/delivery.test.ts
+++ b/suites/metrics/Delivery/delivery.test.ts
@@ -2,7 +2,7 @@ import { loadEnv } from "@helpers/client";
 import { sendDeliveryMetric } from "@helpers/datadog";
 import { logError } from "@helpers/logger";
 import { calculateMessageStats, verifyMessageStream } from "@helpers/streams";
-import { getRandomNames } from "@helpers/tests";
+import { getFixedNames } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
@@ -21,7 +21,7 @@ describe(testName, async () => {
     `[${testName}] Amount of messages: ${amountofMessages}, Receivers: ${receiverAmount}`,
   );
   let workers = await getWorkers(
-    getRandomNames(receiverAmount),
+    getFixedNames(receiverAmount),
     testName,
     typeofStream.Message,
   );

--- a/suites/metrics/Large/conversations.test.ts
+++ b/suites/metrics/Large/conversations.test.ts
@@ -1,7 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyNewConversationStream } from "@helpers/streams";
-import { getInboxIds, getRandomNames } from "@helpers/tests";
+import { getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -26,7 +26,7 @@ describe(testName, async () => {
   const summaryMap: Record<number, SummaryEntry> = {};
 
   workers = await getWorkers(
-    getRandomNames(m_large_WORKER_COUNT),
+    getFixedNames(m_large_WORKER_COUNT),
     testName,
     typeofStream.Conversation,
   );

--- a/suites/metrics/Large/cumulative_syncs.test.ts
+++ b/suites/metrics/Large/cumulative_syncs.test.ts
@@ -1,6 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
-import { getInboxIds, getRandomNames } from "@helpers/tests";
+import { getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
@@ -21,7 +21,7 @@ describe(testName, async () => {
   const summaryMap: Record<number, SummaryEntry> = {};
 
   workers = await getWorkers(
-    getRandomNames((m_large_TOTAL / m_large_BATCH_SIZE) * 2 + 1),
+    getFixedNames((m_large_TOTAL / m_large_BATCH_SIZE) * 2 + 1),
     testName,
     typeofStream.None,
   );

--- a/suites/metrics/Large/membership.test.ts
+++ b/suites/metrics/Large/membership.test.ts
@@ -1,7 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyMembershipStream } from "@helpers/streams";
-import { getInboxIds, getRandomNames } from "@helpers/tests";
+import { getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -26,7 +26,7 @@ describe(testName, async () => {
   const summaryMap: Record<number, SummaryEntry> = {};
 
   workers = await getWorkers(
-    getRandomNames(m_large_WORKER_COUNT),
+    getFixedNames(m_large_WORKER_COUNT),
     testName,
     typeofStream.GroupUpdated,
   );

--- a/suites/metrics/Large/messages.test.ts
+++ b/suites/metrics/Large/messages.test.ts
@@ -1,7 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyMessageStream } from "@helpers/streams";
-import { getInboxIds, getRandomNames } from "@helpers/tests";
+import { getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -26,7 +26,7 @@ describe(testName, async () => {
   const summaryMap: Record<number, SummaryEntry> = {};
 
   workers = await getWorkers(
-    getRandomNames(m_large_WORKER_COUNT),
+    getFixedNames(m_large_WORKER_COUNT),
     testName,
     typeofStream.Message,
   );

--- a/suites/metrics/Large/metadata.test.ts
+++ b/suites/metrics/Large/metadata.test.ts
@@ -1,7 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyMetadataStream } from "@helpers/streams";
-import { getInboxIds, getRandomNames } from "@helpers/tests";
+import { getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -26,7 +26,7 @@ describe(testName, async () => {
   const summaryMap: Record<number, SummaryEntry> = {};
 
   workers = await getWorkers(
-    getRandomNames(m_large_WORKER_COUNT),
+    getFixedNames(m_large_WORKER_COUNT),
     testName,
     typeofStream.GroupUpdated,
   );

--- a/suites/metrics/Large/syncs.test.ts
+++ b/suites/metrics/Large/syncs.test.ts
@@ -1,6 +1,6 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
-import { getInboxIds, getRandomNames } from "@helpers/tests";
+import { getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
@@ -21,7 +21,7 @@ describe(testName, async () => {
   const summaryMap: Record<number, SummaryEntry> = {};
 
   workers = await getWorkers(
-    getRandomNames((m_large_TOTAL / m_large_BATCH_SIZE) * 2 + 1),
+    getFixedNames((m_large_TOTAL / m_large_BATCH_SIZE) * 2 + 1),
     testName,
     typeofStream.None,
   );

--- a/suites/metrics/Performance/performance.test.ts
+++ b/suites/metrics/Performance/performance.test.ts
@@ -1,7 +1,7 @@
 import { loadEnv } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { verifyMessageStream } from "@helpers/streams";
-import { getAddresses, getInboxIds, getRandomNames } from "@helpers/tests";
+import { getAddresses, getFixedNames, getInboxIds } from "@helpers/tests";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
@@ -23,11 +23,7 @@ describe(testName, async () => {
   let dm: Conversation;
   let workers: WorkerManager;
 
-  workers = await getWorkers(
-    getRandomNames(10),
-    testName,
-    typeofStream.Message,
-  );
+  workers = await getWorkers(getFixedNames(10), testName, typeofStream.Message);
   const creator = workers.getCreator();
   console.warn("creator is:", creator.name);
   const creatorClient = creator.client;

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -412,9 +412,7 @@ export class WorkerClient extends Worker {
             }
           }
         } catch (error) {
-          console.error(
-            `[${this.nameId}] Message stream error: ${String(error)}`,
-          );
+          console.error(`[${this.nameId}] message stream: ${String(error)}`);
         }
       }
     })();
@@ -511,7 +509,7 @@ export class WorkerClient extends Worker {
           }
         } catch (error) {
           console.error(
-            `[${this.nameId}] Conversation stream error: ${String(error)}`,
+            `[${this.nameId}] conversation stream error: ${String(error)}`,
           );
         }
       }
@@ -559,7 +557,7 @@ export class WorkerClient extends Worker {
           }
         } catch (error) {
           console.error(
-            `[${this.nameId}] Consent stream error: ${String(error)}`,
+            `[${this.nameId}] consent stream error: ${String(error)}`,
           );
         }
       }

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -609,7 +609,7 @@ export class WorkerClient extends Worker {
       // Add timeout to prevent hanging indefinitely
       const timeoutId = setTimeout(() => {
         this.off("worker_message", onMessage);
-        console.debug(
+        console.error(
           `[${this.nameId}] Stream collection timed out. ${
             DEFAULT_STREAM_TIMEOUT_MS / 1000
           }s.`,

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -134,6 +134,7 @@ export class WorkerManager {
       const installations = await worker.client.preferences.inboxState();
       const totalInstallations = installations.installations.length;
       if (totalInstallations > 25) {
+        await worker.client.revokeAllOtherInstallations();
         throw new Error(
           `[${worker.name}] Max installation reached: ${totalInstallations}`,
         );

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -135,10 +135,16 @@ export class WorkerManager {
       const totalInstallations = installations.installations.length;
       if (totalInstallations > 25) {
         await worker.client.revokeAllOtherInstallations();
-        throw new Error(
-          `[${worker.name}] Max installation reached: ${totalInstallations}`,
-        );
-        // console.warn(`[${worker.name}] Package details: ${totalInstallations}`);
+        const installations = await worker.client.preferences.inboxState(true);
+        if (installations.installations.length > 25) {
+          throw new Error(
+            `[${worker.name}] Max installation reached: ${totalInstallations}`,
+          );
+        } else {
+          console.warn(
+            `[${worker.name}] Package details: ${totalInstallations}`,
+          );
+        }
       }
       for (const installation of installations.installations) {
         // Convert nanoseconds to milliseconds for Date constructor

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -135,7 +135,7 @@ export class WorkerManager {
       const totalInstallations = installations.installations.length;
       if (totalInstallations > 25) {
         throw new Error(
-          `[${worker.name}] Package details: ${totalInstallations}`,
+          `[${worker.name}] Max installation reached: ${totalInstallations}`,
         );
         // console.warn(`[${worker.name}] Package details: ${totalInstallations}`);
       }

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -129,20 +129,19 @@ export class WorkerManager {
     return this.workers[firstBaseName][firstInstallId].sdkVersion;
   }
 
-  public async packageDetails() {
+  public async checkInstallations() {
     for (const worker of this.getAll()) {
       const installations = await worker.client.preferences.inboxState();
-      const totalInstallations = installations.installations.length;
-      if (totalInstallations > 25) {
+      if (installations.installations.length > 10) {
         await worker.client.revokeAllOtherInstallations();
         const installations = await worker.client.preferences.inboxState(true);
-        if (installations.installations.length > 25) {
+        if (installations.installations.length > 10) {
           throw new Error(
-            `[${worker.name}] Max installation reached: ${totalInstallations}`,
+            `[${worker.name}] Max installation reached: ${installations.installations.length}`,
           );
         } else {
           console.warn(
-            `[${worker.name}] Package details: ${totalInstallations}`,
+            `[${worker.name}] Package details: ${installations.installations.length}`,
           );
         }
       }
@@ -412,7 +411,7 @@ export async function getWorkers(
   );
   await Promise.all(workerPromises);
   manager.printWorkers();
-  await manager.packageDetails();
+  await manager.checkInstallations();
   return manager;
 }
 

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -133,8 +133,11 @@ export class WorkerManager {
     for (const worker of this.getAll()) {
       const installations = await worker.client.preferences.inboxState();
       const totalInstallations = installations.installations.length;
-      if (totalInstallations > 10) {
-        console.warn(`[${worker.name}] Package details: ${totalInstallations}`);
+      if (totalInstallations > 25) {
+        throw new Error(
+          `[${worker.name}] Package details: ${totalInstallations}`,
+        );
+        // console.warn(`[${worker.name}] Package details: ${totalInstallations}`);
       }
       for (const installation of installations.installations) {
         // Convert nanoseconds to milliseconds for Date constructor


### PR DESCRIPTION
### Add tests for bug_kpke to ensure proper functionality and rename command line flags from --log to --debug across the codebase
This pull request makes two primary changes:

• Adds a new test file [bug_kpke.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/367/files#diff-bfd1c8916dcb9a92d6f2a44d5c82563bf40709522d3cbac74369b9695a160422) that tests sending messages to a specific Ethereum address (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) by creating a conversation, syncing all conversations, and sending a 'GANG' message to verify message streaming functionality
• Renames command line flags from `--log` to `--debug` and `--log-file` to `--debug-file` across all GitHub workflow files, CLI scripts, documentation, and helper files
• Changes test worker name generation from `getRandomNames` to `getFixedNames` across multiple test files to make tests more deterministic
• Enhances the `packageDetails` method in [manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/367/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) by renaming it to `checkInstallations` and adding functionality to automatically revoke installations when there are more than 10

#### 📍Where to Start
Start with the new test file [bug_kpke.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/367/files#diff-bfd1c8916dcb9a92d6f2a44d5c82563bf40709522d3cbac74369b9695a160422) to understand the core functionality being tested, then review the CLI flag changes in [cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/367/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810).

----

_[Macroscope](https://app.macroscope.com) summarized 5b91c2b._