### PR TITLE
Refactor test suite names for clarity and consistency

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -172,6 +172,6 @@ The workflows have been updated to use standardized naming conventions:
 | `m_delivery.yml`    | `Delivery.yml`    | `yarn test delivery`    |
 | `m_performance.yml` | `Performance.yml` | `yarn test performance` |
 | `m_large.yml`       | `Large.yml`       | `yarn test large`       |
-| `StressGroup.yml`   | `GroupStress.yml` | `yarn test not-forked`  |
+| `StressGroup.yml`   | `GroupStress.yml` | `yarn test group`       |
 
 All test suites now follow consistent kebab-case naming conventions for better organization and maintainability.

--- a/helpers/tests.ts
+++ b/helpers/tests.ts
@@ -253,21 +253,6 @@ export const createRandomInstallations = async (
   return worker;
 };
 
-export const checkIfGroupForked = async (
-  workers: WorkerManager,
-  groupId: string,
-): Promise<void> => {
-  const worker = workers.getRandomWorkers(1)[0];
-  const group = await worker.client.conversations.getConversationById(groupId);
-  if (!group) throw new Error(`Group ${groupId} not found`);
-  const debugInfo = await group.debugInfo();
-
-  if (debugInfo.maybeForked) {
-    console.error(`Group ${groupId} may have forked`);
-    throw new Error(`Group ${groupId} may have forked`);
-  }
-};
-
 /**
  * Gets a random version from the versions array
  */

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "tsc",
     "clean": "rimraf .data/ ||: && rimraf logs/ ||  :",
     "cli": "tsx scripts/cli.ts",
+    "forked": "yarn test suites/automated/group",
     "format": "prettier -w .",
     "functional": "yarn test suites/functional",
     "gen": "tsx scripts/gen.ts",

--- a/suites/README.md
+++ b/suites/README.md
@@ -17,11 +17,11 @@ This directory contains six main categories of test suites:
 
 Tests that run automatically on CI/CD pipelines to monitor production systems.
 
-| Test Suite                                | Purpose                                             | Documentation                                 |
-| ----------------------------------------- | --------------------------------------------------- | --------------------------------------------- |
-| **[agents](./automated/agents/)**         | Health monitoring of production XMTP agents         | [README.md](./automated/agents/README.md)     |
-| **[gm](./automated/gm/)**                 | Validation of GM bot and browser integration        | [README.md](./automated/gm/README.md)         |
-| **[not-forked](./automated/not-forked/)** | Group membership and message forking stress testing | [README.md](./automated/not-forked/README.md) |
+| Test Suite                        | Purpose                                             | Documentation                             |
+| --------------------------------- | --------------------------------------------------- | ----------------------------------------- |
+| **[agents](./automated/agents/)** | Health monitoring of production XMTP agents         | [README.md](./automated/agents/README.md) |
+| **[gm](./automated/gm/)**         | Validation of GM bot and browser integration        | [README.md](./automated/gm/README.md)     |
+| **[group ](./automated/group/)**  | Group membership and message forking stress testing | [README.md](./automated/group/README.md)  |
 
 ## ⚙️ Functional Test Suites
 

--- a/suites/automated/group/README.md
+++ b/suites/automated/group/README.md
@@ -46,5 +46,5 @@ GROUP_ID=""
 ## Test Execution
 
 ```bash
-yarn test not-forked
+yarn test group
 ```

--- a/suites/automated/group/group.test.ts
+++ b/suites/automated/group/group.test.ts
@@ -18,17 +18,13 @@ import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-// ============================================================
-// Test Configuration
-// ============================================================
-
-const TEST_NAME = "not-forked";
+const TEST_NAME = "group";
 const testConfig = {
   testName: TEST_NAME,
-  groupName: `NotForked ${getTime()}`,
+  groupName: `Group ${getTime()}`,
   epochs: 3,
   network: "production",
-  workerNames: getFixedNames(10),
+  workerNames: getFixedNames(40),
   groupId: process.env.GROUP_ID || undefined,
   freshInstalls: false, // more installs
 } as const;
@@ -205,7 +201,7 @@ export async function testMembershipChanges(
       groupId,
     )) as Group;
 
-    for (const member of getRandomInboxIds(5)) {
+    for (const member of getRandomInboxIds(6)) {
       try {
         await group.removeMembers([member]);
         await group.addMembers([member]);

--- a/suites/automated/group/run-tests-periodically.sh
+++ b/suites/automated/group/run-tests-periodically.sh
@@ -4,7 +4,7 @@ while true; do
     echo "Starting test cycle at $(date)"
     for i in {1..3}; do
         echo "Running test iteration $i of 3"
-        yarn test not-forked --debug-verbose
+        yarn test group --debug-verbose
     done
     echo "Waiting 30 minutes before next cycle..."
     sleep 1800


### PR DESCRIPTION
### Rename test suite from 'not-forked' to 'group' and increase worker count from 10 to 40 in automated test configuration
This PR renames the test suite from 'not-forked' to 'group' for clarity and consistency across the codebase. The changes include:

• Renaming the test directory from [suites/automated/not-forked/](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-e637bff0ebc82c3e81e954853c9318de3bec0734787d1954ccb205988d6229f6) to [suites/automated/group/](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-084b307d7499df1b1e6fefc9440f78bac9e668460dd4697592455669d76c974c) and updating all associated files
• Updating test commands in workflows and scripts from `yarn test not-forked` to `yarn test group`
• Increasing the number of test workers from 10 to 40 in [group.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-801bdf7c1547120f2b601268f45614f9a909bf49bfff119f706cb132bfb5e1f2)
• Removing the `checkIfGroupForked` function from [helpers/tests.ts](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-d0765ec47b88b04ac5639d5e41ed13b9cf1e7f55ad28f1ea37951a668f33c626)
• Adding a new `forked` npm script in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) that runs `yarn test suites/automated/group`
• Updating documentation in [suites/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-5762ed4d5d7990eaec92cd3b240359fe7e25e1425fd259386f2ba4c2b8eebbb5) and workflow configuration in [.github/workflows/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffb)

#### 📍Where to Start
Start with the main test file [group.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/397/files#diff-801bdf7c1547120f2b601268f45614f9a909bf49bfff119f706cb132bfb5e1f2) to understand the test configuration changes and increased worker count.

----

_[Macroscope](https://app.macroscope.com) summarized 34277e3._