### PR TITLE
Initial network chaos utilities & smoke tests

### DIFF
--- a/network-stability-tests/README.txt
+++ b/network-stability-tests/README.txt
@@ -1,0 +1,2 @@
+Must have Docker installed and `docker` command available to run as the test user
+Must have passwordless SUDO enabled

--- a/network-stability-tests/smoketests.test.ts
+++ b/network-stability-tests/smoketests.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "vitest";
+import { DockerContainer } from "../network-stability-utilities/container";
+
+describe("Basic Network Fault Tests", () => {
+    const node1 = new DockerContainer("multinode-node1-1");
+    const node2 = new DockerContainer("multinode-node2-1");
+    const node4 = new DockerContainer("multinode-node4-1");
+
+    it("should add and remove 200ms latency between node1 and node2", () => {
+        console.log("[netem] Clearing existing qdisc (ok if already absent)...");
+        node1.clearLatency();
+
+        console.log("[netem] Pinging node2 from node1 before latency:");
+        node1.ping(node2);
+
+        console.log(`[netem] Applying 200ms delay to node1 veth interface: ${node1.veth}`);
+        node1.addLatency(200);
+
+        console.log("[netem] Pinging node2 from node1 with latency:");
+        node1.ping(node2);
+
+        console.log("[netem] Removing latency...");
+        node1.clearLatency();
+
+        console.log("[netem] Pinging node2 from node1 after latency removed:");
+        node1.ping(node2);
+    });
+
+    it("should block and restore traffic between node1 and node4", () => {
+        console.log("[iptables] Pinging node4 from node1 before partition:");
+        node1.ping(node4);
+
+        console.log("[iptables] Blocking outbound traffic from node1 to node4...");
+        node1.blockOutboundTrafficTo(node4);
+
+        console.log("[iptables] Pinging node4 from node1 during partition (expect failure):");
+        node1.ping(node4, 3, true);
+
+        console.log("[iptables] Unblocking outbound traffic from node1 to node4...");
+        node1.unblockOutboundTrafficTo(node4);
+
+        console.log("[iptables] Pinging node4 from node1 after restoring:");
+        node1.ping(node4);
+    });
+});

--- a/network-stability-utilities/README.txt
+++ b/network-stability-utilities/README.txt
@@ -1,0 +1,2 @@
+Must have Docker installed and `docker` command available to run as the test user
+Must have passwordless SUDO enabled

--- a/network-stability-utilities/container.ts
+++ b/network-stability-utilities/container.ts
@@ -1,0 +1,167 @@
+import { execSync, execFileSync } from "child_process";
+import { Netem } from "./netem";
+import { Iptables } from "./iptables";
+
+export class DockerContainer {
+    name: string;
+    ip: string;
+    pid: string;
+    veth: string;
+
+    constructor(name: string) {
+        DockerContainer.validateDependencies();
+        this.name = name;
+        this.ip = this.getIP();
+        this.pid = this.getPID();
+        this.veth = this.getVeth();
+    }
+
+    private getIP(): string {
+        return this.sh(`docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${this.name}`);
+    }
+
+    private getPID(): string {
+        return this.sh(`docker inspect -f '{{.State.Pid}}' ${this.name}`);
+    }
+
+    private getVeth(): string {
+        try {
+            const pid = this.pid;
+            const ifLine = this.sh(`sudo nsenter -t ${pid} -n ip link show eth0`);
+            const match = ifLine.match(/eth0@if(\d+):/);
+            if (!match) throw new Error(`Could not extract ifindex from: ${ifLine}`);
+
+            const ifIndex = parseInt(match[1], 10);
+            const linksOutput = this.sh("ip -o link");
+            const lines = linksOutput.split("\n");
+
+            const vethLine = lines.find((line) => line.startsWith(`${ifIndex}: `));
+            if (!vethLine) throw new Error(`Could not find host veth interface for ifindex ${ifIndex}`);
+
+            const iface = vethLine.split(":")[1].trim().split("@")[0];
+            return iface;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            throw new Error(`[sh] getVeth() failed for ${this.name}: ${msg}`);
+        }
+    }
+
+    sh(cmd: string, expectFailure = false): string {
+        console.log(`[sh] Executing: ${cmd}`);
+        try {
+            const output = execSync(cmd, { stdio: ["inherit", "pipe", "pipe"] }).toString().trim();
+            return output;
+        } catch (e) {
+            if (expectFailure) {
+                console.log(`[sh] Shell command failed as expected: ${cmd}`);
+                return "";
+            }
+
+            if (e instanceof Error && "stderr" in e) {
+                const stderr = (e as { stderr?: Buffer }).stderr?.toString().trim();
+                console.error(`[sh] Error output: ${stderr}`);
+            }
+
+            throw new Error(`Command failed: ${cmd}\n${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+
+    ping(target: DockerContainer, count = 3, expectFailure = false): void {
+        console.log(`[sh] Pinging ${target.name} (${target.ip}) from ${this.name}...`);
+        try {
+            const output = execSync(`docker exec ${this.name} ping -c ${count} ${target.ip}`, {
+                stdio: "pipe"
+            }).toString();
+            const summary = output.split("\n").find((line) => line.includes("rtt") || line.includes("round-trip"));
+            if (summary !== undefined) {
+                console.log(`[sh] ${summary}`);
+            } else {
+                console.log(`[sh] ${output}`);
+            }
+        } catch (e) {
+            if (expectFailure) {
+                console.log("[iptables] Ping failed as expected");
+            } else {
+                console.error(`[sh] Ping failed unexpectedly: ${e instanceof Error ? e.message : String(e)}`);
+            }
+        }
+    }
+
+    addLatency(ms: number): void {
+        if (!Netem?.applyLatency) {
+            throw new Error("Netem module not available.");
+        }
+        Netem.applyLatency(this, ms);
+    }
+
+    addJitter(delay: number, jitter: number): void {
+        Netem.applyJitter(this, delay, jitter);
+    }
+
+    addLoss(percent: number): void {
+        Netem.applyLoss(this, percent);
+    }
+
+    clearLatency(): void {
+        try {
+            Netem.clear(this);
+        } catch {
+            console.log(`[netem] No existing qdisc to clear on ${this.name}`);
+        }
+    }
+
+    async addFixedLatencyTo(other: DockerContainer, latencyMs: number): Promise<void> {
+        await Netem.applyBidirectionalLatency(this, other, latencyMs);
+    }
+
+    blockOutboundTrafficTo(target: DockerContainer): void {
+        Iptables.blockOutboundTraffic(this, target);
+    }
+
+    unblockOutboundTrafficTo(target: DockerContainer): void {
+        Iptables.unblockOutboundTraffic(this, target);
+    }
+
+    blackHoleTo(target: DockerContainer): void {
+        Iptables.blockOutboundTraffic(this, target);
+    }
+
+    kill(): void {
+        execFileSync("docker", ["kill", this.name], { stdio: "inherit" });
+    }
+
+    pause(): void {
+        execFileSync("docker", ["pause", this.name], { stdio: "inherit" });
+    }
+
+    unpause(): void {
+        execFileSync("docker", ["unpause", this.name], { stdio: "inherit" });
+    }
+
+    static listRunningXmtpNodes(): DockerContainer[] {
+        const output = execSync(
+            `docker ps --filter "ancestor=xmtp-node" --format "{{.Names}}"`
+        ).toString().trim();
+        if (!output) return [];
+        return output.split("\n").map((name) => new DockerContainer(name));
+    }
+
+    static validateDependencies(): void {
+        const dependencies = ["docker", "iptables", "tc"];
+        for (const cmd of dependencies) {
+            try {
+                execSync(`command -v ${cmd}`, { stdio: "ignore" });
+            } catch {
+                throw new Error(`Dependency not found - please install: ${cmd}`);
+            }
+        }
+    }
+
+    static listByNamePrefix(prefix: string): DockerContainer[] {
+        const output = execSync(
+            `docker ps --format "{{.Names}}" | grep ^${prefix} || true`
+        ).toString().trim();
+        if (!output) return [];
+        return output.split("\n").map((name) => new DockerContainer(name));
+    }
+}

--- a/network-stability-utilities/iptables.ts
+++ b/network-stability-utilities/iptables.ts
@@ -1,0 +1,20 @@
+import type { DockerContainer } from "./container";
+import { execSync } from "child_process";
+
+export class Iptables {
+    private constructor() { }
+
+    static blockOutboundTraffic(from: DockerContainer, to: DockerContainer): void {
+        console.log(`[iptables] Blocking outbound traffic from ${from.name} to ${to.name}...`);
+        execSync(`sudo nsenter -t ${from.pid} -n iptables -A OUTPUT -d ${to.ip} -j DROP`);
+    }
+
+    static unblockOutboundTraffic(from: DockerContainer, to: DockerContainer): void {
+        console.log(`[iptables] Restoring outbound traffic from ${from.name} to ${to.name}...`);
+        try {
+            execSync(`sudo nsenter -t ${from.pid} -n iptables -D OUTPUT -d ${to.ip} -j DROP`);
+        } catch (e) {
+            console.warn(`[iptables] Could not delete iptables rule: ${e instanceof Error ? e.message : String(e)}`);
+        }
+    }
+}

--- a/network-stability-utilities/netem.ts
+++ b/network-stability-utilities/netem.ts
@@ -1,0 +1,33 @@
+import type { DockerContainer } from "./container";
+
+export class Netem {
+    private constructor() { }
+
+    static applyLatency(container: DockerContainer, latencyMs: number): void {
+        console.log(`[netem] Clearing any existing qdisc on ${container.veth} (ok if none exists)...`);
+        container.sh(`sudo tc qdisc del dev ${container.veth} root`, true);
+
+        console.log(`[netem] Applying ${latencyMs}ms latency to ${container.veth}...`);
+        container.sh(`sudo tc qdisc add dev ${container.veth} root netem delay ${latencyMs}ms`);
+    }
+
+    static applyJitter(container: DockerContainer, delay: number, jitter: number): void {
+        this.clear(container);
+        container.sh(`sudo tc qdisc add dev ${container.veth} root netem delay ${delay}ms ${jitter}ms`);
+    }
+
+    static applyLoss(container: DockerContainer, percent: number): void {
+        this.clear(container);
+        container.sh(`sudo tc qdisc add dev ${container.veth} root netem loss ${percent}%`);
+    }
+
+    static clear(container: DockerContainer): void {
+        console.log(`[netem] Clearing latency from ${container.veth} (ok if already cleared)...`);
+        container.sh(`sudo tc qdisc del dev ${container.veth} root`, true);
+    }
+
+    static applyBidirectionalLatency(a: DockerContainer, b: DockerContainer, ms: number): void {
+        this.applyLatency(a, ms);
+        this.applyLatency(b, ms);
+    }
+}


### PR DESCRIPTION
Add network chaos utilities and smoke tests for Docker container network manipulation including latency, jitter, packet loss, and traffic blocking capabilities

Sample smoke test output:
```
ubuntu@ip-172-31-15-190:~/xmtp-qa-testing$ npx vitest run network-stability-tests/smoketests.test.ts

 RUN  v3.1.3 /home/ubuntu/xmtp-qa-testing
      API started at http://localhost:51204/

stdout | network-stability-tests/smoketests.test.ts
[sh] Executing: docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' multinode-node1-1
[sh] Executing: docker inspect -f '{{.State.Pid}}' multinode-node1-1
[sh] Executing: sudo nsenter -t 174642 -n ip link show eth0
[sh] Executing: ip -o link
[sh] Executing: docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' multinode-node2-1
[sh] Executing: docker inspect -f '{{.State.Pid}}' multinode-node2-1
[sh] Executing: sudo nsenter -t 174758 -n ip link show eth0
[sh] Executing: ip -o link
[sh] Executing: docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' multinode-node4-1
[sh] Executing: docker inspect -f '{{.State.Pid}}' multinode-node4-1
[sh] Executing: sudo nsenter -t 175010 -n ip link show eth0
[sh] Executing: ip -o link

stdout | network-stability-tests/smoketests.test.ts > Basic Network Fault Tests > should add and remove 200ms latency between node1 and node2
[netem] Clearing existing qdisc (ok if already absent)...
[netem] Clearing latency from vethac5932e (ok if already cleared)...
[sh] Executing: sudo tc qdisc del dev vethac5932e root
[sh] Shell command failed as expected: sudo tc qdisc del dev vethac5932e root
[netem] Pinging node2 from node1 before latency:
[sh] Pinging multinode-node2-1 (172.23.0.7) from multinode-node1-1...
[sh] round-trip min/avg/max = 0.053/0.056/0.063 ms
[netem] Applying 200ms delay to node1 veth interface: vethac5932e
[netem] Clearing any existing qdisc on vethac5932e (ok if none exists)...
[sh] Executing: sudo tc qdisc del dev vethac5932e root
[sh] Shell command failed as expected: sudo tc qdisc del dev vethac5932e root
[netem] Applying 200ms latency to vethac5932e...
[sh] Executing: sudo tc qdisc add dev vethac5932e root netem delay 200ms
[netem] Pinging node2 from node1 with latency:
[sh] Pinging multinode-node2-1 (172.23.0.7) from multinode-node1-1...
[sh] round-trip min/avg/max = 200.102/200.213/200.339 ms
[netem] Removing latency...
[netem] Clearing latency from vethac5932e (ok if already cleared)...
[sh] Executing: sudo tc qdisc del dev vethac5932e root
[netem] Pinging node2 from node1 after latency removed:
[sh] Pinging multinode-node2-1 (172.23.0.7) from multinode-node1-1...
[sh] round-trip min/avg/max = 0.057/0.061/0.064 ms

stdout | network-stability-tests/smoketests.test.ts > Basic Network Fault Tests > should block and restore traffic between node1 and node4
[iptables] Pinging node4 from node1 before partition:
[sh] Pinging multinode-node4-1 (172.23.0.9) from multinode-node1-1...
[sh] round-trip min/avg/max = 0.055/0.058/0.063 ms
[iptables] Blocking outbound traffic from node1 to node4...
[iptables] Blocking outbound traffic from multinode-node1-1 to multinode-node4-1...
[iptables] Pinging node4 from node1 during partition (expect failure):
[sh] Pinging multinode-node4-1 (172.23.0.9) from multinode-node1-1...
[iptables] Ping failed as expected
[iptables] Unblocking outbound traffic from node1 to node4...
[iptables] Restoring outbound traffic from multinode-node1-1 to multinode-node4-1...
[iptables] Pinging node4 from node1 after restoring:
[sh] Pinging multinode-node4-1 (172.23.0.9) from multinode-node1-1...
[sh] round-trip min/avg/max = 0.055/0.062/0.070 ms

 ✓ network-stability-tests/smoketests.test.ts (2 tests) 10696ms
   ✓ Basic Network Fault Tests > should add and remove 200ms latency between node1 and node2  6460ms
   ✓ Basic Network Fault Tests > should block and restore traffic between node1 and node4  4235ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  12:30:25
   Duration  11.24s (transform 83ms, setup 0ms, collect 280ms, tests 10.70s, environment 0ms, prepare 82ms)
```