### PR TITLE
Update log file filtering for consistency in naming

### DIFF
--- a/scripts/parse-ansi-logs.ts
+++ b/scripts/parse-ansi-logs.ts
@@ -91,9 +91,9 @@ async function main(): Promise<void> {
     // Read all files in logs directory
     const files = await readdir(logsDir);
 
-    // Filter for raw-*.log files
+    // Filter for raw-parse-*.log files
     const rawLogFiles = files.filter(
-      (file) => file.startsWith("raw-") && file.endsWith(".log"),
+      (file) => file.startsWith("raw-parse-") && file.endsWith(".log"),
     );
 
     if (rawLogFiles.length === 0) {
@@ -114,7 +114,7 @@ async function main(): Promise<void> {
 
     for (const file of rawLogFiles) {
       const inputPath = join(logsDir, file);
-      const outputFileName = file.replace("raw-", "cleaned-");
+      const outputFileName = file.replace("raw-parse-", "cleaned-parse-");
       const outputPath = join(outputDir, outputFileName);
 
       const stats = await readFile(inputPath);


### PR DESCRIPTION
### Update log file filtering pattern from `raw-*.log` to `raw-parse-*.log` and modify output filename replacement in parse-ansi-logs.ts for consistency in naming
The script modifies its file processing logic to target a more specific subset of log files. The filter condition changes from matching `raw-*.log` files to `raw-parse-*.log` files, and the output filename generation updates from replacing `raw-` with `cleaned-` to replacing `raw-parse-` with `cleaned-parse-` in [parse-ansi-logs.ts](https://github.com/xmtp/xmtp-qa-tools/pull/398/files#diff-231d4862f0f654659552e28983839093d022176d7f83051ff43612d11d4e3381).

#### 📍Where to Start
Start with the file filtering logic in [parse-ansi-logs.ts](https://github.com/xmtp/xmtp-qa-tools/pull/398/files#diff-231d4862f0f654659552e28983839093d022176d7f83051ff43612d11d4e3381) where the pattern matching and filename replacement occurs.

----

_[Macroscope](https://app.macroscope.com) summarized 420cede._