### PR TITLE
Remove unnecessary section from spam README file

### DIFF
--- a/suites/spam/README.md
+++ b/suites/spam/README.md
@@ -37,5 +37,3 @@ const spamInboxIds = [
   "c10e8c13c833f1826e98fb0185403c2c4d5737cc432d575468613abf9adae26b",
 ];
 ```
-
-### Details

--- a/suites/spam/README.md
+++ b/suites/spam/README.md
@@ -39,16 +39,3 @@ const spamInboxIds = [
 ```
 
 ### Details
-
-The spam test creates groups containing:
-
-- Random inbox IDs (based on member count - 2)
-- Predefined spam inbox IDs
-- The bot creator
-
-Groups are created continuously until the database reaches the target storage size, allowing analysis of:
-
-- Storage growth patterns from spam groups
-- Number of spam groups created before reaching threshold
-- Storage efficiency impact of spam conversations
-- Database size progression during spam scenarios


### PR DESCRIPTION
### Remove unnecessary Details section from spam test suite README documentation
This change removes the 'Details' section from [suites/spam/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/426/files#diff-36e65c6fc21889b0af2eb51a5febef90d8d1843095bdd9861f229af36f5810b7) which contained documentation explaining how the spam test works, including information about group creation with random inbox IDs, predefined spam inbox IDs, bot creator functionality, and analysis capabilities for storage growth patterns and database size progression.

#### 📍Where to Start
Start with the modified [suites/spam/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/426/files#diff-36e65c6fc21889b0af2eb51a5febef90d8d1843095bdd9861f229af36f5810b7) file to see the removed documentation section.

----

_[Macroscope](https://app.macroscope.com) summarized cca1d6f._