### PR TITLE
Update README to clarify repro steps for bug

### DIFF
--- a/suites/bugs/bug_addmember/README.md
+++ b/suites/bugs/bug_addmember/README.md
@@ -2,13 +2,18 @@
 
 • **Repro**:
 
-- Create group with Node.js + XMTP Chat users
-- Add new Node.js member
-- New member only uses `conversation.stream()` before being added
-- Stream never receives the group conversation but an error `create group from welcome: welcome with cursor`
+Repro test
 
-• **Works**: All Node.js users only ✅
-• **Fails**: Mixed Node.js + XMTP Chat users ❌
+- Create group with with an [xmtp.chat](https://xmtp.chat/conversations/5ef738ad0a9b61bcc294a3bf621779e6) user
+- Start new node member with `conversation.stream()`
+- Add member on the already created group
+
+Other:
+
+- Only happens with addMember , not newGroup
+- Doesn't happen in node-only
+- Happens when the member is added from browser or RN
+- Happens with 2 xmtp chat windows opened
 
 ## Description
 


### PR DESCRIPTION
### Update README to clarify repro steps for bug_addmember test suite bug reproduction scenario
The [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/419/files#diff-e3dd96f75be3b6bb52d00f9cd88d4dc30ad7f990ab156351d4f12d6dc308bcf4) file for the `bug_addmember` test suite replaces general bug description with specific reproduction steps that detail creating a group with an xmtp.chat user, starting a new node member with `conversation.stream()`, and adding the member to the existing group. The documentation adds clarifications that the issue occurs only with `addMember` (not `newGroup`), does not happen in node-only environments, and manifests when members are added from browser or React Native environments or when two xmtp chat windows are opened.

#### 📍Where to Start
Start with the updated reproduction steps in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/419/files#diff-e3dd96f75be3b6bb52d00f9cd88d4dc30ad7f990ab156351d4f12d6dc308bcf4).

----

_[Macroscope](https://app.macroscope.com) summarized e0a67c8._