### PR TITLE
Change test command to prevent failure on errors

### DIFF
--- a/.github/workflows/NotForked.yml
+++ b/.github/workflows/NotForked.yml
@@ -109,7 +109,7 @@ jobs:
             find .data -name "*.db" -exec ls -la {} \;
           fi
       - name: Run tests
-        run: yarn test not-forked --debug
+        run: yarn test not-forked --no-fail
         env:
           SQLITE_TMPDIR: /tmp
           PRAGMA_MLOCK: 0


### PR DESCRIPTION
### Change test command from `--debug` to `--no-fail` flag to prevent failure on errors in GitHub workflow NotForked.yml
The GitHub workflow file [NotForked.yml](https://github.com/xmtp/xmtp-qa-tools/pull/373/files#diff-9172bff66bb429afb3cdbbb5f26a6414e55a245687ab64fd1e162c5687ff8808) modifies the test execution command in the 'Run tests' step from `yarn test not-forked --debug` to `yarn test not-forked --no-fail`, replacing the debug flag with a no-fail flag that prevents the test runner from failing the workflow when tests encounter errors.

#### 📍Where to Start
Start with the 'Run tests' step in the GitHub workflow file [NotForked.yml](https://github.com/xmtp/xmtp-qa-tools/pull/373/files#diff-9172bff66bb429afb3cdbbb5f26a6414e55a245687ab64fd1e162c5687ff8808).

----

_[Macroscope](https://app.macroscope.com) summarized 2ab2cc5._