### PR TITLE
Improve Medium configuration performance rating to 4 stars

### DIFF
--- a/bots/stress/index.ts
+++ b/bots/stress/index.ts
@@ -16,24 +16,23 @@ export const TEST_CONFIGS: Record<
     { size: 50, count: 5, messages: 50 },
   ],
   medium: [
-    { size: 2, count: 5, messages: 10 },
-    { size: 10, count: 5, messages: 10 },
+    { size: 2, count: 10, messages: 10 },
+    { size: 10, count: 10, messages: 10 },
     { size: 50, count: 5, messages: 10 },
     { size: 100, count: 10, messages: 20 },
     { size: 150, count: 15, messages: 20 },
   ],
   large: [
-    { size: 2, count: 5, messages: 10 },
-    { size: 10, count: 5, messages: 10 },
-    { size: 50, count: 5, messages: 10 },
+    { size: 2, count: 30, messages: 10 },
+    { size: 10, count: 20, messages: 10 },
+    { size: 50, count: 10, messages: 10 },
     { size: 100, count: 10, messages: 20 },
     { size: 150, count: 15, messages: 20 },
-    { size: 100, count: 15, messages: 100 },
     { size: 200, count: 15, messages: 100 },
   ],
   xl: [
-    { size: 2, count: 100, messages: 20 },
-    { size: 10, count: 100, messages: 20 },
+    { size: 2, count: 200, messages: 20 },
+    { size: 10, count: 200, messages: 20 },
   ],
 };
 

--- a/suites/mobile/README.md
+++ b/suites/mobile/README.md
@@ -16,9 +16,9 @@ Measures application performance degradation ("slugishness") under increasing lo
 yarn test stress
 ```
 
-## History
+## Mobile Performance Rating
 
-## Mobile Performance Rating (Original)
+#### Prod v82
 
 | Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating          |
 | ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | --------------- |
@@ -27,7 +27,7 @@ yarn test stress
 | **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
 | **XL**        | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
 
-## Mobile Performance Rating v304 (Medium +30%)
+#### Prod v304 (Medium +40%)
 
 | Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating          |
 | ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | --------------- |

--- a/suites/mobile/README.md
+++ b/suites/mobile/README.md
@@ -36,8 +36,6 @@ yarn test stress
 | **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
 | **XL**        | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
 
-The Medium configuration now performs significantly better, moving from a 2-3 star rating to a solid 4-star rating with consistent performance across all metrics.
-
 ### Performance Metrics
 
 - **Log in** - Time from login to full display of conversation list

--- a/suites/mobile/README.md
+++ b/suites/mobile/README.md
@@ -4,10 +4,10 @@ Measures application performance degradation ("slugishness") under increasing lo
 
 ## Configurations
 
-- **Small** ~20 groups, 15 messages ~ 2 MB
-- **Medium** ~50 groups of various sizes with 50 messages ~ 5 MB
-- **Large** ~100 groups with 15 messages ~ 10 MB
-- **XL** ~200 groups with 20 messages ~ 5 MB
+- **Small** ~15 groups, 10,20 messages
+- **Medium** ~50 groups of various sizes with 10,20 messages
+- **Large** ~100 groups with 10,20,100 messages
+- **XL** ~400 groups with 20 messages
 
 ## How to Run
 

--- a/suites/mobile/README.md
+++ b/suites/mobile/README.md
@@ -23,7 +23,7 @@ yarn test stress
 | Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating          |
 | ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | --------------- |
 | **Small**     | 4      | 4        | 3        | 4                | 5           | 4      | ⭐️⭐️⭐️⭐️⭐️ |
-| **Medium**    | 1      | 1        | 1        | 2                | 3           | 3      | ⭐️⭐️ (2.83)   |
+| **Medium**    | 2      | 3        | 2        | 2                | 3           | 3      | ⭐️⭐️ (2.5)    |
 | **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
 | **XL**        | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
 

--- a/suites/mobile/README.md
+++ b/suites/mobile/README.md
@@ -40,12 +40,13 @@ The Medium configuration now performs significantly better, moving from a 2-3 st
 
 ### Performance Metrics
 
-- **Log in** - Time from app icon tap to conversation list display
-- **On notif** - Time for individual messages to appear when opening a conversation.
-- **Messages** - How quickly UI buttons respond to user taps and interactions.
-- **Button Responses** - Time to open app from push notification after being closed/backgrounded.
-- **Transitions** - Speed of navigation between screens and UI state changes.
-- **Scroll** - How quickly UI scrolls to the bottom of the conversation
+- **Log in** - Time from login to full display of conversation list
+- **On notif** - Time for individual notification to open a conversation.
+- **Messages** - How quickly messages render in a message list
+- **Button Responses** - How quickly UI buttons respond to user taps and interactions
+- **Transitions** - Speed of navigation between screens (conversation and messages)
+- **Scroll** - How quickly UI scrolls to the bottom of the conversation list or top for message history
+- **Rating** - Overall rating of the application's performance based on the above metrics
 
 ### Rating Scale
 

--- a/suites/mobile/README.md
+++ b/suites/mobile/README.md
@@ -29,12 +29,12 @@ yarn test stress
 
 ## Mobile Performance Rating v304 (Medium +30%)
 
-| Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating           |
-| ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | ---------------- |
-| **Small**     | 4      | 4        | 3        | 4                | 5           | 4      | ⭐️⭐️⭐️⭐️⭐️  |
-| **Medium**    | 2      | 3        | 3        | 4                | 4           | 3      | ⭐️⭐️⭐️ (3.17) |
-| **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️              |
-| **XL**        | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️              |
+| Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating          |
+| ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | --------------- |
+| **Small**     | 4      | 4        | 3        | 4                | 5           | 4      | ⭐️⭐️⭐️⭐️⭐️ |
+| **Medium**    | 3      | 4        | 3        | 4                | 4           | 3      | ⭐️⭐️⭐️ (3.5) |
+| **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
+| **XL**        | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
 
 The Medium configuration now performs significantly better, moving from a 2-3 star rating to a solid 4-star rating with consistent performance across all metrics.
 

--- a/suites/mobile/README.md
+++ b/suites/mobile/README.md
@@ -18,23 +18,25 @@ yarn test stress
 
 ## History
 
-### Mobile Performance Rating v82
+## Mobile Performance Rating (Original)
+
+| Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating          |
+| ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | --------------- |
+| **Small**     | 4      | 4        | 3        | 4                | 5           | 4      | ⭐️⭐️⭐️⭐️⭐️ |
+| **Medium**    | 1      | 1        | 1        | 2                | 3           | 3      | ⭐️⭐️ (2.83)   |
+| **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
+| **XL**        | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️             |
+
+## Mobile Performance Rating v304 (Medium +30%)
 
 | Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating           |
 | ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | ---------------- |
-| **Small**     | 4      | 4        | 3        | 4                | 5           | 4      | ⭐️⭐️⭐️ (2.83) |
-| **Medium**    | 1      | 1        | 1        | 2                | 3           | 3      | ⭐️⭐️⭐️        |
-| **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️              |
-| **XL**        | 1      | 1        | 1        | 3                | 4           | 1      | ⭐️              |
-
-### Mobile Performance Rating v304
-
-| Configuration | Log in | On notif | Messages | Button Responses | Transitions | Scroll | Rating           |
-| ------------- | ------ | -------- | -------- | ---------------- | ----------- | ------ | ---------------- |
-| **Small**     | 4      | 4        | 3        | 4                | 5           | 4      | ⭐️⭐️⭐️ (2.83) |
-| **Medium**    | 2      | 3        | 3        | 3                | 3           | 3      | ⭐️⭐️           |
+| **Small**     | 4      | 4        | 3        | 4                | 5           | 4      | ⭐️⭐️⭐️⭐️⭐️  |
+| **Medium**    | 2      | 3        | 3        | 4                | 4           | 3      | ⭐️⭐️⭐️ (3.17) |
 | **Large**     | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️              |
 | **XL**        | 1      | 1        | 1        | 1                | 1           | 1      | ⭐️              |
+
+The Medium configuration now performs significantly better, moving from a 2-3 star rating to a solid 4-star rating with consistent performance across all metrics.
 
 ### Performance Metrics
 


### PR DESCRIPTION
### Remove performance rating statement from Medium configuration documentation in mobile suite README
This change removes a single line from the mobile suite documentation that described the Medium configuration's performance improvement from 2-3 star rating to 4-star rating. The modification affects only the [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/424/files#diff-6ec5c5f7e1a7b9a4655c0be7d01f669c801eeb762db5e37cf52061779a0e4333) file in the mobile test suite.

#### 📍Where to Start
Start with the [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/424/files#diff-6ec5c5f7e1a7b9a4655c0be7d01f669c801eeb762db5e37cf52061779a0e4333) file to see the documentation change.

----

_[Macroscope](https://app.macroscope.com) summarized 4701abb._