### PR TITLE
Improve debug logging for test execution results

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -18,7 +18,6 @@ jobs:
       XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      WALLET_KEY: ${{ secrets.WALLET_KEY }}
       DEFAULT_STREAM_TIMEOUT_MS: 8000
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/Browser.yml
+++ b/.github/workflows/Browser.yml
@@ -17,7 +17,6 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
-      WALLET_KEY: ${{ secrets.WALLET_KEY }}
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}

--- a/.github/workflows/PR_Test.yml
+++ b/.github/workflows/PR_Test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [dev, production]
+        environment: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}

--- a/.github/workflows/PR_Test.yml
+++ b/.github/workflows/PR_Test.yml
@@ -1,0 +1,34 @@
+name: PR_Test
+description: "should verify performance of PR"
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [dev, production]
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      XMTP_ENV: ${{ matrix.environment }}
+      GEOLOCATION: ${{ vars.GEOLOCATION }}
+      BATCH_SIZE: 50
+      MAX_GROUP_SIZE: 200
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+      - name: Install dependencies
+        run: yarn
+      - name: Run tests
+        run: yarn test membership.test

--- a/helpers/inboxes.json
+++ b/helpers/inboxes.json
@@ -3,139 +3,162 @@
     "accountAddress": "0x491902f20d1f00147deb1a4f99a90b36684d59bd",
     "walletKey": "0xed56dded34094633f891ab68d3c1742eeaa1bfb1867fdb48d746c523b7497292",
     "dbEncryptionKey": "f763f33b5f41cdfac294fce8f9879696a22478ddced7d1ade9282c966bfa9d8c",
-    "inboxId": "2132095affc1b14a4d85dd76e9c0459135216ed0c2da69fb32b8ec245e0f67c0"
+    "inboxId": "2132095affc1b14a4d85dd76e9c0459135216ed0c2da69fb32b8ec245e0f67c0",
+    "installations": 2
   },
   {
     "accountAddress": "0x8314682f55688294ea5bf1940ce3612f02872820",
     "walletKey": "0x80484f676c9a8d5f4e63842197b770dc3663a974caf004dfbed502db652ad198",
     "dbEncryptionKey": "5c27e9f3f9208bfc66ede658ceea74e57f564fa711a8c0ca0423dc569390747d",
-    "inboxId": "0f9d351b9848b15f4747d131dc90be4b17737f82d3da739f4ce5efb8a5b5050e"
+    "inboxId": "0f9d351b9848b15f4747d131dc90be4b17737f82d3da739f4ce5efb8a5b5050e",
+    "installations": 2
   },
   {
     "accountAddress": "0x7ab5f1e2abdd649a76186fa587acc1293d87544b",
     "walletKey": "0xeee8db7e47da03c0dbf39bf736882c9d8b4596a6b19b3f8ef9fd1bc7541b5ba1",
     "dbEncryptionKey": "08d227c6a3d2f10eca761ce73e13c8cd58fbbf644929c2ef9fb56021d0e8c30b",
-    "inboxId": "72b0741d66ba5e7bbd042adf12856b40e8a1b1f8d9f53497e84876cfff86303b"
+    "inboxId": "72b0741d66ba5e7bbd042adf12856b40e8a1b1f8d9f53497e84876cfff86303b",
+    "installations": 2
   },
   {
     "accountAddress": "0xc1c862a68ef4bbb1644ce06b26892bff907b9acf",
     "walletKey": "0x9dc02676e886f63e75a3efc48e33844aec778d26557c7705f9077d0da6c4a9ed",
     "dbEncryptionKey": "c72a58a183beb94a0220a2144bfa3eb97ecb33d1e6da88186a302f9cb64ed18c",
-    "inboxId": "f38e0acead50e3ceff2f26b9b276a0715885740635ff7d4642c601d0550d6d90"
+    "inboxId": "f38e0acead50e3ceff2f26b9b276a0715885740635ff7d4642c601d0550d6d90",
+    "installations": 2
   },
   {
     "accountAddress": "0x0b91176d2b54393773c79a379746ddafda4fad68",
     "walletKey": "0xe6759d65b07ede432598cf3713c034be4ed7579e2a53db38d3fbbb0a819bdff1",
     "dbEncryptionKey": "611bdf750337403ea83645a8b483e4114e3b05572d50e9d08c8ea613dddfde49",
-    "inboxId": "e6362898bec2a57cc06fa492ede22001d40ff1e4677974cca6d1db6b3639b63b"
+    "inboxId": "e6362898bec2a57cc06fa492ede22001d40ff1e4677974cca6d1db6b3639b63b",
+    "installations": 2
   },
   {
     "accountAddress": "0x3d207fc09271b00a64af402a638670176a112009",
     "walletKey": "0x9de894e1a9ab4c9213c757476dd5ec6dc01f5fbafbba89947384920e94b707be",
     "dbEncryptionKey": "a5a4140db7f9e4b82500b2a85d7152a3b8ca29846d7b06ecf45ccaea9b8b38f2",
-    "inboxId": "af9a5429787bafe1027a145edd8ab2bb056ccb09a1ec49c132b32c91c5a6253d"
+    "inboxId": "af9a5429787bafe1027a145edd8ab2bb056ccb09a1ec49c132b32c91c5a6253d",
+    "installations": 2
   },
   {
     "accountAddress": "0x945614edd15ab4f9571de8eb442dd35e6d6b3d91",
     "walletKey": "0x22716d0fcdb36cfda98ab81f308b6605ab4f8956b638ae4d77f0da275467bdb0",
     "dbEncryptionKey": "20ed990fc188e66861b770fbb66a75bb59e060511a3bd12bba5fa7e69e1c0615",
-    "inboxId": "4bfc4484acc83d8bc8b4828c65f14fafe08a23c35e289a8f11f0ca9d09d3e51b"
+    "inboxId": "4bfc4484acc83d8bc8b4828c65f14fafe08a23c35e289a8f11f0ca9d09d3e51b",
+    "installations": 2
   },
   {
     "accountAddress": "0x7afa73678a2d487cab1754818f682bbf666f31ae",
     "walletKey": "0x898838ac712ead53939f700735dd1959450246b2cc9f5c0ca60a82b5929e1941",
     "dbEncryptionKey": "ac5b1b52935b53ef12bb739eb9158c3ebaaf49825fdbadb79bf9ab9f1279335d",
-    "inboxId": "eb42af331bc5bf5040f8c88f4c8eb5d15ce8ac2dfb872572824eda1e91ed0f24"
+    "inboxId": "eb42af331bc5bf5040f8c88f4c8eb5d15ce8ac2dfb872572824eda1e91ed0f24",
+    "installations": 2
   },
   {
     "accountAddress": "0x21f5913e7dd94abff5e67d8aa30b790412bee8e2",
     "walletKey": "0x736e475a844b89eb5829e8f2da49b55c835f98ad33d927587945babba83db9ec",
     "dbEncryptionKey": "f775a6569967e7f1c39afb4d05abcc3dd2e57fcdcd97a55644dc251fc34722a1",
-    "inboxId": "010778e7a13a7691a52758c005cd02bd51bb06303d8b6310b870c3681777d019"
+    "inboxId": "010778e7a13a7691a52758c005cd02bd51bb06303d8b6310b870c3681777d019",
+    "installations": 2
   },
   {
     "accountAddress": "0x075e7114339aca3803a3ea94483727e05b7db7d8",
     "walletKey": "0xdb7a214d1bcc9bae50aecbea62cd2ff631ec5558ed5853499afc8ad9cd756735",
     "dbEncryptionKey": "eaec788b138964d6d307d781f2048226517edcb377fe480cb1603b0e987dee6a",
-    "inboxId": "491d91ee9c72a6bf0b6d5651a65e95448a6a2216c1b15ad640cbe0f48bc59719"
+    "inboxId": "491d91ee9c72a6bf0b6d5651a65e95448a6a2216c1b15ad640cbe0f48bc59719",
+    "installations": 2
   },
   {
     "accountAddress": "0xeab866ab13a0e5699d1979538d504cda286d4e44",
     "walletKey": "0xc1653194466c96f5f7e1e30959217c468b7b8012a2e3ba105d39c9eba7879e9f",
     "dbEncryptionKey": "6d27025edb9f937432676b6988cc0aeb24b8af26438e515d37abed8c958f9869",
-    "inboxId": "e82c0b835ff1772eb264026139d41246c135c6f72c92432fb6c67a4ac13b6eac"
+    "inboxId": "e82c0b835ff1772eb264026139d41246c135c6f72c92432fb6c67a4ac13b6eac",
+    "installations": 2
   },
   {
     "accountAddress": "0xd849bba102200ed4b326a06c6b7965f88849bdb1",
     "walletKey": "0x96ce9c7a5a5b874af0606d822a0ce479462a536091c3887bc99f82af88e99049",
     "dbEncryptionKey": "64db5652ba5b2263936be8a03350a73ae9123ce8521b1389ca18f16ef330d5ba",
-    "inboxId": "f7de7a220e1596fbb70b89a8a808046e95950d576e824d546ecdd394b07deffb"
+    "inboxId": "f7de7a220e1596fbb70b89a8a808046e95950d576e824d546ecdd394b07deffb",
+    "installations": 2
   },
   {
     "accountAddress": "0x468c5fd1e39ded22f92d76bf3b42e614461528d2",
     "walletKey": "0xd6eecd45b9f4372781f92a9faebb4f35efd8615daea8f946bdec36933822084a",
     "dbEncryptionKey": "fe7fb4037dc7472bb3ec782d7bb5286314feb6d3bfe1c65d06cf571b07619728",
-    "inboxId": "7010e2561452ad90928c146ad1235e2d8100f1ea7a0ed35a4a5cd815a8887870"
+    "inboxId": "7010e2561452ad90928c146ad1235e2d8100f1ea7a0ed35a4a5cd815a8887870",
+    "installations": 2
   },
   {
     "accountAddress": "0xaa3d58c26ccd8de52221f325b78eb2224e79114b",
     "walletKey": "0x2614c93f723fba79a65b5450aaaebfdb7fb5b43e1305170d1d48600e28207b73",
     "dbEncryptionKey": "3ce3fb26e088e1f3b8a1d08ed6fb2786afc895aff9f174b988b1374523f0cb4e",
-    "inboxId": "4dc054819c3c900b57e1a7b209778920b46a1dfa27bc0f51f697908feac1e8e1"
+    "inboxId": "4dc054819c3c900b57e1a7b209778920b46a1dfa27bc0f51f697908feac1e8e1",
+    "installations": 2
   },
   {
     "accountAddress": "0x61d6f2cf19cdb129fa698793fd24e213fe0b45f8",
     "walletKey": "0x95035226a634668a1efa89bb58a359ed244cf2466e1611ae16b1a3a4c732c599",
     "dbEncryptionKey": "0ab48e80ef7568bbd318e6a42ba4a0f3d3b747fd36b4bdf192b1e24b710aeb4e",
-    "inboxId": "6fdf53ddfe1842983bb391cedf67c49a3f275863826794ee924c8989a51214dc"
+    "inboxId": "6fdf53ddfe1842983bb391cedf67c49a3f275863826794ee924c8989a51214dc",
+    "installations": 2
   },
   {
     "accountAddress": "0x54314f55f4f26297f028db46e44127c2b578ecbf",
     "walletKey": "0x0a6a73beac5037d2f1265f609b2cc8326749da1d8446799802d8462e02224707",
     "dbEncryptionKey": "f50112b492aa2990ce18bbb765399636adf80a65f6a1def4eb26eb98c90a2b19",
-    "inboxId": "3f668580fd74c1c9a5597b61e05ba41c4808f28c37ccb5d83cd001f52c21d889"
+    "inboxId": "3f668580fd74c1c9a5597b61e05ba41c4808f28c37ccb5d83cd001f52c21d889",
+    "installations": 2
   },
   {
     "accountAddress": "0x31e11b7c6bd21e4bf13b135ac9062790ad0480f5",
     "walletKey": "0xee5f2a46190ab6e4f80ceb501b88723ef55a6c9ff2120597a05d287d6fc26a7b",
     "dbEncryptionKey": "3b45ae0e0fa7b8172fbe47bca8ea77a48fc4e0c120927da36de69a7c10e381e6",
-    "inboxId": "8a8695bed8817cace8c69d800e6d04a07384f8563099926a441c2daae0d61c7d"
+    "inboxId": "8a8695bed8817cace8c69d800e6d04a07384f8563099926a441c2daae0d61c7d",
+    "installations": 2
   },
   {
     "accountAddress": "0x3e7ac220d3e253e8b52c723310e74694e003838b",
     "walletKey": "0x31c0bb08b5b34c44fa56c747a559599509e769776c44abf13109d34699fe6ed5",
     "dbEncryptionKey": "b78d95f6d825d8983c5744bf418fa7f2f33a4ea450294d36464641adac6b1425",
-    "inboxId": "10e4510ecc3fea1120d64361b2545ed473785558286f70664d1c63769af0c59b"
+    "inboxId": "10e4510ecc3fea1120d64361b2545ed473785558286f70664d1c63769af0c59b",
+    "installations": 2
   },
   {
     "accountAddress": "0xb783876ec0dd726cc298bb19dbf330fc64767b05",
     "walletKey": "0xe6cc09e09a090763a689c7d812d021e90f4e8e4ba72864bf7f84084bad53125e",
     "dbEncryptionKey": "b0031a1b405d0b3b54100a5804a5fa493801028dd205cf9daa9af3560e1778fe",
-    "inboxId": "6c8fe6538f53fdf2790b8d7d18102b5c912e7d0fd25064ff78b1f1222f095af5"
+    "inboxId": "6c8fe6538f53fdf2790b8d7d18102b5c912e7d0fd25064ff78b1f1222f095af5",
+    "installations": 2
   },
   {
     "accountAddress": "0x24a36f0ca0a75aa58f9411e936930ac9f727cd55",
     "walletKey": "0xeca5ae882a67295900a34c4072eb6dde5b6aca96d0548ff0316d34f2c3c524df",
     "dbEncryptionKey": "4d8e94174c4ec9ccc05528b0073ab05ba1f97f7cc25bf13078451e23edaaa173",
-    "inboxId": "070c9ebe0951cbd4fd4af07ef54b723b8216063a189c22ffc44adffb041aebf5"
+    "inboxId": "070c9ebe0951cbd4fd4af07ef54b723b8216063a189c22ffc44adffb041aebf5",
+    "installations": 2
   },
   {
     "accountAddress": "0x529ec2bce699e4575e70bf2f2865960411fe6184",
     "walletKey": "0x01ba6be1dd7e6f2db250dde5b02c1cbb6faef2b4a080297d096888791b8018d4",
     "dbEncryptionKey": "1db2099b8e22fb58ceccdc859cc23b96c0c61138f267a257e7b2d04e09554683",
-    "inboxId": "9f7f9cfe15c03b174dbf9a1399f296874f776212bb11df87d679566e604b502a"
+    "inboxId": "9f7f9cfe15c03b174dbf9a1399f296874f776212bb11df87d679566e604b502a",
+    "installations": 2
   },
   {
     "accountAddress": "0x2ace7450edd189d3394e46ebafcee034abdc8bc6",
     "walletKey": "0x78b302d8ebed1e52b928a405e7302129f0991b5fb83336d44b23e89b9ed43b9e",
     "dbEncryptionKey": "b0e0790d342004cc9c1977f9a4ba6fd1a18b6932c6acc5d2be1fb4083fa8adb9",
-    "inboxId": "ee85abc65e32ba2f69c8745877f00e9f7948c98fcecaa017a001f3b2935c0142"
+    "inboxId": "ee85abc65e32ba2f69c8745877f00e9f7948c98fcecaa017a001f3b2935c0142",
+    "installations": 2
   },
   {
     "accountAddress": "0x6584435019853593475bc01ecc28cf1822cd1176",
     "walletKey": "0xa7b46e24d433426471e065c5f305e995f5a954bf9cffe0d1c9c6cddd5fa93b67",
     "dbEncryptionKey": "1fc13b62e6327e1e52ca226a4fe154489a23ebea3a3c050045e49ce8b247a05f",
-    "inboxId": "a27fd6574e63d38f343e9ad87ee6035542fb75fd8a7c55f3827fc3dc3ba6e6bb"
+    "inboxId": "a27fd6574e63d38f343e9ad87ee6035542fb75fd8a7c55f3827fc3dc3ba6e6bb",
+    "installations": 2
   },
   {
     "accountAddress": "0x7d4ef254df029fbd6acc3560a22a3f7b8576793c",

--- a/helpers/inboxes.json
+++ b/helpers/inboxes.json
@@ -164,2562 +164,2989 @@
     "accountAddress": "0x7d4ef254df029fbd6acc3560a22a3f7b8576793c",
     "walletKey": "0x29cb5db45abb2fb98b8c848b37403b97b310d417fed84d5385706022fd74af43",
     "dbEncryptionKey": "806885ff44226a303b1562d20696b68a0402d7243e5e67c0e3ab54ef377f32ee",
-    "inboxId": "56c4c8f75bc6923b6c9961619ae01707633d5d9913a843bd9be9ceff0937f8f1"
+    "inboxId": "56c4c8f75bc6923b6c9961619ae01707633d5d9913a843bd9be9ceff0937f8f1",
+    "installations": 2
   },
   {
     "accountAddress": "0xac061b9596b90fa6a0f755edbbedb970d77ecd0d",
     "walletKey": "0xff13c537334a75510eca4d94475b5e014d5a102c1687bdabd7f0725bee1c4b8d",
     "dbEncryptionKey": "ae60929a3d6ad4535cfac08b241b843aa2934397b792c5e1aed9fee0d0afaea6",
-    "inboxId": "4989afdbc6616f0180dd799957b87f9a421e0c237968f20aa826199d6fa4d04a"
+    "inboxId": "4989afdbc6616f0180dd799957b87f9a421e0c237968f20aa826199d6fa4d04a",
+    "installations": 2
   },
   {
     "accountAddress": "0x1646a948fb105c4e28d3fba47b50f3d5c030b11b",
     "walletKey": "0x08601be244d44de2f5f4deb02d8335fccc628556215d50214834c2d6503da6c4",
     "dbEncryptionKey": "464fff7aabd416d0c92f01ac0bccfd89cfd4aacda7a2595c30138ac54bdf15c1",
-    "inboxId": "d3b8a4c4f9cef31750847b47b0fcfb608b997ebe98a50f8674d1a21f1080cfff"
+    "inboxId": "d3b8a4c4f9cef31750847b47b0fcfb608b997ebe98a50f8674d1a21f1080cfff",
+    "installations": 2
   },
   {
     "accountAddress": "0x0624d19aced9fd26ef898fe0fcc934f48969f386",
     "walletKey": "0xfb9dae86a76c80f6da662e80a0d478f2a26f4cc4c7390c8eba51228c165d1b26",
     "dbEncryptionKey": "a97ac5bc376d506315972e6aca6c1248e79361ef5f6d426f72eaaf3ba8f69e78",
-    "inboxId": "76f4c1084e22858563f616d264ab33e77c8e80fe2efb1602ef574d67a4aad48e"
+    "inboxId": "76f4c1084e22858563f616d264ab33e77c8e80fe2efb1602ef574d67a4aad48e",
+    "installations": 2
   },
   {
     "accountAddress": "0xc7450d70d4c9eb278b44a8eabb729bcf4d19abeb",
     "walletKey": "0x2e7d354a7480e54ebf3889eb09e13214b5cb9987fa211ee05fc2ad610e5e47c1",
     "dbEncryptionKey": "0d839f247ce811ee8fa159244bf86d123fc240174a086977ca393398c71818f5",
-    "inboxId": "df3b922d61d452b5db83ec856ec0344595a5fc1149eaffc3a74738c95a1c1820"
+    "inboxId": "df3b922d61d452b5db83ec856ec0344595a5fc1149eaffc3a74738c95a1c1820",
+    "installations": 2
   },
   {
     "accountAddress": "0xb96d1eece18e4730824cfb9cf8f08d5e4be36357",
     "walletKey": "0x414c55ca4391cc583fb433c90bdd3fe60f36a556b6dfbddcf5b07749346f1eb2",
     "dbEncryptionKey": "3d8bd6c27bf55cc87b3caf8b8f97aaa9484c1c4df47ff846b1ff171fe543d436",
-    "inboxId": "423ec03ad5e82551bfcdd8ae4970ce4918fe5509cd9bd1693b305de5d3ad748a"
+    "inboxId": "423ec03ad5e82551bfcdd8ae4970ce4918fe5509cd9bd1693b305de5d3ad748a",
+    "installations": 2
   },
   {
     "accountAddress": "0xd5a6afd03ce61da320f20049ac4e1d232a6bf157",
     "walletKey": "0x52ecc7317bea0e5d449023ec20ce15bbcdd7f070c8c6f925d963c423e9193c89",
     "dbEncryptionKey": "49a991097b36826bea8bdd3972b1480abe9cab241bfce0ea6bb33cbf4c4a4292",
-    "inboxId": "35cef6702069253174a28fd0165b6aad1d3e6aff25755aad57d79c177c31aa55"
+    "inboxId": "35cef6702069253174a28fd0165b6aad1d3e6aff25755aad57d79c177c31aa55",
+    "installations": 2
   },
   {
     "accountAddress": "0x0cec35752dffdf1b632f10496eadc7271f7481ad",
     "walletKey": "0xcbc88fade5a19b98f976736b69f7062fbed9820ab8211d5a49e1df05bb46bf40",
     "dbEncryptionKey": "2d66735c918a454d46867ff1dc81e3a4b22dbab84b766a2e849bbc157c5ded97",
-    "inboxId": "f1268e8192dfa36ccc514479d29fe871103d40433461b38090abbe51ba68ff58"
+    "inboxId": "f1268e8192dfa36ccc514479d29fe871103d40433461b38090abbe51ba68ff58",
+    "installations": 2
   },
   {
     "accountAddress": "0xcbf25748373fc87bf751c2b17836670f2fd1cb2e",
     "walletKey": "0x9382c22e07f3fd4534fefa378106d7dd4cb7fa9911709371f9a64bd8278fe506",
     "dbEncryptionKey": "26283a9ce762c9278a0102cf1f19eabbcee3417ed99d3777a1e537d51f82144f",
-    "inboxId": "1ada818975b129cc4cef6de99733cc72c3bd5e628722b1bfe15a54dd7f7a6fc3"
+    "inboxId": "1ada818975b129cc4cef6de99733cc72c3bd5e628722b1bfe15a54dd7f7a6fc3",
+    "installations": 2
   },
   {
     "accountAddress": "0xddfffb1b95d5584adb8ef0d85374006fe9a86e2a",
     "walletKey": "0x4db8edbcf2d21aee2e2021b10d821422408494f907da99849cd211b25fd3a29a",
     "dbEncryptionKey": "63e9a23e49bb47375a95fb6c913cb33458d1c633c0fcf4cbb7a44283854a7b4d",
-    "inboxId": "044710d3d69f2070b8d3acfcda61418c2d4464d086c2830e9dc00fda79f7404a"
+    "inboxId": "044710d3d69f2070b8d3acfcda61418c2d4464d086c2830e9dc00fda79f7404a",
+    "installations": 2
   },
   {
     "accountAddress": "0x066210fbfcf02b3e1062276fb37a1cf7b203506f",
     "walletKey": "0x27f6b72f55c07d5d6a48698b0cae755f44b7902bea15e2e5472878fb0e6babf8",
     "dbEncryptionKey": "a08c40876b9139152133fe53c438ca8f0c651f4ade95537077a1d172f52d3d63",
-    "inboxId": "34dcfa36c1daff32b35fbdbf5f10e6e037c06dd7557b84c8ff16c5d36dfed29c"
+    "inboxId": "34dcfa36c1daff32b35fbdbf5f10e6e037c06dd7557b84c8ff16c5d36dfed29c",
+    "installations": 2
   },
   {
     "accountAddress": "0x570d83745d2c15bb0c29c3dbb7233e8f7bc26485",
     "walletKey": "0x1f7cb96c987333575d9d1510947a3b2c299c5d5a196f9326f889c101559a8b17",
     "dbEncryptionKey": "7294bb3cefb7106e7b1b18435fe48cf2fa3ca457515dfdcf30d799974f547e4c",
-    "inboxId": "45b0c6741d199cad56e89da04b739b0c959d4aa088918897697d929a39a1bc6e"
+    "inboxId": "45b0c6741d199cad56e89da04b739b0c959d4aa088918897697d929a39a1bc6e",
+    "installations": 2
   },
   {
     "accountAddress": "0x9c17372fbd6418d99b7b824295a8b297a8670ab5",
     "walletKey": "0x1df9d19f6ac1dcc227f380e6d49205c4089fc7cbc905364122c0c58e183b033c",
     "dbEncryptionKey": "eece4d4d7f3e475df73376f87756ed555c00b4630060aeac002ed64c8964952a",
-    "inboxId": "abc0e09728011ea11b3aaf9c525b7835b0a1b2200fb7e1faf8abaf8b57e00ee2"
+    "inboxId": "abc0e09728011ea11b3aaf9c525b7835b0a1b2200fb7e1faf8abaf8b57e00ee2",
+    "installations": 2
   },
   {
     "accountAddress": "0x7eedc707232ed9825fb1b3568e0a9d4971d95c89",
     "walletKey": "0x16b7eb877b448ac9f6ce0c187b7e2617f76d950060104bad668635bab5c9326e",
     "dbEncryptionKey": "76e5399f03adb89b82e210cbf3563121f2f14b90511a005a4fed55ee4039fccc",
-    "inboxId": "0318c7e6bb4feb8253c4ab5ce99e56e6d49f5175d263e7bec013e65fd545f357"
+    "inboxId": "0318c7e6bb4feb8253c4ab5ce99e56e6d49f5175d263e7bec013e65fd545f357",
+    "installations": 2
   },
   {
     "accountAddress": "0xf5779dc2f361ac012e57838d24f024c4ec5bb486",
     "walletKey": "0x5689c9aa8a98715ec8c49da2f7cb77a359ac6356e4db374c7aa4758dc07e1f8d",
     "dbEncryptionKey": "9d14df0372ed1e2a0d1a61860b114a08177794b1d6fa5ab9662ad9a09d4d1abc",
-    "inboxId": "54dc86f71a853c614c6760f623a220b5d79fbe55bf019f9aaa1f0dbc9585f263"
+    "inboxId": "54dc86f71a853c614c6760f623a220b5d79fbe55bf019f9aaa1f0dbc9585f263",
+    "installations": 2
   },
   {
     "accountAddress": "0xfd90fbc472d31d8ab7fc3fe4ddc443df80fa5442",
     "walletKey": "0xd6366ff59d31c290a602f09ec6c83d9e7681a66dd49d5695ac1ead4a4c9b183d",
     "dbEncryptionKey": "5d258bba4162cf1480c2ae677506657920e25057cf885002a0ca9ff1878acfae",
-    "inboxId": "042573b863a62e46f0a2f6f37271efb5502af0bb6a45304819d6e7ef3cc7f2a4"
+    "inboxId": "042573b863a62e46f0a2f6f37271efb5502af0bb6a45304819d6e7ef3cc7f2a4",
+    "installations": 2
   },
   {
     "accountAddress": "0x4770ab7f2dc0dc7fefac7d0bf98e039397115a67",
     "walletKey": "0xf58aed5e583f3306299a01a4e71f6dbc719960469a4af90d061c0d2ecf95f761",
     "dbEncryptionKey": "f39f6fb2233e55ec41da00cf43ef80bfe0b228c53c2b86f7fcec1b7d94ef3c51",
-    "inboxId": "56442c6b564ce9bcad35c4f86b5bbdf32e08a38ebe86b7a3b19715162d4a6f02"
+    "inboxId": "56442c6b564ce9bcad35c4f86b5bbdf32e08a38ebe86b7a3b19715162d4a6f02",
+    "installations": 2
   },
   {
     "accountAddress": "0x8fc3ccdc6716adb3b708823bf4e08b65a19bfba8",
     "walletKey": "0xffdb022d4a0e6128f1666b29cd32388e2d079dddab3fe114f59d4fb820db2458",
     "dbEncryptionKey": "8d75fd81812e01b7e52853f3d197923a0ac7e8173eefb76eeecb4e19cdb0cd0b",
-    "inboxId": "6f1ea2b40e99585f8ff757c4309b42e67c7246ad80b9670767a729d1c7dbbf5f"
+    "inboxId": "6f1ea2b40e99585f8ff757c4309b42e67c7246ad80b9670767a729d1c7dbbf5f",
+    "installations": 2
   },
   {
     "accountAddress": "0xa46a1cd111f43a9f6ff9bba446fe1c503027a363",
     "walletKey": "0x45942dfca156a99051a555e0d567d03d416634a2fcef5ffbac99990c5c9fea68",
     "dbEncryptionKey": "fab12861d13c6dfb98b983f9544fb98d4df301cc8c94110a456a5ff48580c510",
-    "inboxId": "63d10caeb4349dd77147a07cf6b677fec4884220cda7cfb13ea7190ef13b567b"
+    "inboxId": "63d10caeb4349dd77147a07cf6b677fec4884220cda7cfb13ea7190ef13b567b",
+    "installations": 2
   },
   {
     "accountAddress": "0x6378273de8b987c37a1658bfe371fe68997c6b68",
     "walletKey": "0xd601c19f885294953462cd8cdd357b36df354d178dbf7cedbc73ca7a22d664a9",
     "dbEncryptionKey": "0d35decafcc41eb0c238ba60a8a550b6683575761d00730ae92e5a2950385510",
-    "inboxId": "7f18d9324a0d70a1bfa5c37a512c6f1fbb7942344bbc2ce46a37dcd82abfcee7"
+    "inboxId": "7f18d9324a0d70a1bfa5c37a512c6f1fbb7942344bbc2ce46a37dcd82abfcee7",
+    "installations": 2
   },
   {
     "accountAddress": "0xa19d8be9fc097b6631c45add4ce21cadb29e06b5",
     "walletKey": "0xe807ec93743658dca3280d2baf693a323e1292f243a05c1bb3d4c0d36943f857",
     "dbEncryptionKey": "b9fbd5b5fa6cc14fea807d72b5257aeb1091f8efcd97ba14538aaf15d84fcabe",
-    "inboxId": "e7aba3801a1dcb1c3d795b0dcd225934cb9d21f86c1efd2cc7854768e7c9a6ff"
+    "inboxId": "e7aba3801a1dcb1c3d795b0dcd225934cb9d21f86c1efd2cc7854768e7c9a6ff",
+    "installations": 2
   },
   {
     "accountAddress": "0x10e59324110733144460384531343c223ba5d1f0",
     "walletKey": "0x89fb25f0854a344e61c43de6ec14ecc8d814ad23363c005bfcea752e40b2975a",
     "dbEncryptionKey": "8ddf4d3b117970c78a44cce64f7f1bfa0be47550e99d795ba7dba3b943849fa4",
-    "inboxId": "eaf6d2effa8210cc12c45c487bd0949f205cb3d9e908f93ff0ab46942d459965"
+    "inboxId": "eaf6d2effa8210cc12c45c487bd0949f205cb3d9e908f93ff0ab46942d459965",
+    "installations": 2
   },
   {
     "accountAddress": "0xde469ba8ea900cbd676906866788fefe885dcf40",
     "walletKey": "0x4d65baaebd7fc5397d1c6c30fa68b187bcb583b00502f52a70b14bfb23030c1a",
     "dbEncryptionKey": "dddd98b2720aaf6a603e67d21e8b12cfd2030ea0613342b2f09d00b131a399bc",
-    "inboxId": "920b18f17bbbc9bd67659a20dc081fffb78ead621cc68ae71063830f28b69581"
+    "inboxId": "920b18f17bbbc9bd67659a20dc081fffb78ead621cc68ae71063830f28b69581",
+    "installations": 2
   },
   {
     "accountAddress": "0x2a406767573933bdc0659b2c305de62c590ae365",
     "walletKey": "0x05f3e44ccff38db65e131a1f08fa5016a8d2307570939322129aa5aedfd0da68",
     "dbEncryptionKey": "4a6b8e1e9f1bf77b26089c85a8dcded4b50e3279385fb59aa15f8708b5394a85",
-    "inboxId": "36fe3093a33f29c13249e61707a297f7bd7f9256ef51899f3b58c3871e94d41a"
+    "inboxId": "36fe3093a33f29c13249e61707a297f7bd7f9256ef51899f3b58c3871e94d41a",
+    "installations": 2
   },
   {
     "accountAddress": "0x9c82901826dd7ef308d0faeddb1e34d5245c75b9",
     "walletKey": "0x582a1bd776e08b5cae0bf450508243a884b83330778897ff23e1471692f8c9c8",
     "dbEncryptionKey": "1216e194f5c74bee63ca11fd5582bb05135975b33816df19c1de3307eb977fdc",
-    "inboxId": "0dc079a0209f008e0bc83f6491fd8c767ff7e28ec968e21f022fe756ac98088e"
+    "inboxId": "0dc079a0209f008e0bc83f6491fd8c767ff7e28ec968e21f022fe756ac98088e",
+    "installations": 2
   },
   {
     "accountAddress": "0xc0dcdc0bbcf5da79dbf92e104a6e6a5787f079c1",
     "walletKey": "0x259b18a6cc6a81bd2b643793c7d3d902b7b40dca352e9de92a41f2484d56976e",
     "dbEncryptionKey": "f53a78e13c5f67490ad6dad9d84e2cdb65ddc277dac0c7b9dd1cadadfd0ec2e0",
-    "inboxId": "31bbd284e2a64fe717c5ecc788a24f091a60e7e06d3759fe550f43f200157bd8"
+    "inboxId": "31bbd284e2a64fe717c5ecc788a24f091a60e7e06d3759fe550f43f200157bd8",
+    "installations": 2
   },
   {
     "accountAddress": "0x9b4b05fdde5b06074582e76a3a694469c9f476bd",
     "walletKey": "0x536dcf1e8c4874e04f9e1b470c6652673e4157b095f54d4168bf2fd117a5f5a5",
     "dbEncryptionKey": "70fd9ab70580d0e306fac63a336273bbc423cdc05c4efe2ee20cc410c0379beb",
-    "inboxId": "b634b6f6b1b759d3e53e9c302cbb161d43f421da786631277196a662e91a212b"
+    "inboxId": "b634b6f6b1b759d3e53e9c302cbb161d43f421da786631277196a662e91a212b",
+    "installations": 2
   },
   {
     "accountAddress": "0x25c8cb3e1f7cb509a655cb8dfc942358d50fbf2c",
     "walletKey": "0x5866869d117b67c2ee0c53e5587dc56ea9dcd61751438768d4411626f6a312bb",
     "dbEncryptionKey": "bba9c0a8bdff12c607be3c1f60dcd33b17ed64954e5279e63ec71d540e7cbf52",
-    "inboxId": "47f85b17d00ad468e480e098aa17f690f6425b8706758e8ef8f7ea6fd8038d89"
+    "inboxId": "47f85b17d00ad468e480e098aa17f690f6425b8706758e8ef8f7ea6fd8038d89",
+    "installations": 2
   },
   {
     "accountAddress": "0x278dff4b4f9322bf2fb4ecdf44210dbc5dce0985",
     "walletKey": "0xb5ddc20ae5aeff3fc1583f1ed183b7c54c2b7e5dc2e4ff7eed948b546aff180d",
     "dbEncryptionKey": "f5b675227b4e8cda2a5cfe760b424900b2f9643a03ae800f8c4b992207b4d581",
-    "inboxId": "52adf36ac4b3415eb73fa19cf329349d250d00d3f5e641d1d0692b64cc3e52e2"
+    "inboxId": "52adf36ac4b3415eb73fa19cf329349d250d00d3f5e641d1d0692b64cc3e52e2",
+    "installations": 2
   },
   {
     "accountAddress": "0x6f4c204dcf60123d4d58a57589e863eef1d87e63",
     "walletKey": "0x73866b329499389ae72977140db5ece1b6d45065d0e76609d94b24ce33d3a354",
     "dbEncryptionKey": "fd26007d6d691de8f5d6ca73148cfb6a56d1fbed9bf52462749a7e37955042a3",
-    "inboxId": "472fe702773d253ad310c7a62a7d997fbaaecc6058dac16a9161c4cea89ad600"
+    "inboxId": "472fe702773d253ad310c7a62a7d997fbaaecc6058dac16a9161c4cea89ad600",
+    "installations": 2
   },
   {
     "accountAddress": "0x757c376fa6b1144eaa685d7811bfbefc74cedee0",
     "walletKey": "0x5dc2af850f76585af2aeabc9f6fe6550913be7e14b3830ec1ba1e52765e72c23",
     "dbEncryptionKey": "5806eb2e8bccd040085eee6a6f02183c0720de697cb346708db65921e15998f7",
-    "inboxId": "5b2a4b56798d2f6a87dfffbf0a4374f0799e0fd663e2ae2e075785d6caa7959a"
+    "inboxId": "5b2a4b56798d2f6a87dfffbf0a4374f0799e0fd663e2ae2e075785d6caa7959a",
+    "installations": 2
   },
   {
     "accountAddress": "0xecf098c5db0b7c1db4c405717118a5b04c0b6c65",
     "walletKey": "0xbc10e6288c3364736e2092cca9070134bcaa2ff1287b105169baf43856b5aff8",
     "dbEncryptionKey": "7a437da551b1b072402fdd72cf09006b3e3206dd17f6b91c0fe5dd3834e0897e",
-    "inboxId": "f89e6c894d48efc9aab7e20c7e8380365ae3572abed9d41195596e3439574e24"
+    "inboxId": "f89e6c894d48efc9aab7e20c7e8380365ae3572abed9d41195596e3439574e24",
+    "installations": 2
   },
   {
     "accountAddress": "0x93c290038a3d8d37012886ff918eff28e028a064",
     "walletKey": "0xcfd4480154646f8979a11560693827ed398ab07a5046c1970b4397a74fba421e",
     "dbEncryptionKey": "773bb8d66929459f1da8d7485f1e7888b8a7b96d5ac75ae96a126103325a4b45",
-    "inboxId": "2d725d3eb4a096a98ada93a86dceb136efe05786f31bbf11a50048aab6db4bf5"
+    "inboxId": "2d725d3eb4a096a98ada93a86dceb136efe05786f31bbf11a50048aab6db4bf5",
+    "installations": 2
   },
   {
     "accountAddress": "0xa39ebc2011238de51aaca9e35a94c67b08bd747f",
     "walletKey": "0xa28732411223ce3702ca4c1d247d66bbe5154c0dc8cc5a9f3dab65ff61cffd74",
     "dbEncryptionKey": "a7f3b113d0336c37da81ce4d84b303c904a800051b955db16a1decd0f9b183d3",
-    "inboxId": "0f6c27b455feb31b28fc968f792cb1eaac318d7cbca36c07d8f7b969af27d440"
+    "inboxId": "0f6c27b455feb31b28fc968f792cb1eaac318d7cbca36c07d8f7b969af27d440",
+    "installations": 2
   },
   {
     "accountAddress": "0xc6eeac83447b988deaab12c0240dcc6b0d496394",
     "walletKey": "0xaf66749118d4311c3b5fff41e3408d863d300dc3a5c6111a1ade0e0d362e1f2e",
     "dbEncryptionKey": "e4c90870676e084bac78ae49e326cbddc51fd3dada59c3008849d2bfec6c93b7",
-    "inboxId": "3db0f68173fa56df834a9c46e8ade10002112eded41e77993adb37c6a8f1294a"
+    "inboxId": "3db0f68173fa56df834a9c46e8ade10002112eded41e77993adb37c6a8f1294a",
+    "installations": 2
   },
   {
     "accountAddress": "0xcec164bae7b4b7860d11d9e0e9f4ff54cf4945af",
     "walletKey": "0xcd862c20ddd75144e72770577bc57b73e806280ffd3c78c5df63e339d77f5fc8",
     "dbEncryptionKey": "a60b255a08c654071dcbd11c9e12580f1aa184f45e9804805a06e5ed0dab528b",
-    "inboxId": "02b880db6f45acf1d13fb9e875b106563943d6c8e4483c716870a9e66068a063"
+    "inboxId": "02b880db6f45acf1d13fb9e875b106563943d6c8e4483c716870a9e66068a063",
+    "installations": 2
   },
   {
     "accountAddress": "0x4a87911ebf52aa957e4323a77eca4e49fca12bfd",
     "walletKey": "0x2ee2d34643da96c5ff1d42f1e5b4349a655ddf965130d2cc98ee9e90feecb5b6",
     "dbEncryptionKey": "8acc7c7a954a6ebfc3f349c3da78060942a6cae847d5e565e49e635083fbaff6",
-    "inboxId": "458d0a4dce011051d69144ffcbfeb96a57c05a9b7a22ff2692cc456a3cd3bfbe"
+    "inboxId": "458d0a4dce011051d69144ffcbfeb96a57c05a9b7a22ff2692cc456a3cd3bfbe",
+    "installations": 2
   },
   {
     "accountAddress": "0xe35c64e52c5b634e404343eca18f2217431ec029",
     "walletKey": "0x802ddea7ff6fe41b8d503e8a6514388d82231cf1111e3b56645c654b72a4dcca",
     "dbEncryptionKey": "2e74fba8e761d45f63e2da8ab0935cb1425f1a8e8b693724587583839cd5273d",
-    "inboxId": "f4cc4cfa4f15316384839d0954be98f23ea14036c68ee5567a138d7e21e8d9fa"
+    "inboxId": "f4cc4cfa4f15316384839d0954be98f23ea14036c68ee5567a138d7e21e8d9fa",
+    "installations": 2
   },
   {
     "accountAddress": "0x99dc817641d43a6a6f5e96817a3791a282cdd4a0",
     "walletKey": "0xec0a944f7b0985a2f0631475fadb5d7155459acc5f312e33212ae0701a6330b7",
     "dbEncryptionKey": "84f794a4ba6147fe477445a3789506a625eb511c343977189408719ff557f735",
-    "inboxId": "cc25b9220a8518480286dba26d4ccc4e1982abfdcc4b6c0d1f060b9d40372a22"
+    "inboxId": "cc25b9220a8518480286dba26d4ccc4e1982abfdcc4b6c0d1f060b9d40372a22",
+    "installations": 2
   },
   {
     "accountAddress": "0x57a48f960dbc344fce36263335ac6612394c9386",
     "walletKey": "0x6ada965782acb6eed69428769742ada9e3367a8b1978b40c2059f29f4bb37fc3",
     "dbEncryptionKey": "207cacf479b7dd503410cd62081bd430f056f3181563d90e846a1b6d4ec7d937",
-    "inboxId": "1181accdbb3678ddc31606a78734a6dbcefd72fa9b7b1aca292fd11b98f432a7"
+    "inboxId": "1181accdbb3678ddc31606a78734a6dbcefd72fa9b7b1aca292fd11b98f432a7",
+    "installations": 2
   },
   {
     "accountAddress": "0x458298feff67b4a4d27b9c43ff385ebfbfd527f1",
     "walletKey": "0x6fd8613623ed11948a3f91be6d111915ed94def845fdb2f3d2cff88408ff7e81",
     "dbEncryptionKey": "f7d4bf0c3899f535dc7f5ffe41bf4ccfbff3df3a3b531dc7c17eda4cd270a868",
-    "inboxId": "b5ad13a80748d0bc7eeb3d366b1dff1705fec22b7c7ce99767c013fabd9d8515"
+    "inboxId": "b5ad13a80748d0bc7eeb3d366b1dff1705fec22b7c7ce99767c013fabd9d8515",
+    "installations": 2
   },
   {
     "accountAddress": "0x80c6b607338dfe6d38f78a6008f50481e4c8c30f",
     "walletKey": "0x6685f4ecd7efed86d77b8d18935b5a35cd79495d3f561155163d0c8d820cfaf9",
     "dbEncryptionKey": "158a6dc004e2594394185ddfab0bf825b588877f53fe98fb0e8033ba29184005",
-    "inboxId": "8ed0c710232b8c2b129096286e060c896dfd274c9fa1e730a464cd302a5df1a1"
+    "inboxId": "8ed0c710232b8c2b129096286e060c896dfd274c9fa1e730a464cd302a5df1a1",
+    "installations": 2
   },
   {
     "accountAddress": "0xf8196b354884b941d2d808e7ad9c7130d04430bb",
     "walletKey": "0x577e340c4c7d7cb5e2cc434abb024856463b9704d997c62eeffa6c05c150a3d7",
     "dbEncryptionKey": "18a873c9329ae9acb63bfd3a24a206b8ebcf77614c1103541b90c0f5d4b34a96",
-    "inboxId": "f64558076e375bc7f1c5585bf6627826cb56c935b8266cf20da76e34c60409d8"
+    "inboxId": "f64558076e375bc7f1c5585bf6627826cb56c935b8266cf20da76e34c60409d8",
+    "installations": 2
   },
   {
     "accountAddress": "0x35ff73c756b859ee560889f568a323bb28f71ed9",
     "walletKey": "0x89125459190c0f5d1c060ec9da9f2d4f408ccbad757ef8a5b5992bbd6c9ea0ca",
     "dbEncryptionKey": "960206c76c0bd5e5ddb99d4ee87866d8da59e381a746ce92cf185462daac70c3",
-    "inboxId": "7e2d1322674aa7a1ebe4f3838b86fb61a414e4fdab2ee47edd6331a851bb3e3f"
+    "inboxId": "7e2d1322674aa7a1ebe4f3838b86fb61a414e4fdab2ee47edd6331a851bb3e3f",
+    "installations": 2
   },
   {
     "accountAddress": "0x51d2c3483eaad788cdd383cdda9144c7d85f3f5a",
     "walletKey": "0xea652d29fa6d0ecb3f7cbda1193cd7de5b95c0ef15f0927c72b3f88009bb65b8",
     "dbEncryptionKey": "1259d873977686b1384e1cdae39b4ecd0fda14c65a47495874fc8bc5dc396800",
-    "inboxId": "5cb045c4ea57119b6c468298c1741b341ab7c7b0eceba3334f9675f73087d816"
+    "inboxId": "5cb045c4ea57119b6c468298c1741b341ab7c7b0eceba3334f9675f73087d816",
+    "installations": 2
   },
   {
     "accountAddress": "0x9ba0149e1cefe6a439b10b2c1efd0471ae44f19f",
     "walletKey": "0x2faab9a0a03461e494e329058316368c8046c27924f85194a3638f9e516b6ddf",
     "dbEncryptionKey": "9f3cb482b92b4ba8a0d001e6c53c751fc54906d6be12a58ebd4e09601500fb41",
-    "inboxId": "c00c9d103ae52bc1e124ee5448f5beeb914c7403b1693e796f13eb860f04df89"
+    "inboxId": "c00c9d103ae52bc1e124ee5448f5beeb914c7403b1693e796f13eb860f04df89",
+    "installations": 2
   },
   {
     "accountAddress": "0x070369f03f04190489a1f586303450a66d085171",
     "walletKey": "0x0135c306c05269af35155efd37a63f971a21de9f87339eb707cbaedbde409bdb",
     "dbEncryptionKey": "882e31f9703d2b4ecd36a6fea32ca1f5d7d1d215dced681d11066c693422eaa1",
-    "inboxId": "4005c03b794a2fbfb2fff31daf23d19138e1f2f781c716a6b641a5dfc5d2dc3f"
+    "inboxId": "4005c03b794a2fbfb2fff31daf23d19138e1f2f781c716a6b641a5dfc5d2dc3f",
+    "installations": 2
   },
   {
     "accountAddress": "0xe742dc42aa02bf14a910cb6ada4e81fc1487ccfb",
     "walletKey": "0xa52b821afc4c8ca0f8d429e74ce59d7010f5458d4b106a0daf8dd38527499fa1",
     "dbEncryptionKey": "80a0c97df3bef0dd3939b614da7f9c54810a6638865a109cabe83e7b4f3c4f3e",
-    "inboxId": "49533cf9b4055fad18522411563cf326c488d93e887aed5772687d8ca90c3980"
+    "inboxId": "49533cf9b4055fad18522411563cf326c488d93e887aed5772687d8ca90c3980",
+    "installations": 2
   },
   {
     "accountAddress": "0xda1638a4b3ad17c797f67bc49c46d75911e119bb",
     "walletKey": "0x63fab99960d030d2a35165b2c8ed5b0599427014a86d57ba92716d255af17531",
     "dbEncryptionKey": "4c2d8444b0ddd448254bb7abf0e98d132d65522d946276aa3ca53ac0444e4e27",
-    "inboxId": "930935c6f014fca6c0fe80f5c91149038a37cc98c43f555dcddd46b0fb410fe8"
+    "inboxId": "930935c6f014fca6c0fe80f5c91149038a37cc98c43f555dcddd46b0fb410fe8",
+    "installations": 2
   },
   {
     "accountAddress": "0x1e9f4df4835d770c237cf623ea5d16f538c2eaef",
     "walletKey": "0x5b1fe56d8aaa9af78c117211aa8832ba2cebdcf27c2296912da038d85a1d4073",
     "dbEncryptionKey": "23471cf16c0717849223b9f877253df190eed83b8ea5f5b17b043938e7d0ad9e",
-    "inboxId": "86516ed4f1ed1b26484144d6ee9554bef95cdabfe7ba41fbcecffb65f8a32eb2"
+    "inboxId": "86516ed4f1ed1b26484144d6ee9554bef95cdabfe7ba41fbcecffb65f8a32eb2",
+    "installations": 2
   },
   {
     "accountAddress": "0xb6ad785bba361e98bde472f560b6add4c3edffdc",
     "walletKey": "0x49390d9e8c6030b651ee0c2d578852543fed604649166deefad346d4036d2852",
     "dbEncryptionKey": "9210e5cbd1b93690ff9d3fc5dd485982693089c5879949f35a647c58d18e0dc4",
-    "inboxId": "48748eaa63d988e1b09ce7ccf2900c4140b17f4a07a6ce57b3bd90f054b1abb4"
+    "inboxId": "48748eaa63d988e1b09ce7ccf2900c4140b17f4a07a6ce57b3bd90f054b1abb4",
+    "installations": 2
   },
   {
     "accountAddress": "0x891c2e19be990b7270b1ff2bb32b38a8e3b7dd5c",
     "walletKey": "0x24e60451286ed896ff2824c528fd14ad240cbbb1642ebb0040c827beae703638",
     "dbEncryptionKey": "96103cbec6bb3565ff1d182f58895dcef3c4ce9cac4a77b463cb698dc22b682e",
-    "inboxId": "e4fa3f64619fa08d1ff912223289b3acc24f73a16159a1ce76bc2f30011672d6"
+    "inboxId": "e4fa3f64619fa08d1ff912223289b3acc24f73a16159a1ce76bc2f30011672d6",
+    "installations": 2
   },
   {
     "accountAddress": "0xd9db50250f4d647f17116150ae6baf7defc0fbdf",
     "walletKey": "0x510c8ce6a883b74f5413b5ebb529fc1ad1459a5f93d34c9a215587794b5e4ba2",
     "dbEncryptionKey": "2c6530364bfa2aff0dbf6f8208f5b04fe0be320769d53064694d1d3b55b57e2d",
-    "inboxId": "13b395db3685196864fdf949fc7b9a9915a102872b1830fc13b26cddb0c5274b"
+    "inboxId": "13b395db3685196864fdf949fc7b9a9915a102872b1830fc13b26cddb0c5274b",
+    "installations": 2
   },
   {
     "accountAddress": "0xcd50b4aed21e3adfa411106737e97de431e2eddf",
     "walletKey": "0x9fb73f84b3f6ac457f48ee0ea8ff1b757e00f11c60389eaf166bdcb64ce2b11f",
     "dbEncryptionKey": "0cb3fd80723858194b3767df7cb9aac300aed88cc39e0d081dc60e53af475896",
-    "inboxId": "a5402cdaea8ca241516574d4b855dbb82cfedd29e5f3ba2b997f6bee321879fe"
+    "inboxId": "a5402cdaea8ca241516574d4b855dbb82cfedd29e5f3ba2b997f6bee321879fe",
+    "installations": 2
   },
   {
     "accountAddress": "0x714130af378e7b744f479789a9b2838361237436",
     "walletKey": "0x87d299d6ba4130a2579e3eb99eb8cd5259f7453842b8d7d78e271135b3c58ff8",
     "dbEncryptionKey": "b5d153c33715ca176dd77995572a6f7d393a432d8861af2dcf4282f8a2187ec3",
-    "inboxId": "449c0564b394bf12313bda4f0527a5d500afb1d7802250bc382d346ced3f63eb"
+    "inboxId": "449c0564b394bf12313bda4f0527a5d500afb1d7802250bc382d346ced3f63eb",
+    "installations": 2
   },
   {
     "accountAddress": "0xe68e95b1c6d8b333eaec27bce67e45e9eceff9b0",
     "walletKey": "0xc2363a6733eee112980ee9739c1a2259d56e600b1788ea247fc90f2ae5b39098",
     "dbEncryptionKey": "bb6827de9cd16828a072d55b05754f85dd5932f63b938086806c6bf8200b5e85",
-    "inboxId": "cb7213baf2dc77488a597f2ad47136fe1612fb686221903d7f09f155fe1cf2f5"
+    "inboxId": "cb7213baf2dc77488a597f2ad47136fe1612fb686221903d7f09f155fe1cf2f5",
+    "installations": 2
   },
   {
     "accountAddress": "0xe8eea3d70651402f3a15e981bba25ee5a76fbf74",
     "walletKey": "0xa7b565936cf427921e2406976701240ca9f112aa3252d050aef9e5eaec5a6fda",
     "dbEncryptionKey": "5fb5beea14c91aa3def967930cae529720f4fa2b2df896adadde603c8684ec74",
-    "inboxId": "b164a6401398ac50ad9c80f1530201d4dbd2b0771ea26d697c0e43a358b79f59"
+    "inboxId": "b164a6401398ac50ad9c80f1530201d4dbd2b0771ea26d697c0e43a358b79f59",
+    "installations": 2
   },
   {
     "accountAddress": "0x5dc8fbe0d64bab50d1a97d29b069d7203fae755b",
     "walletKey": "0x4eae15c64207098934aae828c87f81922b0fcb7dcbaf97f5f89b513f3a3b9b68",
     "dbEncryptionKey": "e5e7272135da1dedfdffaeb6e51b166aebeecef7b176316f132848cd2c57caf0",
-    "inboxId": "13ccdd297ed5e9de229e298ab35b6f3b07cc6d318850bbf5e3cd162aa8c3dc57"
+    "inboxId": "13ccdd297ed5e9de229e298ab35b6f3b07cc6d318850bbf5e3cd162aa8c3dc57",
+    "installations": 2
   },
   {
     "accountAddress": "0x995309f2ecca945e10a153fa805bee71719da794",
     "walletKey": "0x739f90c465447d0b73362118d8d258326b1c39c3c4f2f5fdf32a306aa0ea7530",
     "dbEncryptionKey": "d4fe33b86b1a1f45354744c384f8466e59fe61d0746298e0cc543591d2a8fa43",
-    "inboxId": "362e88663aab240a6c5b0c9c6b91429b520065ccc0eace63ecaf63dbda7d0fd5"
+    "inboxId": "362e88663aab240a6c5b0c9c6b91429b520065ccc0eace63ecaf63dbda7d0fd5",
+    "installations": 2
   },
   {
     "accountAddress": "0xff842d5af12259c56366c18eaa3b5af7092ac519",
     "walletKey": "0xc45234a1341f8deb948985d16aa4d23badc379bb8e65401b181d4b3b29cbc124",
     "dbEncryptionKey": "fe51075973a08511f1e4b98f729e92444bf8ce9b6e32050fcb8c6c57187f0cf5",
-    "inboxId": "ad83a9c6b7dfce4d149d25e4e7a49afe3d2cdcddc39d7172ee58ef0c877d2083"
+    "inboxId": "ad83a9c6b7dfce4d149d25e4e7a49afe3d2cdcddc39d7172ee58ef0c877d2083",
+    "installations": 2
   },
   {
     "accountAddress": "0xfc98996526ecb0a3b74f0dbe410ba98264024c4c",
     "walletKey": "0x2f8d625fb23e548d9686f4f9afaf4c496aabf8e1dc7cb7573702148f7a0eda62",
     "dbEncryptionKey": "e7f9d2dd153c6de82f05ec4834c5ee5dd75fa8891be7c648b13d9066f5cec16d",
-    "inboxId": "3ced945619024e549d8f68013b52beb3025a46258d4db0366e33c6dfd988d648"
+    "inboxId": "3ced945619024e549d8f68013b52beb3025a46258d4db0366e33c6dfd988d648",
+    "installations": 2
   },
   {
     "accountAddress": "0xfe5dea04136988288869f504c9ae745bfdabc478",
     "walletKey": "0xfecfbf6a6e4ef841ec1ea265c5b06a4e5f0a79dc5d35992aa8a59d055df3721a",
     "dbEncryptionKey": "b9bafda0e0727b54e3f4d0d31ae5adebc055d30dd5f742046a3079015f7391e6",
-    "inboxId": "bdc8cbca0e1cc7e5061786b5b9ea08ba4162176bfb57f3352871858b49d9944b"
+    "inboxId": "bdc8cbca0e1cc7e5061786b5b9ea08ba4162176bfb57f3352871858b49d9944b",
+    "installations": 2
   },
   {
     "accountAddress": "0x3d0d9dcfc2cd8dd490129a5c1eb989be25a11ca5",
     "walletKey": "0x42d9e663c5022d15989a5fa4fd353ff21a6b11ffba756430016aab5db46074a7",
     "dbEncryptionKey": "4c327386c066b4717135cff2a0befdf736540971fc4ba2aa8fb5f295f20951ec",
-    "inboxId": "ae2dc1e82588406e94a8a3e6305348a792dd9e1da380e55f3eca4ca1d4d6eca7"
+    "inboxId": "ae2dc1e82588406e94a8a3e6305348a792dd9e1da380e55f3eca4ca1d4d6eca7",
+    "installations": 2
   },
   {
     "accountAddress": "0x2daf0a0f3a88f24c842e969e379d7d394a04f8f3",
     "walletKey": "0xf276e7ddb103baf09235253283c3121f9dfa379cb8d88a96802c8431ab839748",
     "dbEncryptionKey": "83a3ca3a82ec19e988de80debfe4646ea2ec506daf652e602968369da6259866",
-    "inboxId": "d2d09efdbb9745055e674d7342206064bd26ed005f63e703c8e7fd32d85056b7"
+    "inboxId": "d2d09efdbb9745055e674d7342206064bd26ed005f63e703c8e7fd32d85056b7",
+    "installations": 2
   },
   {
     "accountAddress": "0x0627917c3190c6d17ec230088a7ad77a01ac17f4",
     "walletKey": "0xe8f632fcdc822c13c792f74499d110291a6b7f537c9f40972b8c1849b1cd6577",
     "dbEncryptionKey": "5d5ffba5b709c491802ab5de35c8abfb01647fa9f7a1da3c02c501fc9b85479c",
-    "inboxId": "9318e4dbfe3cedee8ef30846fc7139db9f07cce98133e99e09bba9ce62100598"
+    "inboxId": "9318e4dbfe3cedee8ef30846fc7139db9f07cce98133e99e09bba9ce62100598",
+    "installations": 2
   },
   {
     "accountAddress": "0x96290668941e16c5447efaaafb02b48554d79e3c",
     "walletKey": "0x2be4030d8be1789d77b2cc436cf55caf7822e3418d75e392a28fa325c27d1a32",
     "dbEncryptionKey": "91f48aa8963f79a4727f643a112f28a33672e8dd758306a298af4c9a50a562cf",
-    "inboxId": "52e3a85bfa32eef5241791fae8d063bab87d6cb00f56e8aa8b12bf39fe134cc3"
+    "inboxId": "52e3a85bfa32eef5241791fae8d063bab87d6cb00f56e8aa8b12bf39fe134cc3",
+    "installations": 2
   },
   {
     "accountAddress": "0x566b7fb144760f52d7221352fb4d3fd1c931da75",
     "walletKey": "0x174ba773ee7a49dce30affe33d8822bb45b85cdc8ef45ca6c06ca2e6145c314d",
     "dbEncryptionKey": "4d0fafa15f73929e6e3a2edeb6bfe9324a430f332772a1e0766ef1061f36615b",
-    "inboxId": "ff799dac7b3ff81eeea68c70fb4b5a1b983dc00d4d2166e316564c535846127c"
+    "inboxId": "ff799dac7b3ff81eeea68c70fb4b5a1b983dc00d4d2166e316564c535846127c",
+    "installations": 2
   },
   {
     "accountAddress": "0x3efcd752d3d4cc6cde5523a7e7bfa5c405b0e1a6",
     "walletKey": "0x69bdfd2790a71debb26af821b49004b241fc0da4515e6f7ed50737d3aac0f20d",
     "dbEncryptionKey": "5f77af73c894d3db1fd49b3c7edf62e44a9fc073e1cc6e8ac06d38d9e62ac195",
-    "inboxId": "745a6f4594e2e9ab330413c348bb575dd7a3f218106aae904dd9e28052a7c54c"
+    "inboxId": "745a6f4594e2e9ab330413c348bb575dd7a3f218106aae904dd9e28052a7c54c",
+    "installations": 2
   },
   {
     "accountAddress": "0x57aec5c6458b4b636b01075050231d9db2cce578",
     "walletKey": "0x7d7349a91c60525086054f6b04704220bb010d6185a4b3a1bc45cc3a27aa77ba",
     "dbEncryptionKey": "1153a7960cfeb6fb16b61c8f0930ec6a4c75f07e1d892b3866a4f4e4e625d695",
-    "inboxId": "05c27875753e186806d3cb81887c61e738553212747afd662d1976482f97918c"
+    "inboxId": "05c27875753e186806d3cb81887c61e738553212747afd662d1976482f97918c",
+    "installations": 2
   },
   {
     "accountAddress": "0x68fa3afe2c99ed5042ccf456bd34cb42835dfd28",
     "walletKey": "0x73f917c51492e484b7e30e29b5765650032f446ca0f27ea96bb5d86047cdc740",
     "dbEncryptionKey": "a66223bbfedbfa767861883896142638d0e5fa63e4ea5c11bd007982fc80acc0",
-    "inboxId": "c5685a3c02632f997726d85a638603f0a14df8cdf92dd54b236286e082fe47e8"
+    "inboxId": "c5685a3c02632f997726d85a638603f0a14df8cdf92dd54b236286e082fe47e8",
+    "installations": 2
   },
   {
     "accountAddress": "0x0b201e5a7b01c6da0b5bc24ee383411d8aca9597",
     "walletKey": "0x6adb40f270d5a522265e2f66db1610a3974eef67497274bd1db6bf41b3260fb3",
     "dbEncryptionKey": "eda1dae1ff55c4abdb9104cf33aa9b445634fcac93d4323a0aed1917d39f5146",
-    "inboxId": "fd8099ee99ded1d9d7a0cd616777ca2d659ae61254a9c461cb10e7c95c5c648b"
+    "inboxId": "fd8099ee99ded1d9d7a0cd616777ca2d659ae61254a9c461cb10e7c95c5c648b",
+    "installations": 2
   },
   {
     "accountAddress": "0x8f4108e80f7c9fdb9819c322ffe9f18651b46ec1",
     "walletKey": "0x6f77f8d54b943834474f531c4b9f97cceb934b127a4c9dc985183db4a808e062",
     "dbEncryptionKey": "2759743f5651857e7fdcb9f2fce6246c9a7b54b8a60f0396e4654ef6ae392125",
-    "inboxId": "d9d57ad4f250fbc0643be31ba73871a8dd8e1907b7444c1a0c782fdebdcc85e6"
+    "inboxId": "d9d57ad4f250fbc0643be31ba73871a8dd8e1907b7444c1a0c782fdebdcc85e6",
+    "installations": 2
   },
   {
     "accountAddress": "0x2605caf873075d1e39a063a6f9665bcbcf146649",
     "walletKey": "0xc44e68ff89602c68157768b821fb8de74738d900ce06371a4f0f565f46d3183c",
     "dbEncryptionKey": "7b19beea08f7f98c88ef7c1f39a9b13fb9b0706341d9199c62e46b80d7fb5094",
-    "inboxId": "f3fab3ade9dc20c0c40e698d2186df3a97fbcfdf366667368d9efd4989e021e1"
+    "inboxId": "f3fab3ade9dc20c0c40e698d2186df3a97fbcfdf366667368d9efd4989e021e1",
+    "installations": 2
   },
   {
     "accountAddress": "0x8bfe20a3e73425cd4a9e70b08413911c6ff0ed91",
     "walletKey": "0x523eb046ad8a72a4c66f7c2cf4fcf52cc2dfcb19eb60ad7e459fd9b164dbb17c",
     "dbEncryptionKey": "4964854952c2ab6dba5df549599d899d1e69c7c0f013eb6f2e5372f2b1802f43",
-    "inboxId": "45ed19f2d73c2ae97e05855a6b66ae9ad85949bca8bbde45e58cbb9c196bc34d"
+    "inboxId": "45ed19f2d73c2ae97e05855a6b66ae9ad85949bca8bbde45e58cbb9c196bc34d",
+    "installations": 2
   },
   {
     "accountAddress": "0x710145d6d80b201df63295884133e0c9c3108630",
     "walletKey": "0x68814261c607997ecf2d96bb82396f5f29d3cd644f46ebacfbc4dc48c11399ac",
     "dbEncryptionKey": "b91a76f4310454772a83626a01a480b41724d4627ba27feecdd76e924c1addea",
-    "inboxId": "17dcbd10cfcb031ec9c9234da7031cc47ebc1654bcd04c695d4aadc78cc9970f"
+    "inboxId": "17dcbd10cfcb031ec9c9234da7031cc47ebc1654bcd04c695d4aadc78cc9970f",
+    "installations": 2
   },
   {
     "accountAddress": "0x79949651ffe5d237964b587706e7d9cdd4658ada",
     "walletKey": "0x0210d71f6a30fd08b37bf1eaf328c92c37c7d3406a93303d10738798115aa277",
     "dbEncryptionKey": "cc95faee86823011cf8d1116d37dd2b0948f20de19836cd5c9ed0a6aa9f2dc17",
-    "inboxId": "de53ae7fd35d14f0003573e5c81e3c4fba68cae6fd7213b14ff3b22f1cdbdeeb"
+    "inboxId": "de53ae7fd35d14f0003573e5c81e3c4fba68cae6fd7213b14ff3b22f1cdbdeeb",
+    "installations": 2
   },
   {
     "accountAddress": "0x549342734cbb2a9014ca7d6a519b44570b223802",
     "walletKey": "0x67e1e62d042fdf91d4215340e228bb2d604a64619e355b34612341eec78985c5",
     "dbEncryptionKey": "e67bc46e3289c50994e93be77709db79407cb163800268938b31edbfbedeb758",
-    "inboxId": "ee9da51dc15f2583ca8da4bb5e3ec94062ac8c4bd4cbce75dcc7543fc05a1201"
+    "inboxId": "ee9da51dc15f2583ca8da4bb5e3ec94062ac8c4bd4cbce75dcc7543fc05a1201",
+    "installations": 2
   },
   {
     "accountAddress": "0x15b2ac075e3d26b4fcd10bc6b9772e2fd761448b",
     "walletKey": "0xb3539133dfcfe6a9ea422137277a001116af3f644a81e60667c62abf2d21858f",
     "dbEncryptionKey": "892367836d671e43aea0992ef16d6fc84329a8817d0ba16f2b176ec47e81892c",
-    "inboxId": "50b78ee7af7d0fbea662195801e7938720ad77ec45a16b2c689589625ee9f99e"
+    "inboxId": "50b78ee7af7d0fbea662195801e7938720ad77ec45a16b2c689589625ee9f99e",
+    "installations": 2
   },
   {
     "accountAddress": "0xef66307e98cd0112e959ef333fc7b8e1395626af",
     "walletKey": "0xb2d3324a4dbb442889711450ba0c6797b314bb718c0340e2009ffffed115039a",
     "dbEncryptionKey": "baa7b2b134bf30a91b3a309f4f321587821dac59f46bd9ea4fe974917d249bb4",
-    "inboxId": "2ecb781a8a1d40f79f572cd641af2dc628be65d4716cf944756080de659b274c"
+    "inboxId": "2ecb781a8a1d40f79f572cd641af2dc628be65d4716cf944756080de659b274c",
+    "installations": 2
   },
   {
     "accountAddress": "0x7b65e0ce9b2f5222302b68281adfb336a518c610",
     "walletKey": "0x34d6a35d4bc61e49aaa367d9be140fb6b7cb530bec5eeffe2d50787d0e496124",
     "dbEncryptionKey": "331e1dc941c7e7ed1c06ffc90fc1f9ea730351c5892f2f35c2da3f63717c2d1c",
-    "inboxId": "e4a64fa1526733738acbee231694413b873607b4f6c1fb93948ecca8aceb3169"
+    "inboxId": "e4a64fa1526733738acbee231694413b873607b4f6c1fb93948ecca8aceb3169",
+    "installations": 2
   },
   {
     "accountAddress": "0xbe16ec0880a9266c6538c23feed0e000ef953b72",
     "walletKey": "0xc4ae17847b6ee323bb23fbb55a50a5f6643d28070cc5c40be18ab598ccdb9579",
     "dbEncryptionKey": "e05b766221c872117a4c60de62b50b1a5bf12901a029a08388864fa1ffdf4803",
-    "inboxId": "7965768326ea73f4c9f39518973e6a6a52e40ef222c7a8cfdaedb580d1ac248a"
+    "inboxId": "7965768326ea73f4c9f39518973e6a6a52e40ef222c7a8cfdaedb580d1ac248a",
+    "installations": 2
   },
   {
     "accountAddress": "0x855fd98893fab5bdcd4b346cf2895e1b8913a91a",
     "walletKey": "0x144157e4f1ee9e4b88411f0044c218908798a6821e9dd5159720ce8e20fe3619",
     "dbEncryptionKey": "3a812352497ba173c14d23e14a8179ef37bd3e27e0dd46be7e26b8c6ecf4dd68",
-    "inboxId": "d10120164994364d1ff550c207ef6932d11413098d87197e7068b1bf6ef0ea2a"
+    "inboxId": "d10120164994364d1ff550c207ef6932d11413098d87197e7068b1bf6ef0ea2a",
+    "installations": 2
   },
   {
     "accountAddress": "0x84c8a525d848eb096bfa2f6d0e631bdac495eeaf",
     "walletKey": "0x4bf770d7c835ef2e41d6bc4aa1b861afc345bed36a7aa38a77d49409b8f67031",
     "dbEncryptionKey": "1362be39d969597e26e584fbc86f6aa5325052e4b2d0eca3958ed4c4f2034912",
-    "inboxId": "72e82033f2680118eaef87d71985e03313bc4f87bf78215fcd6209234ac9d30b"
+    "inboxId": "72e82033f2680118eaef87d71985e03313bc4f87bf78215fcd6209234ac9d30b",
+    "installations": 2
   },
   {
     "accountAddress": "0xf078bfc3eb2f9f29cc57bda57dfeae07bf8b5830",
     "walletKey": "0x6eb7dc1a2aa6be32876399417a08398383d2ec554ba7e3ff9057b5468dd952e3",
     "dbEncryptionKey": "bf3802491b1d87120179ca6810f225f4fc8d6bb34fbda3ea3227e2734d76594f",
-    "inboxId": "447fc8b4ddcb2ccade18c7eec11fe7c35fbebfa9b8b50d53bf8399fb164ced08"
+    "inboxId": "447fc8b4ddcb2ccade18c7eec11fe7c35fbebfa9b8b50d53bf8399fb164ced08",
+    "installations": 2
   },
   {
     "accountAddress": "0x131591d66527d9586b1349b74e6f65615b6e5357",
     "walletKey": "0xd5d7ec8b77ba571aca9ef0e73a902b1b824cf8a3c045f10f884f6d9611904966",
     "dbEncryptionKey": "7b1acacee44fc29a9be080142ad6cdc5935061ce9369035147ea98f8f7366747",
-    "inboxId": "704db06e0c9737f03ad4dc5e43964fc0b1e9f1f7854ddacc51157939c9f11acc"
+    "inboxId": "704db06e0c9737f03ad4dc5e43964fc0b1e9f1f7854ddacc51157939c9f11acc",
+    "installations": 2
   },
   {
     "accountAddress": "0xa68dad6c4f1c44a06137b71235b257b0cccb0c4b",
     "walletKey": "0x1e895fc4fdd0cfe17b12b5a2897b6d9ceb874e1aaba457f15953947daac6bfb7",
     "dbEncryptionKey": "a5056485721f84b312be0166ae105ed4ddddc1d88eabdffaa953d4f41be8201e",
-    "inboxId": "c629f1a95b6dba1c1560cb25ebff516d7af88c9110428dc127fdda648f7f2d03"
+    "inboxId": "c629f1a95b6dba1c1560cb25ebff516d7af88c9110428dc127fdda648f7f2d03",
+    "installations": 2
   },
   {
     "accountAddress": "0xcf7a5a823f4d29aab2135efc0d48db893079bd13",
     "walletKey": "0x8254ae0bde26133a5e5143e2e0ef4623c3bf6abfbe7433ba5c16c3ac72754a72",
     "dbEncryptionKey": "d5e288d43a05ebf5b4ead8d17bd81195cc7a1cda68cc4ad5c3e2267d5d1dc0a1",
-    "inboxId": "7b981d61e81257e41bb3621805cc6093b285015be3328e8e55655438baff7f86"
+    "inboxId": "7b981d61e81257e41bb3621805cc6093b285015be3328e8e55655438baff7f86",
+    "installations": 2
   },
   {
     "accountAddress": "0x211ffd38136f21a600f583f5082f9a871d7134da",
     "walletKey": "0xf3e10573d2e78f7a8e267750dbe4215b95f4d30bfd8f5ce5f3fe8ab36b9d0b58",
     "dbEncryptionKey": "69c1dfce6ef6e25129ae2d9deb40c0c01e0866f3c334c97cf40398a1b153d37c",
-    "inboxId": "c7bec585096130789929134f0e61350c7c2e67813d53b043b6e47f6fd632a323"
+    "inboxId": "c7bec585096130789929134f0e61350c7c2e67813d53b043b6e47f6fd632a323",
+    "installations": 2
   },
   {
     "accountAddress": "0x9807fcf5ea4de486f8a0f3b50cf4e6c4db327ed4",
     "walletKey": "0xa6276564f9d4c05debff3cac6d87ac385535c5bff4e9de547cc45a5b82d1d951",
     "dbEncryptionKey": "71764ac5891c0a6889056e666bf748a882f7cb6d89c6a3a32ec949aba3db16fe",
-    "inboxId": "8cc567d47183bdb434a31128c4f596d0d53f3b989e89043f9e7f5e50869b29c5"
+    "inboxId": "8cc567d47183bdb434a31128c4f596d0d53f3b989e89043f9e7f5e50869b29c5",
+    "installations": 2
   },
   {
     "accountAddress": "0x3ff70a8c190486b3b5da25b1c73682dd8aae1bf6",
     "walletKey": "0xefbbe8342d3d7d1ce1ac7b776158359071787833687d8bb5cb4293d9e4b539e7",
     "dbEncryptionKey": "43eb2e907d95b0038662b64734c0666bca84df06383fde1c0f600c15b40de69b",
-    "inboxId": "9df13ae3a3ee78a3bfe6180878f3b71ad33be0b1e7ca5e5e70a9a62d3e654aca"
+    "inboxId": "9df13ae3a3ee78a3bfe6180878f3b71ad33be0b1e7ca5e5e70a9a62d3e654aca",
+    "installations": 2
   },
   {
     "accountAddress": "0xac0aa78d859b67ef858cde9187fd075b9d1544db",
     "walletKey": "0x6f2ee1ecd7afc47c40854fe5aece763fbb42ec462118dab077849fe15c691994",
     "dbEncryptionKey": "1012a7e950deafdc2ecd5417c194d7ac70c5b80c8069ca4a666290de9f69f42f",
-    "inboxId": "69d9a01fd0644334e351c7cb3e478b158bfc0fd5b5ff4f312fe3c9a76b56b6b9"
+    "inboxId": "69d9a01fd0644334e351c7cb3e478b158bfc0fd5b5ff4f312fe3c9a76b56b6b9",
+    "installations": 2
   },
   {
     "accountAddress": "0x46557c57480585e6423f39567a0159d50bbb6723",
     "walletKey": "0xca4f10d1023efd2a53397359a0338726cc57ec0bf55306ecb78ebdb827067931",
     "dbEncryptionKey": "ff0706ffd48b474fbcb78c1cd5f44f75a8f5b1b52fe653bfe7d7ce28e4f59120",
-    "inboxId": "329f0d5ebf19f091fb021a691cc46cd90c662c3709c842dfee09c1c6c79be534"
+    "inboxId": "329f0d5ebf19f091fb021a691cc46cd90c662c3709c842dfee09c1c6c79be534",
+    "installations": 2
   },
   {
     "accountAddress": "0x9fd904cebac33bf1eee256e0ddcfd06c6326e61f",
     "walletKey": "0x7060a11fa17b24de5f923fa9da68f857c5cdef1e219e0612164751d1919f1459",
     "dbEncryptionKey": "1db4d5c45848d4daa0e8d201842d9303f443ca6e672cbf816d5e7c0dd22ada3f",
-    "inboxId": "45952bdd7823e1848caf3f0ca4eba3b8f2257c643d83deda000ccebae6e09072"
+    "inboxId": "45952bdd7823e1848caf3f0ca4eba3b8f2257c643d83deda000ccebae6e09072",
+    "installations": 2
   },
   {
     "accountAddress": "0x3638285cc0a8e5756e9819b5c4d856f896fa7714",
     "walletKey": "0x73eeb9018776bb50ea61fb6976da7300a0d8c7d007a389ab2bca8ca1fe8d267f",
     "dbEncryptionKey": "9f34eb7165a23bbbf58403b65e7666d6702c2b9d77c4b2a5f7227cb327abb27a",
-    "inboxId": "92f8cfa1945dbacef811df12ba9ce9a8ed760465a2c86d5f2ab181272ecde427"
+    "inboxId": "92f8cfa1945dbacef811df12ba9ce9a8ed760465a2c86d5f2ab181272ecde427",
+    "installations": 2
   },
   {
     "accountAddress": "0x2df2d10a81e7ff00c84ffd3a170c25d694d4b9c1",
     "walletKey": "0x8a23543fd1a502a42f717d9a9781ccab43daf672d22d0e5b76c3044f88658248",
     "dbEncryptionKey": "e8e4a0b8a5da253987f8d6b006131ffece6d47292e098a93043ce47243ce4bc0",
-    "inboxId": "3cf48c2a821fe510e7cfd8fb7182c0f9d948aeca9528ebe55204f84ee70fc4c3"
+    "inboxId": "3cf48c2a821fe510e7cfd8fb7182c0f9d948aeca9528ebe55204f84ee70fc4c3",
+    "installations": 2
   },
   {
     "accountAddress": "0x23be49b7402d107291aa6690f025b5f1952d7875",
     "walletKey": "0xa61e92bb5d5006df50e1eded9da5f8aaf2c697bafd052e758ac9f835ea92bab3",
     "dbEncryptionKey": "f87808d9f011e49d6417482a075d852c0990faf54e57e2a79e66fe5c619a623a",
-    "inboxId": "6ba9d2b4fa96b31fb3c6c758f6954820a51ad13f27991c3fe0305c57d413c0d7"
+    "inboxId": "6ba9d2b4fa96b31fb3c6c758f6954820a51ad13f27991c3fe0305c57d413c0d7",
+    "installations": 2
   },
   {
     "accountAddress": "0xbbb59b83635a082ccbb5cd0a9a33eb4228feabde",
     "walletKey": "0xb776eb45c1f3f0e4a12d071590dd3b896d5a0795cd1edf5695639113aca86852",
     "dbEncryptionKey": "8ee8827bf8fc945ecbcfe50f94b1882b2a30377601fdb590bb229a64fa008ba1",
-    "inboxId": "d861bf75c33750dc36fdb7c5807f6ed32fb5f06cb55b8bf8d4f36289cdef8c1b"
+    "inboxId": "d861bf75c33750dc36fdb7c5807f6ed32fb5f06cb55b8bf8d4f36289cdef8c1b",
+    "installations": 2
   },
   {
     "accountAddress": "0x0bac44c8830b9a48a5f9546d06bf921f600ccb06",
     "walletKey": "0xbd2712827d01de56675a83de674d860bb083ecc534afe26495e8fd67203f41b8",
     "dbEncryptionKey": "dfba64fbbe89ae13440c25a3d57116c4bcd8f9cb44fc93528ec4e6f8de390339",
-    "inboxId": "632bb2ba56a9bf81a958d3c8d1a2887985be5c36e4d59664bbbc31846249c752"
+    "inboxId": "632bb2ba56a9bf81a958d3c8d1a2887985be5c36e4d59664bbbc31846249c752",
+    "installations": 2
   },
   {
     "accountAddress": "0x6cec14a664073999cd715c1d575f536421c042b8",
     "walletKey": "0x98c9e42a294edfd61765f4375f0ee1a17cfea1713fec3064fa723978414bca81",
     "dbEncryptionKey": "21aefa6007629f611c8a37b5de6ac0eb6a509f7997f949993eb61fe6f8c6f462",
-    "inboxId": "93c43d86a296fe059c649a12a5ff23e35b8c1164cebbae6bfd719654dac749ca"
+    "inboxId": "93c43d86a296fe059c649a12a5ff23e35b8c1164cebbae6bfd719654dac749ca",
+    "installations": 2
   },
   {
     "accountAddress": "0x1981c63998f992a59fbfb28fbb93bf38fdd35795",
     "walletKey": "0x4dfd4f3bb285f74d80cc0aa821ba1358783cd55842ace2346c4dc7c003af6d91",
     "dbEncryptionKey": "4035ab6ffe0f10aa165e5d085660cce01f64182ade24400e6f19e1f401b80133",
-    "inboxId": "20f7d2f52711b38fa7b1e9b6384ed60ca7b54f571757f57997f1a1137e932daa"
+    "inboxId": "20f7d2f52711b38fa7b1e9b6384ed60ca7b54f571757f57997f1a1137e932daa",
+    "installations": 2
   },
   {
     "accountAddress": "0x89acb84f0021ae4632ee14d8767d504c9efd5c45",
     "walletKey": "0x2594e56989bd659309fd13376260c7a6d816208878e6f1c6cf41155e74b037e8",
     "dbEncryptionKey": "87dfff5792f274038e546b68122df970a62e9f059b6e8348b084feda1f90dba6",
-    "inboxId": "1380dbd62c0d71467c5aa26a729c4bb992ba4cc609732356230ab3b83270034b"
+    "inboxId": "1380dbd62c0d71467c5aa26a729c4bb992ba4cc609732356230ab3b83270034b",
+    "installations": 2
   },
   {
     "accountAddress": "0x3c61a77eafb9074f483ea018516e5e6eea00dd6e",
     "walletKey": "0xebdfd58946fe2827c1b2656267b67901d9afe5fba71c6f5b95487945a63cf531",
     "dbEncryptionKey": "43ae7c87d09b55222862219c79b13b6aabf650512590604951e75edd97eb0c50",
-    "inboxId": "6c4329f7433fa1d6151857a2554299eda8b8e5eef2cb852de498eb833f458484"
+    "inboxId": "6c4329f7433fa1d6151857a2554299eda8b8e5eef2cb852de498eb833f458484",
+    "installations": 2
   },
   {
     "accountAddress": "0xdad17b901bbb8ea8a1fd5744f64bf649280b0f5c",
     "walletKey": "0xfeee08c992d82cb57a349ae6fac2daf90ea5249be737b3bf49fa173b1bff4b0c",
     "dbEncryptionKey": "d2445d130f055e3b621b5428c890abdd4e0de11f8d09ee07e1fbe65bc782662b",
-    "inboxId": "2e30172482bdd19d0de2294add0a5f08ad20b1ca92d325bcba766cf95d9b80b0"
+    "inboxId": "2e30172482bdd19d0de2294add0a5f08ad20b1ca92d325bcba766cf95d9b80b0",
+    "installations": 2
   },
   {
     "accountAddress": "0x164261aba35323c413302c39f896ec7187d71484",
     "walletKey": "0xbb65e8bacd9e5e0695933224c83b36b39cdadc02716cd64c6b4de3592235715a",
     "dbEncryptionKey": "c3f5f1ea884bc9a36886526636e4a5063c21267871299b3d1fcfa24b71ee9d00",
-    "inboxId": "6657fbd29163412678f5ebf95e104702081da36d14b7ba0384445366686874ff"
+    "inboxId": "6657fbd29163412678f5ebf95e104702081da36d14b7ba0384445366686874ff",
+    "installations": 2
   },
   {
     "accountAddress": "0xa85b7773dd417f10b9f36611422dc423db41b9f3",
     "walletKey": "0x74fb5dd192f724e8a99a57a01319126b46ccabc4557e9a0be35088bb089af8af",
     "dbEncryptionKey": "56e7bb58acd53aafee02196cb03d43d610132a0aa51188b3a4196880f0b4f705",
-    "inboxId": "abdc994e308d6275edaedbc2d3a73f6dc73805f67290342dd4b5bee63d2b554a"
+    "inboxId": "abdc994e308d6275edaedbc2d3a73f6dc73805f67290342dd4b5bee63d2b554a",
+    "installations": 2
   },
   {
     "accountAddress": "0x3bc19cdaf457a6afd2aa694d7cb3a0b5c2d9d5a7",
     "walletKey": "0x343c477a57d429790d40a777c7b8676f51365d399eb44da1567226a9e16b95c1",
     "dbEncryptionKey": "1900cb0c6c509c0dd1851dbaf41106a3d3b1cb1393321df7dbda35247781c779",
-    "inboxId": "9dced083b0ad5cc0632c5d1aa73c7843b18cadfed834ccc57272472f9f1a38f0"
+    "inboxId": "9dced083b0ad5cc0632c5d1aa73c7843b18cadfed834ccc57272472f9f1a38f0",
+    "installations": 2
   },
   {
     "accountAddress": "0x16370647d6bedd0926b94a0ea013143fe6ec615b",
     "walletKey": "0x483571bcf8a86632429c1e5e2763ddc6b15284fded8b6face7bbacc084ad05b8",
     "dbEncryptionKey": "ca091ff91f30c9b035b4447e888b985373ec643660763e725ffa5561a7a281fe",
-    "inboxId": "43d134bedc4926944bab919448b6b0eefafd8ed1512d737f8d0d7d5200efbf08"
+    "inboxId": "43d134bedc4926944bab919448b6b0eefafd8ed1512d737f8d0d7d5200efbf08",
+    "installations": 2
   },
   {
     "accountAddress": "0x48d4858167560453112dfbaa972315539c397e18",
     "walletKey": "0xf7ff474374e47f08d013a513be10f0a97a13947866f8af84969d2e12689c8f24",
     "dbEncryptionKey": "1ef9fbebd113e355028ed2b6705056d5d4b40a4909338d15ad72cf5db423fa5f",
-    "inboxId": "c27b2fd327de00c06b0f4660e801d30259b7587f7924b7b0284bcfb2a3ecc226"
+    "inboxId": "c27b2fd327de00c06b0f4660e801d30259b7587f7924b7b0284bcfb2a3ecc226",
+    "installations": 2
   },
   {
     "accountAddress": "0x0f4a3a7a131e5214110348421f22b1ec5cea24cc",
     "walletKey": "0x2cb0a907b45de415df859159fa895836eb05e10a407d9813aa227c86f0d2e514",
     "dbEncryptionKey": "5f1bc20dafff9da3b8c33e439f8f4ed37aad4b1695cd625dc5dc7e3ba1b16225",
-    "inboxId": "b449da4e9b99a56998207836e0bfa41fe674831afb8d81c666e58a20dff78dba"
+    "inboxId": "b449da4e9b99a56998207836e0bfa41fe674831afb8d81c666e58a20dff78dba",
+    "installations": 2
   },
   {
     "accountAddress": "0xb857315c68b3902073a545a1a5aa441685ecfe93",
     "walletKey": "0xe1d4f317d0c02ba3e7faefc3a20bc2272af1929576068e842c2928ebad6c7209",
     "dbEncryptionKey": "4599bbc29092834426e31c0c71466c505385f51b8b2d66c1fe398f46766ad921",
-    "inboxId": "11b7edac0f0d15e3abb401f1b9cc8ab19962c08847c8ad87be8218a38f85aad2"
+    "inboxId": "11b7edac0f0d15e3abb401f1b9cc8ab19962c08847c8ad87be8218a38f85aad2",
+    "installations": 2
   },
   {
     "accountAddress": "0x6c567b415ea1fb42ac7dd70e9435d340bddd0e85",
     "walletKey": "0x4ad6197bc60f363617803b9b32f0b4fa73438fe4379de9672c41856e230e0773",
     "dbEncryptionKey": "6162c2e5c7592210bc4988dbfcd9f9ce0d42b4524dc4982af767349cdf079808",
-    "inboxId": "c1d8e412a545808b919275de225048c0cfa1a348f512a9c8b437f11c3338aff6"
+    "inboxId": "c1d8e412a545808b919275de225048c0cfa1a348f512a9c8b437f11c3338aff6",
+    "installations": 2
   },
   {
     "accountAddress": "0x9aeec1f82f807d79107380ef8c84c76f547164c7",
     "walletKey": "0x17f5b413c38e9813d7431b2b9a132af77614a6d9b35b62c330e3a7ee046ad63a",
     "dbEncryptionKey": "246348f7adc8fefff955dca9d79b9208fa3275a2df790f34552338b2301e117e",
-    "inboxId": "7b81382be474999dc39ad4454e95964205efff51c22df9c42edc7809cac2ca47"
+    "inboxId": "7b81382be474999dc39ad4454e95964205efff51c22df9c42edc7809cac2ca47",
+    "installations": 2
   },
   {
     "accountAddress": "0x66b4544be038a26ae4b6140c2c64aee18ce403c2",
     "walletKey": "0x5efab8522f9c897143ff465d8a3148627aac2d7ba13d805329b97531ce3dfccd",
     "dbEncryptionKey": "d0725944f8fae3eddcd354f21d019c71ba2308ce5def7af7690aec1111c27b3a",
-    "inboxId": "3283670a95a1be33daa2c2de2a4464bb4aeda6445047d5daf8fe1e5dd1124221"
+    "inboxId": "3283670a95a1be33daa2c2de2a4464bb4aeda6445047d5daf8fe1e5dd1124221",
+    "installations": 2
   },
   {
     "accountAddress": "0x312e3b80403b9eb902615290caab6df4f04c8a5f",
     "walletKey": "0x9117bca66957fec2848903dd71ef3de4207644d3c3e59ec841959728fe0d15e5",
     "dbEncryptionKey": "e0fb9d95f03be9a571d6c7e070e042610f6dbd19b9066fd59e8e2b81d4b4e805",
-    "inboxId": "8615b67271c122768ae9e36ca3e16ba396d9098c757559b54d52fca66c943b6f"
+    "inboxId": "8615b67271c122768ae9e36ca3e16ba396d9098c757559b54d52fca66c943b6f",
+    "installations": 2
   },
   {
     "accountAddress": "0x6ae598b3c911d41cd50cdfd4d6edbc0f9de345ef",
     "walletKey": "0x71d8c301fb6a528cb4c956e2d4e3b529f28ec356c78fe28d1ae745a25c154abd",
     "dbEncryptionKey": "b318c6febfa1dbc3216f0a8b134408edb877947e48cd678853a269c90706e861",
-    "inboxId": "ca687fef8d62419452ac2ce3777069e1b51f48216932cf58862b4270272a8ec9"
+    "inboxId": "ca687fef8d62419452ac2ce3777069e1b51f48216932cf58862b4270272a8ec9",
+    "installations": 2
   },
   {
     "accountAddress": "0x4b4c72ca75c69123478b2b1ea14f407b1edb12c1",
     "walletKey": "0x855777c4ce4696798a2a7c146a74f8aae4551671fc470dc527f1ddbdd3014e63",
     "dbEncryptionKey": "7f3b3352afdca7b1e0eee40268ee4b947728bc67dd54090efcc4e2b073de8d23",
-    "inboxId": "d80b283013e7d0690ff5584f88793a23961a6f8ddf866f6c0265e4c8a10ee8cc"
+    "inboxId": "d80b283013e7d0690ff5584f88793a23961a6f8ddf866f6c0265e4c8a10ee8cc",
+    "installations": 2
   },
   {
     "accountAddress": "0x4aea02201caec9521ded668977a1c6a64fde3a7b",
     "walletKey": "0xeb77683d1cefad3a6bd1466ebdb67a1520eb0c2aecfeeba840c8255b9d08ebfd",
     "dbEncryptionKey": "2215f19da2d7013dd6ff24c3909cd0e8039a2ce93abe8a561b2ce92926233a65",
-    "inboxId": "626f0034bbedb4254cad7fd30076f51c44145f47a12326ccf9ad5d07ac57b51d"
+    "inboxId": "626f0034bbedb4254cad7fd30076f51c44145f47a12326ccf9ad5d07ac57b51d",
+    "installations": 2
   },
   {
     "accountAddress": "0xaa019696b81f71006d947d13633190eac46b1449",
     "walletKey": "0x1eb9e6c4c167975057398c752c10d8ef9c2377051f5274c3e67b017b6bcff32b",
     "dbEncryptionKey": "c0e8410e0f804ccfcdd57f62164ef0ac315663ab206997d42aaaeed95d68ebf6",
-    "inboxId": "33100643fc9ce601575289840da42e47dba66fe81b2faf45560b6ce70e45e832"
+    "inboxId": "33100643fc9ce601575289840da42e47dba66fe81b2faf45560b6ce70e45e832",
+    "installations": 2
   },
   {
     "accountAddress": "0x80e744ce46f21d6c724a689f73192afd9d7825ea",
     "walletKey": "0x8282e9d0863d4a33fbd46349719aadd3aadb9dee594d07083ab827e1775ef038",
     "dbEncryptionKey": "bed4640594e7a309badfd4fb82609c6d7e4b31a19c8028eb4522fb3e904d0be4",
-    "inboxId": "39e70674eced8a45713b8d079027759a9d6f594d89aa4c91aabe44d4d731fd5f"
+    "inboxId": "39e70674eced8a45713b8d079027759a9d6f594d89aa4c91aabe44d4d731fd5f",
+    "installations": 2
   },
   {
     "accountAddress": "0xb2217ea41fa6b80e51e9fb740b14841c92e86149",
     "walletKey": "0x29c2607ba08d8e634b4786e716ff2dac23cdd30866ae422ecd19949fb82d4e24",
     "dbEncryptionKey": "c5ce7028f6ce58a60ed83dacdc59bca168f5656ede9b4fe1dd6483c01e70bec3",
-    "inboxId": "d61b4072898803204bffd12703659fa57d27cd9537df0a0f165bd9e720a69f50"
+    "inboxId": "d61b4072898803204bffd12703659fa57d27cd9537df0a0f165bd9e720a69f50",
+    "installations": 2
   },
   {
     "accountAddress": "0xeb262cb6a6fe00c5f46725c1513686cc4815b0a3",
     "walletKey": "0x341fd6c45caa6e9481901d985c2b8d23ff28d57bba0b5af5bb29c42b7dc66fb7",
     "dbEncryptionKey": "b23f449d87455a997560891eae78bb0af816e5695830bb14d399b1eee162b976",
-    "inboxId": "401660e813f6d1d0e7c33b1c63ea3670c8b5bd47d6475add336c80a79e0cf59a"
+    "inboxId": "401660e813f6d1d0e7c33b1c63ea3670c8b5bd47d6475add336c80a79e0cf59a",
+    "installations": 2
   },
   {
     "accountAddress": "0x520e613f7c0f4d8b883146b2c041a910c908cc74",
     "walletKey": "0x1da7d2a26bbdef9e1bdce62edf21f2dd524eaf5c1a3abe23989d59593baf3cfa",
     "dbEncryptionKey": "bd08111bd6b9d2df3e76d22f962a665e5a6224ef9df7053e56cb12fb896761eb",
-    "inboxId": "3e12e72ab71eae02d7b78aee62bf58f6d84977525de42c4dd4eb5988c9c9578b"
+    "inboxId": "3e12e72ab71eae02d7b78aee62bf58f6d84977525de42c4dd4eb5988c9c9578b",
+    "installations": 2
   },
   {
     "accountAddress": "0x0b0c8c1ef41357102c7ddc5b27a8999b1978d08a",
     "walletKey": "0xe4015461926ff60f83a1e0c8dec351f0298e63d6072362cb64b85a719e4c0bb2",
     "dbEncryptionKey": "e11ef9d3bcea195cd4c3efa05fccffd62457128963526375da93c8463595760d",
-    "inboxId": "209e6e83fe709b5d1ded8793118bc88cb07adf9e6bb99c246d57d35fdd2b8141"
+    "inboxId": "209e6e83fe709b5d1ded8793118bc88cb07adf9e6bb99c246d57d35fdd2b8141",
+    "installations": 2
   },
   {
     "accountAddress": "0x9a8f6c03105ac9171d235b912e65669489ca9963",
     "walletKey": "0xa932745329146c36feb4a910b5ea5805f0e2ff07cd74cefb3ef10d7ecced3cf7",
     "dbEncryptionKey": "c0a3027e3761f1cbe725788e835550e5b3a90222e75c76f4958610e12737c060",
-    "inboxId": "88ada15cce3801cf485968ec50ec416a2ca25ef8ff27f81d210352e8faa47453"
+    "inboxId": "88ada15cce3801cf485968ec50ec416a2ca25ef8ff27f81d210352e8faa47453",
+    "installations": 2
   },
   {
     "accountAddress": "0xf79b7b541dfdfceab984e5b7b2b4df7b087a92b2",
     "walletKey": "0xaca96c7746a02726db196f58aa0a483fe8df46eb102578a6ebd0d4cedbe74990",
     "dbEncryptionKey": "70cf9301cb4b6eb81f462eb9cd33bb78586b884e441ef2f33e60e23f53fba12c",
-    "inboxId": "ebd4bc360d33c3b991e140e3062820197f305134ea9d96fe7b49fbed2baa8109"
+    "inboxId": "ebd4bc360d33c3b991e140e3062820197f305134ea9d96fe7b49fbed2baa8109",
+    "installations": 2
   },
   {
     "accountAddress": "0x891be5f49344485522b16c83ba8dd6788bb85f50",
     "walletKey": "0x32997a1848fcb7896eb198b804f7916d16164c1715831ea086381b5b58081825",
     "dbEncryptionKey": "c83904641b13db8bd1d7ed1eb160e8dd889afa36651814d2c50cd260688ce130",
-    "inboxId": "17d6110563fe45f60015ddc59d876bd57a667d52d535707f66393af40769f1eb"
+    "inboxId": "17d6110563fe45f60015ddc59d876bd57a667d52d535707f66393af40769f1eb",
+    "installations": 2
   },
   {
     "accountAddress": "0x039bd7b78c1f39a6cc953ecb3a9b9380a46079cd",
     "walletKey": "0xff46d20bd2968e0400cddf262e9b79b11f49030bd994e02561f6489f8041d774",
     "dbEncryptionKey": "df1524bec62382eac4adcc6196654249f70455141704620d7a7569e973b48b6e",
-    "inboxId": "bf9449f3cb45cf0d80706a795508da02ffa5fc6422a41ac87a8da6a4d281a37d"
+    "inboxId": "bf9449f3cb45cf0d80706a795508da02ffa5fc6422a41ac87a8da6a4d281a37d",
+    "installations": 2
   },
   {
     "accountAddress": "0xaf865b217f81051db4b6aa8ed697149eae42b632",
     "walletKey": "0xcc188547e27495d9b2b3c6a3481d036c31b3883916946c90452f46cb992eafb5",
     "dbEncryptionKey": "9c81c57504f7faf4de860d1bab8318b8daa8fde5a2238b57b4abb6ae44246cb7",
-    "inboxId": "f2b60c9e056b7c075bbb118f30a427206764d0319cc56007e4b64c255aef5f98"
+    "inboxId": "f2b60c9e056b7c075bbb118f30a427206764d0319cc56007e4b64c255aef5f98",
+    "installations": 2
   },
   {
     "accountAddress": "0x09fda80147b5aa886892a4882d3a397777e1abde",
     "walletKey": "0x2e6a070b0d06e0adb69bff81dcea6b4b0540eaecbec4d63a5d1cb3a2120d17a5",
     "dbEncryptionKey": "790da6cc0c4cade21cdc4005ae657e6d6b6ac0614ea0611d3d305c4735a68650",
-    "inboxId": "cfe6195db05d4bd082c205f4d5c1c99dcb8ff56982d73b3d0845a95df9fbce66"
+    "inboxId": "cfe6195db05d4bd082c205f4d5c1c99dcb8ff56982d73b3d0845a95df9fbce66",
+    "installations": 2
   },
   {
     "accountAddress": "0x65c3bdb5556df94bf499775c7852f2fe0ac2e7f7",
     "walletKey": "0x19162623ff237f8898148a5cc2245043d552a7c1b19fc13cfa986a707c41ea7c",
     "dbEncryptionKey": "4f20b7d3716da425625875cd8193208a4ce28af8256e95eed3b641a8b8ff7a52",
-    "inboxId": "9dc0108c27447db3b40fb4cf2ca1795ca94f05ff38fa1c285dad0d4425492c8e"
+    "inboxId": "9dc0108c27447db3b40fb4cf2ca1795ca94f05ff38fa1c285dad0d4425492c8e",
+    "installations": 2
   },
   {
     "accountAddress": "0x0a35d6072014a0359960b403326a15dc9e457917",
     "walletKey": "0xd61b4e3a98005c4f7a843d16eedabf0b5d0c758a3fe05b99eacc49790fab1da5",
     "dbEncryptionKey": "5d15d44317b00f249bf9368d7f923fd91df0eed62d9c817cb16ca03de000d92e",
-    "inboxId": "8a81a4e6582073f646230ecda59122848de7189a9e3da94b2cb77bca3414073e"
+    "inboxId": "8a81a4e6582073f646230ecda59122848de7189a9e3da94b2cb77bca3414073e",
+    "installations": 2
   },
   {
     "accountAddress": "0xb0ad0bc8eb4336502da36241465f98d5d7043462",
     "walletKey": "0xeb99f688c03e1c58a744f7e29b9dca3e0d69cc6f7c551f7d4574cf40e9fdfab6",
     "dbEncryptionKey": "d58d8e4b3edb7c78c71442e0bee23916cae837af015b5d8c8d946c73c02d5d82",
-    "inboxId": "1bc8e8b1a0018fb39aac7a0a50e43b60d255e3b30569b28d0b554cc49d36c1ac"
+    "inboxId": "1bc8e8b1a0018fb39aac7a0a50e43b60d255e3b30569b28d0b554cc49d36c1ac",
+    "installations": 2
   },
   {
     "accountAddress": "0x3831ad958cac60244374ade2f0004bd4c3676ec1",
     "walletKey": "0x1eaeb427142fe8a0ea4aad26f80e2e348001d07f9e76842176fbb2f25ee08bec",
     "dbEncryptionKey": "ba31c3a4d50e2a82d78fa8fa9078759392e773c122fbfa74667bfa0e26028e76",
-    "inboxId": "20909f862378ace5554c21c41f2740f9bc1a98900481fe80ced6a8f11e071717"
+    "inboxId": "20909f862378ace5554c21c41f2740f9bc1a98900481fe80ced6a8f11e071717",
+    "installations": 2
   },
   {
     "accountAddress": "0x614527855cdaf169e38ba5da6c60231ecbcae5ac",
     "walletKey": "0x8ac5033aa350591e04717409a09638e2ab8dfae7803a6c8aa50fd80eff544e19",
     "dbEncryptionKey": "b33a1094ab18b6605087b93012abfe8a072e0f2e1dc7fe6dc14eece53b524129",
-    "inboxId": "e65edaf00809caa1eb88ac48bca58b3f6fb5e559b4dec44a8fa2ea31e5a4e65d"
+    "inboxId": "e65edaf00809caa1eb88ac48bca58b3f6fb5e559b4dec44a8fa2ea31e5a4e65d",
+    "installations": 2
   },
   {
     "accountAddress": "0xb620a3db7f1348940ae86e1c25811e50a219b6c9",
     "walletKey": "0x33d894188040324abebedb959f81ad40d10da3065d4674c180a0d8cd9966bc20",
     "dbEncryptionKey": "df1ed7e74aabda39806d938a187efe3f9e7b7d38412628841f88b78d2644e2a4",
-    "inboxId": "9e029f5760fc450631dfa7cbe695d57989c3a1aac073b1d3523f1c30640576bb"
+    "inboxId": "9e029f5760fc450631dfa7cbe695d57989c3a1aac073b1d3523f1c30640576bb",
+    "installations": 2
   },
   {
     "accountAddress": "0x980a344082fb4b5a7a4bcd9fbfb9e00436e92584",
     "walletKey": "0xdc1db114aab87cb4943d864d8aaaa10040a54dc85b1184082584752cb93050ab",
     "dbEncryptionKey": "c08c8ef52db797e6a33057990ea69458ad8bbbf7976b5d8fde6cbfda7ccca487",
-    "inboxId": "9fdfe1798507c88ca0dd3be22183807782c5a7aaaf5bf73b18a824bb31a91967"
+    "inboxId": "9fdfe1798507c88ca0dd3be22183807782c5a7aaaf5bf73b18a824bb31a91967",
+    "installations": 2
   },
   {
     "accountAddress": "0x2fb4e049b7cf25e5e7a7139122f6e9ec380c1c49",
     "walletKey": "0x7d60b43db02ebfbdf6f4b9ed215c67755073f418f0f4d8474fca80852cd02ad3",
     "dbEncryptionKey": "7efa30e167aa83ad74548409c9b9e15bda1f1f868fa1803ec2ec9199c5c73887",
-    "inboxId": "5aa51a78a62cdfbc34a54fb0ffbd92bce2e9e53c51d47f5b6d6c261e54a4aeb1"
+    "inboxId": "5aa51a78a62cdfbc34a54fb0ffbd92bce2e9e53c51d47f5b6d6c261e54a4aeb1",
+    "installations": 2
   },
   {
     "accountAddress": "0x5c557d2249d7d42bcfeddf7872024508399c90bc",
     "walletKey": "0xcc0670c3aa3fe79735d6884faf6f7889b27bcb3f013497f0d39d168a6b133a8f",
     "dbEncryptionKey": "a3c492945333f776eaa3391bd2d3d69e5beb08ee3b49aff05696a7acb38903b9",
-    "inboxId": "e2de8cadf8ce5638c81c0ec6bcc22490f25d341c82e9e849773a42ed08b08451"
+    "inboxId": "e2de8cadf8ce5638c81c0ec6bcc22490f25d341c82e9e849773a42ed08b08451",
+    "installations": 2
   },
   {
     "accountAddress": "0x43673532fab93333f793bfd72c71226f0f2e7a8f",
     "walletKey": "0x7eab0c50cd7548af94090d5f60d1b473ee9d36d10a11d6e03ed1c253f0c47226",
     "dbEncryptionKey": "d81236eab39564764affb28ac3cd44a3042658405185243e12ac5e54ccf270ed",
-    "inboxId": "3d289370f899e8bb663d5b3c5bf125c4391c6e9cc0a98afa75eb5a4e4061a071"
+    "inboxId": "3d289370f899e8bb663d5b3c5bf125c4391c6e9cc0a98afa75eb5a4e4061a071",
+    "installations": 2
   },
   {
     "accountAddress": "0x4e1da18604113db78ab582d3a2f65bf6d8c1ce60",
     "walletKey": "0x37868ed179a328efd7a7ea845ab45ada129f5cc082f88a18b8f8afbd313f21d2",
     "dbEncryptionKey": "046128742a3022498effa4dd19658e9a4c93b22ec069bebb96a5ea77a00eb93a",
-    "inboxId": "dc6ece50803b3b314d1bde48774abe5d9665ab9e12047f94360429593116d068"
+    "inboxId": "dc6ece50803b3b314d1bde48774abe5d9665ab9e12047f94360429593116d068",
+    "installations": 2
   },
   {
     "accountAddress": "0x0134180a060eb0b756cdc0baf243c3b265c165cf",
     "walletKey": "0x851643caa737f94c1dd69c2e884f037e6562990e77ea4ac46d3316a001dc7be2",
     "dbEncryptionKey": "abbcca4706f99e4919ec74fe43bfa45dbbcc0ae4ca8a89b1a3940dfe378cf5ef",
-    "inboxId": "ebe7a84b5818440e243afde7fa4eb80a8aee7e6c44994667216f1a4765d5993b"
+    "inboxId": "ebe7a84b5818440e243afde7fa4eb80a8aee7e6c44994667216f1a4765d5993b",
+    "installations": 2
   },
   {
     "accountAddress": "0x6ec3e55d9372108939519a24141e8fa27414eba0",
     "walletKey": "0x5066fb27482f5d962ae6adb8d4acc51a1debd444ad8db582952c963e0fd70bce",
     "dbEncryptionKey": "99b6c1d8b5e2fde4cbb3edff161f8318a261176edf142e733d4b45ee7951f435",
-    "inboxId": "7e33fe6c470a645410c94ad724b359628a6c54411aa12e2c12fbe0e992c791f7"
+    "inboxId": "7e33fe6c470a645410c94ad724b359628a6c54411aa12e2c12fbe0e992c791f7",
+    "installations": 2
   },
   {
     "accountAddress": "0x16923b821e7af2fdc3e93d380bfe0e87bbc9b994",
     "walletKey": "0x54c988e1816a30bd5fe3377e31d30bd07b1c4fc28292dd661bcedd060b59238c",
     "dbEncryptionKey": "e2fbff36b66a820a8da11603588dba25e6a18713e731d17adc18333750b6f2aa",
-    "inboxId": "9aba16cf1e8b6800dd66b182927eaa801361e33e2d11a43841ece7c232cc6201"
+    "inboxId": "9aba16cf1e8b6800dd66b182927eaa801361e33e2d11a43841ece7c232cc6201",
+    "installations": 2
   },
   {
     "accountAddress": "0x45492003ae73984589ef63e94be8ab230cc625f5",
     "walletKey": "0x2969e77755b77b2a17b08cdaa62728f2492c44c58cc3cf546c917a7836e4eee0",
     "dbEncryptionKey": "7919cdd7da97a78f9e507f7a2c6cdb1be6ddd0da138c663d14898ab0073e9932",
-    "inboxId": "e7b5513d262271b78779d201ab898bab5c6522fdee36cccef8eb0d2c6dcf70c8"
+    "inboxId": "e7b5513d262271b78779d201ab898bab5c6522fdee36cccef8eb0d2c6dcf70c8",
+    "installations": 2
   },
   {
     "accountAddress": "0x084af43124b5e5d8d0bc6802c62955edfdb1d662",
     "walletKey": "0x709c9141971569d6438059e8ac2a59a5aab64b81164096af8f90e2e4f24a7614",
     "dbEncryptionKey": "1507aaf0b75bdcba86221c399af5caf8f74a3b591d9b36751fbaff9cfc1b2069",
-    "inboxId": "eb39750c9a7451d234e9c142417d2a02d55bf216ae4755715546b28e1e2be1b8"
+    "inboxId": "eb39750c9a7451d234e9c142417d2a02d55bf216ae4755715546b28e1e2be1b8",
+    "installations": 2
   },
   {
     "accountAddress": "0x3ac7e239fa3e660ae93c960e0b67dcc608dd98df",
     "walletKey": "0xaca65e2e53c756ad49947b213b34f8081e2146a7e7baaebea3f048fc2f07ba3d",
     "dbEncryptionKey": "1f77076f6ac58b3a01335ca1f0794e992c7090ec3709f0f3390dec2b5d8e4811",
-    "inboxId": "aa9295dffd8cca0a66c366ec4ed58b7cb4a26130b6d3530acf4f17b103f79b91"
+    "inboxId": "aa9295dffd8cca0a66c366ec4ed58b7cb4a26130b6d3530acf4f17b103f79b91",
+    "installations": 2
   },
   {
     "accountAddress": "0x4ba3f0b2054021121c57cd2fdea0d02d5099602f",
     "walletKey": "0x2416f083aba32d54bf578032e8cee9f29bbc2e7b0a8e894cc8ef4d09f0a25354",
     "dbEncryptionKey": "05148a715b07e50dc84bddc080217f746c92fdab41dafc81d304196126d1565b",
-    "inboxId": "b1516a8420138ff552aeab8158e56d21927d929ab9a6cccd37bf28f5c2dc8d47"
+    "inboxId": "b1516a8420138ff552aeab8158e56d21927d929ab9a6cccd37bf28f5c2dc8d47",
+    "installations": 2
   },
   {
     "accountAddress": "0x4906c2db71bc2a2eac5cb03ff35b5d33ad3bcb02",
     "walletKey": "0x235fda26f2d8871cb9c83c12bdf94e8c94c50813c1df9f1fb9ff65565b493e92",
     "dbEncryptionKey": "5e49857a5e2a96470e3ca1cb57f9376b1d4aec5c15825a3ebabd879b1e7591f5",
-    "inboxId": "1b238d8ffc61610f13d1590aa0d8d2338cd614c10fddb26014632cab2b966415"
+    "inboxId": "1b238d8ffc61610f13d1590aa0d8d2338cd614c10fddb26014632cab2b966415",
+    "installations": 2
   },
   {
     "accountAddress": "0x02666a89fcffd6831d3b217ef323967d0ff62132",
     "walletKey": "0xed776da22f689713d2eff0361ea799bde90f22e2884c8dcd21d7dd507a3ccee7",
     "dbEncryptionKey": "acd3357d42b8492324c201d69e753c5e0c8973cb3f39a10c58bfea8925f36dfd",
-    "inboxId": "38830d6b7c45a2f9a6d3ded20f5bbbd23946ca41877f80a0d207637db9ae7be7"
+    "inboxId": "38830d6b7c45a2f9a6d3ded20f5bbbd23946ca41877f80a0d207637db9ae7be7",
+    "installations": 2
   },
   {
     "accountAddress": "0x920892311f941796e35765a241f27fb6f8af0cf8",
     "walletKey": "0x8c4d9001588db54beafe76514b115065171572d2210503cffb6deb03e0f20088",
     "dbEncryptionKey": "3924019ed7b9fde2a5c54a7af7fac1f5d1c162fe249bd27a8fadc4576f844115",
-    "inboxId": "08004d3c7c82fb48b02314b1c84d7e5688e57a75a01231ddd6c2ebf2810a5b23"
+    "inboxId": "08004d3c7c82fb48b02314b1c84d7e5688e57a75a01231ddd6c2ebf2810a5b23",
+    "installations": 2
   },
   {
     "accountAddress": "0x5eac3cc5fca4ed090c33cdafda9f798e81028c8c",
     "walletKey": "0xf05a13e85fceef1e0a3c7491e00620776c4aa53d8d82e265576ec1fe4da165b8",
     "dbEncryptionKey": "9096e4079477da4dc664e8d9201c7edfa165ef9a3febc073b4b88126e46c6ba5",
-    "inboxId": "05f91bda4a72e972a54d37459670731e84e7d8d4d7b99e100dde7894bd3228b0"
+    "inboxId": "05f91bda4a72e972a54d37459670731e84e7d8d4d7b99e100dde7894bd3228b0",
+    "installations": 2
   },
   {
     "accountAddress": "0xc1c69bf53d078fc12eb82f503e1e2bf84b4960fd",
     "walletKey": "0x3ab42041abfb66808e3d75f89b08a964e215f604ac6ba2ec1501169a885468c3",
     "dbEncryptionKey": "bd6f561ea2cf74b6f296d004001b82f2f6831f917399c0f35fdbe85d20a6c8c0",
-    "inboxId": "4512e2a52de3847d0e298fbb0463b16b3d080f9f4d1999a2f7bfcaf7542a8f02"
+    "inboxId": "4512e2a52de3847d0e298fbb0463b16b3d080f9f4d1999a2f7bfcaf7542a8f02",
+    "installations": 2
   },
   {
     "accountAddress": "0x977a29bf2fe591f9b124ccb596b4ab00bc2dc4de",
     "walletKey": "0x72dde9d3e20be8459b254dd1b84dd50db3c254675f7e6010551e0245c47290e2",
     "dbEncryptionKey": "056ce62fcc0b2f9b08a2ed687a662ecea7ea89d5eaa67f8cb1df3de6c40da9a1",
-    "inboxId": "692136ce3fabf871f4bb67b704b943f3dcab6338879090cea8468ca648e8c722"
+    "inboxId": "692136ce3fabf871f4bb67b704b943f3dcab6338879090cea8468ca648e8c722",
+    "installations": 2
   },
   {
     "accountAddress": "0xc59430a59bc9681428133f9e5e8ba59310d6d8fb",
     "walletKey": "0x5adc71bc7120ec99707617923ebf7379a7b80557707696c37b87e9fd0cf157e6",
     "dbEncryptionKey": "132bf43a92696971678f1c49db7509084f7215a0e021ff39785a8d7bc5e65ccf",
-    "inboxId": "c7cedc9721a73d39aacce79b11cfdc3d57299b4c9c50340f05dcdc4b8d20d5d8"
+    "inboxId": "c7cedc9721a73d39aacce79b11cfdc3d57299b4c9c50340f05dcdc4b8d20d5d8",
+    "installations": 2
   },
   {
     "accountAddress": "0xe166a99461f5cde03edc832fb841eb48f1b7c95f",
     "walletKey": "0xe9dcb2d4a0d45fb1d8bdfe0566d02ce10e0f6809e4cc2ed46e14af5a8050c7aa",
     "dbEncryptionKey": "7ab8b8ec21c5614a9deddd180ee21089cf2df17082d148680d63a3d40f763832",
-    "inboxId": "40c7bea64d4a1c55c4e78c8fb216139d4d1db0d2754029608417dfd50c34a75a"
+    "inboxId": "40c7bea64d4a1c55c4e78c8fb216139d4d1db0d2754029608417dfd50c34a75a",
+    "installations": 2
   },
   {
     "accountAddress": "0xfdb7687b3aaeaa0a92d7ccc57fd5976d20ca1e8c",
     "walletKey": "0xec4afb755d9815e4a5b7350fe6897843c35a32923af46fbdd7e7a2acc3c40bec",
     "dbEncryptionKey": "70c31b8b8902e2f5aee84cf7415ea056b979e15b9e3b21fb42667015a9d74c21",
-    "inboxId": "269868e4f3822ca6060a23e7753fd4fea17de026e7f1b41de6d342246062aac2"
+    "inboxId": "269868e4f3822ca6060a23e7753fd4fea17de026e7f1b41de6d342246062aac2",
+    "installations": 2
   },
   {
     "accountAddress": "0x2000774cebb4431251c09554d0c305bafcf371f7",
     "walletKey": "0x79675cbaad4fce95f9be154e9e8004b7dcbc426fddcb1ae1c188022360eb5046",
     "dbEncryptionKey": "fcbe43a1e0c6bfdbbfe7b32620a73e4e1c6c3251022241b863f35e11ba67bb24",
-    "inboxId": "04d1111e510aa1e2adff1220f52f538a4edb4d2d555035616b34dadb3842c277"
+    "inboxId": "04d1111e510aa1e2adff1220f52f538a4edb4d2d555035616b34dadb3842c277",
+    "installations": 2
   },
   {
     "accountAddress": "0xe35e6b0cf39aacef401547e024671595ade7e807",
     "walletKey": "0x6b8acaf073ae4a943217a7f0164993dfcc11a0cc73436c1f070e14e4450461a6",
     "dbEncryptionKey": "70494be9489b4e5a10d05749573928381904fe5a3585128172000184fe21568c",
-    "inboxId": "40113e7ae5cc167ae29f8ae00c51f10366407ebdbd57ead8ac69592a5f5a47ab"
+    "inboxId": "40113e7ae5cc167ae29f8ae00c51f10366407ebdbd57ead8ac69592a5f5a47ab",
+    "installations": 2
   },
   {
     "accountAddress": "0x791952d8fcd6f3b06527c289612778c812df05d4",
     "walletKey": "0x418b3496ea4f81a0bae59106059f6e79a9b7f1d87bb6f878cc34347f02b6bc71",
     "dbEncryptionKey": "25f267909f6d165fdc59219117699507d4392da990e627098764dfc32124b3c2",
-    "inboxId": "4959b8b51ea4777930311ae73e0aa13c87e42fc412270da5f868decb0d838c29"
+    "inboxId": "4959b8b51ea4777930311ae73e0aa13c87e42fc412270da5f868decb0d838c29",
+    "installations": 2
   },
   {
     "accountAddress": "0x76d8c35297ca2a3163862fbed1fb06d82af7a5fb",
     "walletKey": "0x6541ae27ed93266d0a65663a73d27ca655f11349d3ea36406fd799375174d00e",
     "dbEncryptionKey": "f9442451eecb7c2ef010a9627cf7d991fcd3ee357be8ae67b7f389c52a470af8",
-    "inboxId": "fce305c744f3857be626f55402e9c776cee61bdf918f56c311512b0605b0d323"
+    "inboxId": "fce305c744f3857be626f55402e9c776cee61bdf918f56c311512b0605b0d323",
+    "installations": 2
   },
   {
     "accountAddress": "0xffad0effc475590d97b6da04df205e4c1b72cd16",
     "walletKey": "0xabda656e588cde166271d6c5a39de76a23807ae339bfdc3b58f984026f188877",
     "dbEncryptionKey": "eeb5ddfe308f7a0b53d3a37ce45ca09b1cff9e9762b6850e6de8c8d2b176cb4d",
-    "inboxId": "9de9250937407b1552e12c9a8259d23f1fa538a9760a93d9272cc8e0752a0150"
+    "inboxId": "9de9250937407b1552e12c9a8259d23f1fa538a9760a93d9272cc8e0752a0150",
+    "installations": 2
   },
   {
     "accountAddress": "0x9b3ac871c910209818bf123b6cd0fa491fdb9211",
     "walletKey": "0xc0d3ac269304221cc9826f33c12c3a09ae684f43db0b6c4affb7cdc10d7166b2",
     "dbEncryptionKey": "b707135a165b08a1699c6788187c83c28baf68b65c3639855b4d7871a45abbe8",
-    "inboxId": "41155506348ae57f7ac9b1db5c5f8d2ed6dc64c7e579b7e4e28de504b1951c1b"
+    "inboxId": "41155506348ae57f7ac9b1db5c5f8d2ed6dc64c7e579b7e4e28de504b1951c1b",
+    "installations": 2
   },
   {
     "accountAddress": "0x8bbdb33fd412513a7043e5cd78a989608046aa1a",
     "walletKey": "0x6f4f8a8f83dcaae0396c14508a456e53c1ca89057ddda2b2e85a24e3e6b9023f",
     "dbEncryptionKey": "5509e460bc83ca86face0122af1b1dc96b84901a8676fac3ee8c51312e5d2a51",
-    "inboxId": "ab09e95b4414f7841bfef0f995c9430edeb9352425d0b148b8540e84b2c9b525"
+    "inboxId": "ab09e95b4414f7841bfef0f995c9430edeb9352425d0b148b8540e84b2c9b525",
+    "installations": 2
   },
   {
     "accountAddress": "0x8d7dd85d6c2247d362b5fde5b483a70e088105a9",
     "walletKey": "0xc04f1b3441554f886150df2344eddf1b910aaf4276a5f26ee7c8166f07188db1",
     "dbEncryptionKey": "122ae032ecdb0cbd4f8b4c0cf7f05d16f6061943dd15753706c3b7d736927f1c",
-    "inboxId": "5c6893f74e78ed544b2ea08b57a4216224a6a1f25258d8b61896fddbcbb5f9c7"
+    "inboxId": "5c6893f74e78ed544b2ea08b57a4216224a6a1f25258d8b61896fddbcbb5f9c7",
+    "installations": 2
   },
   {
     "accountAddress": "0x145b2acff649dae09c7433b3af2f979c33d340c7",
     "walletKey": "0xba0c33d1a71ef8a5a09e060306db7e5add96ef72a98dc05cc90e963291729d10",
     "dbEncryptionKey": "33379f1c35b4881254aed6af2e567a44c1e6810b566b9471bdd845d5ef201e3c",
-    "inboxId": "7655e71f8c68dabd32d6d205412a3d6f7117744a2b2dd960138bd833ac53be25"
+    "inboxId": "7655e71f8c68dabd32d6d205412a3d6f7117744a2b2dd960138bd833ac53be25",
+    "installations": 2
   },
   {
     "accountAddress": "0x120c7433bd312e1d669fcc670bbcbb0313771439",
     "walletKey": "0xfaf3c0116ac0ae0c695b551680e41f97206e83809d6a735baebbb2bcc58951dc",
     "dbEncryptionKey": "ff9248fd20d29637f86d96c6b1c82a9a028bd82c393a6c693a009e095224f12a",
-    "inboxId": "c1dadad97678016529dd81e28f0679a3f13f349672239c9f4aa86b7144edb0df"
+    "inboxId": "c1dadad97678016529dd81e28f0679a3f13f349672239c9f4aa86b7144edb0df",
+    "installations": 2
   },
   {
     "accountAddress": "0x070a2461da48685611cf2aa14ba292f32f094d79",
     "walletKey": "0x6e33c32983d96a12680d7318c0e964c5558babe3a92e86b0d49442f1fa083c0a",
     "dbEncryptionKey": "ab8835acb8eb8a6d93754e304d0792ffe22ebce84110b608b6c2edaefdb097d9",
-    "inboxId": "7fe1058e348977897db6449df58b7efc388dfa9f088429d305535e8c974b1279"
+    "inboxId": "7fe1058e348977897db6449df58b7efc388dfa9f088429d305535e8c974b1279",
+    "installations": 2
   },
   {
     "accountAddress": "0xa8d6349c58975d05384dc38fea55eaacf98df5b4",
     "walletKey": "0x498759465d44dc781e4547d36d9805dd0bb9626e3f15e92004a851adee650f54",
     "dbEncryptionKey": "8d020535d3f204690d6dd3a6ad48f709828a350b9a5389428203013b793e44f1",
-    "inboxId": "3573eeb7840309ce095c1c0a4eb872aea443b8f30463a4e774e5b80e74e9777c"
+    "inboxId": "3573eeb7840309ce095c1c0a4eb872aea443b8f30463a4e774e5b80e74e9777c",
+    "installations": 2
   },
   {
     "accountAddress": "0xae8091566d0227a8319cb6a805eac321a2a77f21",
     "walletKey": "0xb8678f6e0a8da1367f3da26e45fd6637d11a9eaa69124f8edadb07099abf0edf",
     "dbEncryptionKey": "33afeb188df4e940bc7ffd773bb8e91882afd840126d17628b274f4b5c074dd9",
-    "inboxId": "740511fd464273669290eedeb091450980bce2b9ea32e08f096b53fa38752a88"
+    "inboxId": "740511fd464273669290eedeb091450980bce2b9ea32e08f096b53fa38752a88",
+    "installations": 2
   },
   {
     "accountAddress": "0xe30f2618b21900ff666aacfb2f9c0e2abb080e9d",
     "walletKey": "0xe4c9ba8f505ee0b6185190e2be9584af9e2699302d812ba3bccb81a8878b9ce9",
     "dbEncryptionKey": "5ba167abbc73f657da1f24e9b4f48784280cfcdec029a832cb7b954b81dfb77d",
-    "inboxId": "70dfd8915a68bae280920585ce0fde6dc0f6bdb0966ac642fc050ff7298cb389"
+    "inboxId": "70dfd8915a68bae280920585ce0fde6dc0f6bdb0966ac642fc050ff7298cb389",
+    "installations": 2
   },
   {
     "accountAddress": "0x733023c3c9efddaa4e01a25f61bc9e90d9be8415",
     "walletKey": "0x67de6014f1fcd9ffd92093c27e1e6f8ee8565cd7139d26ff6751f18ebaf78d69",
     "dbEncryptionKey": "1c847b7cd1bca2736a50021c71cfb9a65b1892764151e3aada5362aac2f378a4",
-    "inboxId": "640b75b40293e5b8f2a5ca534d96bb5ba6c5c131da898c35d7f4b979aa96a270"
+    "inboxId": "640b75b40293e5b8f2a5ca534d96bb5ba6c5c131da898c35d7f4b979aa96a270",
+    "installations": 2
   },
   {
     "accountAddress": "0xec64f8903052742a8a4bdfb92a018a9b50fc63fa",
     "walletKey": "0x086912eb751a8a05f46b2643de69ec56e8cef5ea91ed28adef08bb9de1abbb45",
     "dbEncryptionKey": "37208dfbfba8812ff3d7d8296b350078bda123cfc3e987b7e7799054e4a7dc77",
-    "inboxId": "9b4d4660ec6ca4ae32106f04bcc283260de74d25ee69747f8584b56766b660ed"
+    "inboxId": "9b4d4660ec6ca4ae32106f04bcc283260de74d25ee69747f8584b56766b660ed",
+    "installations": 2
   },
   {
     "accountAddress": "0xdf90aed5208037ce405beccb7ecec97288588a16",
     "walletKey": "0xa4bc19a03f3b9ac7a81a29c8f21b8fc81ef4a1a8e9f48709008d1c23de92f004",
     "dbEncryptionKey": "28d6b159b82fc9a671af30674b57bef1b47d8b906d7b2bc6914f2893d9bbe634",
-    "inboxId": "55f49bc8268c5f59f02799d2d7c0e2e8f7dc06a5ea25b942ddbba0d11fb1b7e0"
+    "inboxId": "55f49bc8268c5f59f02799d2d7c0e2e8f7dc06a5ea25b942ddbba0d11fb1b7e0",
+    "installations": 2
   },
   {
     "accountAddress": "0xf88c630e757732c86f3c8a9e474ba99434fd4bad",
     "walletKey": "0x3c93244af7137fb2225dbb6fb7874e0a83774c1bb81b5a759600e313ffe519a0",
     "dbEncryptionKey": "019b4faf793f1b79448754fda3db632596293cd58a2d44314c79e5d7ae44213f",
-    "inboxId": "33c577257f9f05e40faccdf35756fefc4f769d1ee5b383b3c257686ceea196be"
+    "inboxId": "33c577257f9f05e40faccdf35756fefc4f769d1ee5b383b3c257686ceea196be",
+    "installations": 2
   },
   {
     "accountAddress": "0xe15b0b6bcc7f8f4d552d3b472564d6866ec0e39c",
     "walletKey": "0x66677609be4a39f190f0c66e37d193a5bd35b83825a3bcfedb04c729c036a3fc",
     "dbEncryptionKey": "3b6710944099e45408df458e028890884be0a868ce3f72cd2df292725e6c8ec2",
-    "inboxId": "e751aea64ef7e6137a081226c842f46e04b7cc93dc1d0d8e38e1e66fdfb8d719"
+    "inboxId": "e751aea64ef7e6137a081226c842f46e04b7cc93dc1d0d8e38e1e66fdfb8d719",
+    "installations": 2
   },
   {
     "accountAddress": "0x195cc62641c68a406027630357a02593c2bb3600",
     "walletKey": "0x00885115eef5c4e6c375d531f6356e3b93c2844c5ebaf061224f9b2c0856091a",
     "dbEncryptionKey": "560f974e94469a5253a49d19f94bbbf70c788494859b6b9caf2f06e8a378f935",
-    "inboxId": "899e4e81109b167a6bf1cc467facf2f3d131e10267fb88bdf5d495914f95b54a"
+    "inboxId": "899e4e81109b167a6bf1cc467facf2f3d131e10267fb88bdf5d495914f95b54a",
+    "installations": 2
   },
   {
     "accountAddress": "0xae49b5644918c93d860f9111c572ca71d14e98f6",
     "walletKey": "0xf80864518ebeee05b6de789ef662e5139295ed1fe486d4102cbb6008b270f0df",
     "dbEncryptionKey": "be129bc956b380c060881ea08e7820086948bbce36812069d2ff01b5f947b1f2",
-    "inboxId": "c0577656558de1581c9ae7241e3623ad081032e79e31ef626de451659b09384c"
+    "inboxId": "c0577656558de1581c9ae7241e3623ad081032e79e31ef626de451659b09384c",
+    "installations": 2
   },
   {
     "accountAddress": "0x8b7b353672c56a6e4418fe90e79da21112e61d64",
     "walletKey": "0x3a1ba5b733e3252fff87ecd5a8f9708c9d34d6a9f542dfee7c448115dc120747",
     "dbEncryptionKey": "2c2c8e947cfc2f2a286335b333eab400c4ecee06ca8ab5108f89aa4399dd7e43",
-    "inboxId": "306ff3e3d8099392e6e87335eedc7853d2b0263a7233e1e8eb435352c5f95ffe"
+    "inboxId": "306ff3e3d8099392e6e87335eedc7853d2b0263a7233e1e8eb435352c5f95ffe",
+    "installations": 2
   },
   {
     "accountAddress": "0xb4d30ebc3544e0ea3a05e478ace9984c100f6074",
     "walletKey": "0x55dfeeab2387939a4e1ef6a3b13d646459227af23688f2c59867c364b3ad3657",
     "dbEncryptionKey": "494bb32bf8ec37e8f0e9fe5ffd0a146dfc1c9f3069e2b8f3bd0be2fea61746fd",
-    "inboxId": "d4b5b0547871c721ef2ffb5478732d65712a2413b1de3d41601497b72822c089"
+    "inboxId": "d4b5b0547871c721ef2ffb5478732d65712a2413b1de3d41601497b72822c089",
+    "installations": 2
   },
   {
     "accountAddress": "0xdfbbea10312b7bc7dfb7cf0121c52d68a8d67f40",
     "walletKey": "0x514c49aba3632c9683a97fde77cf3f12db0f75dc377ab4fbcee7566757cc6a14",
     "dbEncryptionKey": "9b1f51f386da26d471349bc70a9f9f2957688e146046e1aa352c7391a11701a8",
-    "inboxId": "39eeab33a93eaa53cf09d1fa122fabef684310aeb1e3cde1555f71bd4d0f0f86"
+    "inboxId": "39eeab33a93eaa53cf09d1fa122fabef684310aeb1e3cde1555f71bd4d0f0f86",
+    "installations": 2
   },
   {
     "accountAddress": "0xc9f2796899c48c39e0884d35c803535170e07c88",
     "walletKey": "0x28bfa9193ad1acb9360f263d0074d3529202874f0aae56b593b14a71e7ee6c0c",
     "dbEncryptionKey": "b0e56f88859316eda9b1d83eeaf419a6513f7d886b331ff5edffe110686ed047",
-    "inboxId": "e30c60bdf905234fca590fd6eeee78f4ae7a4dd89030262baa9b35d9a07d2117"
+    "inboxId": "e30c60bdf905234fca590fd6eeee78f4ae7a4dd89030262baa9b35d9a07d2117",
+    "installations": 2
   },
   {
     "accountAddress": "0x286f626ba201c3101d61ba5a06ae40a189f2c887",
     "walletKey": "0x24cfaebb0fa7ae82a03adaf50d507dc1f31ac5ab15fda2cd0706196a5a630045",
     "dbEncryptionKey": "0ba0cd98a3119ae1a22eb6c0a4a1b03b082e575efc12e93b9e187effc8ad57ab",
-    "inboxId": "449c0ab2cbc78bd859aace02ff9d5f4c108d4df7a8d10049f1db3ac70b007a55"
+    "inboxId": "449c0ab2cbc78bd859aace02ff9d5f4c108d4df7a8d10049f1db3ac70b007a55",
+    "installations": 2
   },
   {
     "accountAddress": "0xa399d09c939dc727741c9ec27ce27178abb414b1",
     "walletKey": "0x4478814a5eba6da6c2c57f8cfa232fde2a9162098c650a393cac9d7533721de6",
     "dbEncryptionKey": "a1f042ae822dd56fd41cbd4ef0416c2ced7cad7966f0766ecd35daecffb62791",
-    "inboxId": "14a2796033fb380ab2c8aff05db521576a63dcebe034ba7d6f5f7cce735aaeea"
+    "inboxId": "14a2796033fb380ab2c8aff05db521576a63dcebe034ba7d6f5f7cce735aaeea",
+    "installations": 2
   },
   {
     "accountAddress": "0x8933e9f5b071f175157811f9de82ca55f2ac8848",
     "walletKey": "0x01a1d3d297a4ec2c4fd85fb0ff86f220dc2936f60868c6128ade4ab91b2bd53f",
     "dbEncryptionKey": "7265f969cd0fd5ea1392c1613842a0f1f4221bf179a1f71b838fb43f073e9186",
-    "inboxId": "8c7b602a9883dec1e3782b6f48f3970825bdc775528d0b6a846009668e914ad2"
+    "inboxId": "8c7b602a9883dec1e3782b6f48f3970825bdc775528d0b6a846009668e914ad2",
+    "installations": 2
   },
   {
     "accountAddress": "0x4fcd93248a911a99d6a1d70967c113271ed1c534",
     "walletKey": "0x542ac1116d26d0e3af6556cbe1fd6afd392dfa6ae932fa15cf2a142e6ca2276c",
     "dbEncryptionKey": "82cf76806b65d6b0935a23aaf632d5a146f2c0fd175155f4546064afffc20934",
-    "inboxId": "d6fc9367b68bff7baa46e0121a12778c4f9e31c80eae44da71624f8bbf1ca597"
+    "inboxId": "d6fc9367b68bff7baa46e0121a12778c4f9e31c80eae44da71624f8bbf1ca597",
+    "installations": 2
   },
   {
     "accountAddress": "0x5a8fe953ba1f12d1110c80e7c9550a767671f36e",
     "walletKey": "0x1d54600c40ecceafd793f13e6bbde755ac4a48186dedc65c9636e887e06ebc85",
     "dbEncryptionKey": "81df74faba8324c3cea8efc9c12b772b421b0ac7319f11973f4ed946d7c70df6",
-    "inboxId": "5c33e1631e97986a2ddf421875ad4df6c60c901f313e81c3851da34a3ceac1d4"
+    "inboxId": "5c33e1631e97986a2ddf421875ad4df6c60c901f313e81c3851da34a3ceac1d4",
+    "installations": 2
   },
   {
     "accountAddress": "0x10bc346a31bcaf76c0cddf2ad6a32589b68aa4af",
     "walletKey": "0x72d22791daba5b36bc8f9752e7cd1e749d7b12730c0ecdb89e3765015e534329",
     "dbEncryptionKey": "ddd55009d41f3d784f43868794cbf09faa3eb275b63a6b92c2c769f40d2970d8",
-    "inboxId": "e86e80a4fd1b34eeef8487809abe66f2b2eca0211487cc257e3fb6009544766b"
+    "inboxId": "e86e80a4fd1b34eeef8487809abe66f2b2eca0211487cc257e3fb6009544766b",
+    "installations": 2
   },
   {
     "accountAddress": "0x4edc3d65fe57aa261541f92e853c83194f3ef312",
     "walletKey": "0x46a3f69e35ece69440c85a8321acd4003b2cda5724fd38285709c5d7688c80da",
     "dbEncryptionKey": "2e3a866973bd6cd8b35e070dfc9f908bc5d5253f7dd8e11fa59c9848ba141132",
-    "inboxId": "0e95dd2c29d3ec71044aef9628ca1c55b722bdac472418121bc7d74fa9a789b7"
+    "inboxId": "0e95dd2c29d3ec71044aef9628ca1c55b722bdac472418121bc7d74fa9a789b7",
+    "installations": 2
   },
   {
     "accountAddress": "0x1b34168bab7bdf83042bdfeffeeca9333d0671bd",
     "walletKey": "0x68990eb61f21c3674ba0604cb31b3a82d402839cdb8ca98f8a5913245b8341e0",
     "dbEncryptionKey": "9fd546bf65a74b08d8fc2700b293d8d0fc42829242fa1660d5bab0837cb108b9",
-    "inboxId": "a5c50050a04f85bde0252f06ea340d9d173f9d13c7384e1391959cf3923f714b"
+    "inboxId": "a5c50050a04f85bde0252f06ea340d9d173f9d13c7384e1391959cf3923f714b",
+    "installations": 2
   },
   {
     "accountAddress": "0x8247ed80285f2e6d29cc419faeba6f1b88165e4a",
     "walletKey": "0x240ee0577f599e539d0bdfbe2e3610fe470dc6c3d9ddb105a45dfb940f98c647",
     "dbEncryptionKey": "746c582ffd0efd9a38abbd331ea6926330c440491b08fd8cd189fcd493525da0",
-    "inboxId": "8ac0b5e5bcdf10cdfa00a66756cfeb78a560422cf618946d977cd721744e0d9d"
+    "inboxId": "8ac0b5e5bcdf10cdfa00a66756cfeb78a560422cf618946d977cd721744e0d9d",
+    "installations": 2
   },
   {
     "accountAddress": "0x375da798278fec1bf88810639522e95ae7e06207",
     "walletKey": "0x6ff889432d1ecc5c26fe0e7902969b451e6c7ce63aa12d1bef322f497bf9e8e0",
     "dbEncryptionKey": "1f5dc009ca122c25e7a0212669e80fb4c7714183a5e9b26c1cbb52bedfa1a8b7",
-    "inboxId": "9ef742ba86c55ea4bf95c7ed21dcce4bcb94a00f43690f6ffe9aeafc6a3e078d"
+    "inboxId": "9ef742ba86c55ea4bf95c7ed21dcce4bcb94a00f43690f6ffe9aeafc6a3e078d",
+    "installations": 2
   },
   {
     "accountAddress": "0xfbf0aed87e23353f826b8cc6a8f4fd8bc3b66f0e",
     "walletKey": "0x41901de1ff12b5fc1834d57bf964c2a8b377f392d1e13c1c916a6c6bcebfc828",
     "dbEncryptionKey": "f66cd0db6e09e7c7f99cb3a4cee93767303f5ae7f6a1ffbcb4e4a99cdb84d004",
-    "inboxId": "0401a399b4db508db0a9fe09fe92ed7f5fbc1a813baad4247a14281cabb5b3d1"
+    "inboxId": "0401a399b4db508db0a9fe09fe92ed7f5fbc1a813baad4247a14281cabb5b3d1",
+    "installations": 2
   },
   {
     "accountAddress": "0xbf93dc4a98a98ac23cdccc6ad73f90f89440cb63",
     "walletKey": "0x701a271c62785b3e4ff96ade58e8accb80a76aefa1c5427628804889c9b8902e",
     "dbEncryptionKey": "1f27a707d8c98d1363af3c73b27be9437369adb14e969d6a59ded8e9f7603766",
-    "inboxId": "fdabc08be83c197b4f81904ff6231bb7a4f5c6c8bf4efa9733874ea6cff8b9bc"
+    "inboxId": "fdabc08be83c197b4f81904ff6231bb7a4f5c6c8bf4efa9733874ea6cff8b9bc",
+    "installations": 2
   },
   {
     "accountAddress": "0x6d6dbd9d003e5625efc78d606886567db4fa8de2",
     "walletKey": "0xd6737c6245e3c3f4793f68f5cf678b1e71a03677dc6baf7a126c3585bddd3559",
     "dbEncryptionKey": "6ae11f4dbea7d29878bfdd78c4ea4d87cddce1a580d80bbd769732788173f74e",
-    "inboxId": "3dc9899312f47fbc6b621f375379c7ac9b89c48b61e9e7e2e40249ff658a7e0f"
+    "inboxId": "3dc9899312f47fbc6b621f375379c7ac9b89c48b61e9e7e2e40249ff658a7e0f",
+    "installations": 2
   },
   {
     "accountAddress": "0xb5614718ea2f356abab8bcdbce891e9a2203b382",
     "walletKey": "0xf91880c047a1ef776fd2cf8e83812f6dbc6218fa522c0b19c01c4d6240ff6d68",
     "dbEncryptionKey": "f0dbb8d450db8503c859a4a70a1c65328dd94b54a331a84e00d544f245a15c9f",
-    "inboxId": "14c62dec2551f260e5a4f64bba9feab70f73e33184f93e4507c39a2514f83621"
+    "inboxId": "14c62dec2551f260e5a4f64bba9feab70f73e33184f93e4507c39a2514f83621",
+    "installations": 2
   },
   {
     "accountAddress": "0x2a4754bef1e33be9f614cb506f62721d0ac59e5e",
     "walletKey": "0x643f331f0fad07a8fb02ca08017ef3999ea2d8c0ed4cee95604f9a766a0aad4d",
     "dbEncryptionKey": "3ef92511b533b12859687daac0bee3900215d97e278951f36168dd406c7f85a9",
-    "inboxId": "af5f8e0be8d51259eca34c4ccac8bccf111b6b6c6a2416165c5453a702ffea80"
+    "inboxId": "af5f8e0be8d51259eca34c4ccac8bccf111b6b6c6a2416165c5453a702ffea80",
+    "installations": 2
   },
   {
     "accountAddress": "0xc4cfae9e23e7151fe9a32fc3441e8335654f1724",
     "walletKey": "0x50213de5b9383c0f57c1fb327932d105fee5175261c0ce66500250817085a8e2",
     "dbEncryptionKey": "9c7db636b6f1aa17e9e39be1f9bd77c41e1ca36842f86ddb368ddf268a1d6aea",
-    "inboxId": "45efe6bda465476ee7d0d454406a8dec4104f806b5c4e189183cda1167218710"
+    "inboxId": "45efe6bda465476ee7d0d454406a8dec4104f806b5c4e189183cda1167218710",
+    "installations": 2
   },
   {
     "accountAddress": "0x0029ecef1b7b60bf0768eca8a3cd52138a911d27",
     "walletKey": "0x484a496a94b81ba16a829ad053a460595103eed65d3778382aef892b0f360bfb",
     "dbEncryptionKey": "47565e8e3ff11327588629202dc3870ba09bcd38d55794104f84ec41e254e4d5",
-    "inboxId": "6e85355662205967ab2465c87a1288edfd05b671e77f7ac65d8a8629e0768e0e"
+    "inboxId": "6e85355662205967ab2465c87a1288edfd05b671e77f7ac65d8a8629e0768e0e",
+    "installations": 2
   },
   {
     "accountAddress": "0xb5c78fc3b2e238a35fffc87fa804ecc278b7e64d",
     "walletKey": "0x5bed75c2196eb0f90913abbe07b96f8baa69a996d783ee689b74321af356421b",
     "dbEncryptionKey": "162b68fb2e06386796ccd19184dd671c9746d24fa9a2116c9329c1a7cc21cd3c",
-    "inboxId": "7275f907f45e22a38cc0369a4c81b3906d8c02233722c69f4cd5ee8e5512ae78"
+    "inboxId": "7275f907f45e22a38cc0369a4c81b3906d8c02233722c69f4cd5ee8e5512ae78",
+    "installations": 2
   },
   {
     "accountAddress": "0x857378015732b13a2f01fd108b7704c709838828",
     "walletKey": "0xf948c7a2e5bd1c36ff3c0587708fa9297c0ecbed3b0bf10fb16bb67402e51481",
     "dbEncryptionKey": "2970555c6f5fcd7094d59e207e212a28923f9aff51f74aac1b312ececd2f56ae",
-    "inboxId": "450e3f5480a1165dd49f2413f19aafeee2d412d885df7ef9ed9a411b948df9fd"
+    "inboxId": "450e3f5480a1165dd49f2413f19aafeee2d412d885df7ef9ed9a411b948df9fd",
+    "installations": 2
   },
   {
     "accountAddress": "0x1689b4a9d7065885872e73524dba52767e3251c9",
     "walletKey": "0x35a60ac4bc07faa12192530ddf9365c83fb9598f7118349e01d4f9aadbce421a",
     "dbEncryptionKey": "664c9f1fd2c06f3e9f0c939e3bb079aa37e8ee5d126a7e04f292609a94938a2d",
-    "inboxId": "68333fe79dbfe07a68d854199c651774abbdbd5b5bddc363b79a2d4cfa2e80e9"
+    "inboxId": "68333fe79dbfe07a68d854199c651774abbdbd5b5bddc363b79a2d4cfa2e80e9",
+    "installations": 2
   },
   {
     "accountAddress": "0xbd1e5a1a055c08b98f630f6595fdb6b0667b2094",
     "walletKey": "0xf7c7e7b06d7fc251465dd882c37f7a4c5163edeba244c600bbaf9daccbe60eb0",
     "dbEncryptionKey": "b11313f366c716125f30f5df1394d3177cebc289430d3fbd449eb68a3843fb2a",
-    "inboxId": "97f4d51d9b55d8af652a2669ffee04e445b508077612226d53b76090858c86fa"
+    "inboxId": "97f4d51d9b55d8af652a2669ffee04e445b508077612226d53b76090858c86fa",
+    "installations": 2
   },
   {
     "accountAddress": "0xd4f17e3ce459a7516a5dc30e87a08f9c68aa2dda",
     "walletKey": "0x7ed9550d853c4b57b9ad3408f72bc88fbf3b69df4972628e0fec6900b471d671",
     "dbEncryptionKey": "735f37ba5c991e69358403607dda2bcd34bb3761c5c5aebd9997a4e682f2b745",
-    "inboxId": "ace506b6c95468a8e05c822c778756c4cc157b44053d4b515d8720b54f9d8a4a"
+    "inboxId": "ace506b6c95468a8e05c822c778756c4cc157b44053d4b515d8720b54f9d8a4a",
+    "installations": 2
   },
   {
     "accountAddress": "0x05983677f8539f8be373633c77f6a5d509da1143",
     "walletKey": "0xb3eefc5a551989a2b6e726dd05e40347db79bfab8b7dde1a6593bad3f07a87a7",
     "dbEncryptionKey": "6df9e9702cf00b233b54ffa9bb609340a8afb8d647baf2b47357cf6203816cc8",
-    "inboxId": "4ecdce4c704a178c9a861b1065eceaa3c522afccca7db497c22b6e293d19f9ca"
+    "inboxId": "4ecdce4c704a178c9a861b1065eceaa3c522afccca7db497c22b6e293d19f9ca",
+    "installations": 2
   },
   {
     "accountAddress": "0x032fe02e9c80728b08c58f8e57f3a70d9a790521",
     "walletKey": "0x630488c5d33178f37ee90de66658fa693156895c19fde305821f5a747620061c",
     "dbEncryptionKey": "9c087ad182fabef7a6ea571c8162da738e51b8796ce35121e473fbd3972f53e1",
-    "inboxId": "eedc5d524f4f861f547d9c57e0fca32bc64cc23b0237e6f9dbcbabc72cbcb33f"
+    "inboxId": "eedc5d524f4f861f547d9c57e0fca32bc64cc23b0237e6f9dbcbabc72cbcb33f",
+    "installations": 2
   },
   {
     "accountAddress": "0x6cd2a66f2c073db73f8ed7b1a2e6e5db5fd7a403",
     "walletKey": "0xd79f7db4741c98dd9d7606f5c510783636efbffec1c3b1e891bf121abd757500",
     "dbEncryptionKey": "c6ee955a4d26e0757b97e2101a902e7d00ce9cd218ed664a076d577824427ff2",
-    "inboxId": "69d2c242c0b83cf0197b04355d2e6f26275b9b7711d8d37245e9e4b8e8f7d240"
+    "inboxId": "69d2c242c0b83cf0197b04355d2e6f26275b9b7711d8d37245e9e4b8e8f7d240",
+    "installations": 2
   },
   {
     "accountAddress": "0x6b2af82090e4df6afedac6b74477c1806216e98e",
     "walletKey": "0xd8788ca7cbf48d1aca2cdac6dde5fa5fdcc21e9a9bc8759dc3c848de5a02a4f9",
     "dbEncryptionKey": "2e4cc340e13532ffad4ba09028df52a74f4720235877e0b3f6687b8499ffdb8e",
-    "inboxId": "21a4ea45027f2780affe9dad949c944a3561bd9aaebbdf2081970238c66403a8"
+    "inboxId": "21a4ea45027f2780affe9dad949c944a3561bd9aaebbdf2081970238c66403a8",
+    "installations": 2
   },
   {
     "accountAddress": "0x983fc68aa8180b2ee17e2b6821c7fe7c0dc60564",
     "walletKey": "0xd52c56592330a68442e7d5124523b6103bd75b1db7f95b9bab4fffddb4562402",
     "dbEncryptionKey": "e72baa2c345ff4a10af689122f5fd7fc22260cf474ba323d876dc405cd0a54c6",
-    "inboxId": "cd2d4eb0555704807defd73fde4cc5fb3a0e0f0e15c199702d6b651e13d305bb"
+    "inboxId": "cd2d4eb0555704807defd73fde4cc5fb3a0e0f0e15c199702d6b651e13d305bb",
+    "installations": 2
   },
   {
     "accountAddress": "0x19c19ffcf3501f8c4f48ee6cd52bcfce8f973cf5",
     "walletKey": "0x055b19abde2de5441f96bde4fe8bd162074a267ac7b7d25cb58074190ec2dbd8",
     "dbEncryptionKey": "769ead4e3c0bcd7b2a3cc4272ba850ceea1c8b1ac61684706edf1179e2922fdf",
-    "inboxId": "b950aeaf2f897040f53ef15391a25501b8d69bbf69f5a87af1fc0ab5f7e26602"
+    "inboxId": "b950aeaf2f897040f53ef15391a25501b8d69bbf69f5a87af1fc0ab5f7e26602",
+    "installations": 2
   },
   {
     "accountAddress": "0xc7b5f8f26fe9b2a785c80844128a840a219cc6a6",
     "walletKey": "0x5f481323c31f995042776a306c3eb19ef8ca6242802b4d7607e472bd751d285c",
     "dbEncryptionKey": "9f57d4e36cae3e8d63c1b2cc0be0015c776950ad902a13b63ab70a6c05568be6",
-    "inboxId": "9c92d52e577f908d4e411a4d04e3230bc3ec8b06acd11c6b988497a325626e20"
+    "inboxId": "9c92d52e577f908d4e411a4d04e3230bc3ec8b06acd11c6b988497a325626e20",
+    "installations": 2
   },
   {
     "accountAddress": "0xb1741a75e57279b01322f097ff7439aa6293dae8",
     "walletKey": "0xee0a47a54968b96ad2b8310f38cf48c4a945d1c43bc9c2ceb92d5844974fd8b2",
     "dbEncryptionKey": "d00e6b90799c83f906b401da5ae4ba1127a1d5fa55e1640b51b9491fc209a896",
-    "inboxId": "9b4e0648d2603a46acbd34904b6b69bb44795a2729bdf0d2d4a6822c045a44c9"
+    "inboxId": "9b4e0648d2603a46acbd34904b6b69bb44795a2729bdf0d2d4a6822c045a44c9",
+    "installations": 2
   },
   {
     "accountAddress": "0x5bcc9e7bdd9b5eb28b129255961730184e6d3f69",
     "walletKey": "0xef1fb35892a292b7f9d9f2d5cc3caa723d9f2a9dac0855456a2e63f3655e0087",
     "dbEncryptionKey": "6067e9800c4bfb8b2fef46c715c096a001f262d3f06e828daa3afa3c13f7d0a3",
-    "inboxId": "e09309c64fe7914eb5a4f00b3963d4397f759d2ea6f87c18ab80254f6a4e4ec6"
+    "inboxId": "e09309c64fe7914eb5a4f00b3963d4397f759d2ea6f87c18ab80254f6a4e4ec6",
+    "installations": 2
   },
   {
     "accountAddress": "0x7a864a5540245c08b92e814177092ab1c24fb86e",
     "walletKey": "0xae641918b73509e27cc5ec278149876cdb0a2f785c223a004e23f5e38e0ef529",
     "dbEncryptionKey": "881a45e6cf9581758166b8eaa1619db633e20e9b4acaa9a50a71bccc137dcb55",
-    "inboxId": "5774bef27710d436da5099781a69bbcef682003206479ebec045ae94a1d8685e"
+    "inboxId": "5774bef27710d436da5099781a69bbcef682003206479ebec045ae94a1d8685e",
+    "installations": 2
   },
   {
     "accountAddress": "0x9a2cd4a7d57ce51d3f71bcc0556ecc4a2ee1fe17",
     "walletKey": "0xdb4fb03c6d87ede67927045088ed45b2b3ea269f23710c26bed512178fdbf4f2",
     "dbEncryptionKey": "c7f52178b175162c5ca450f8608e306b82ad095f1d3d76d3734f771cbf5d768b",
-    "inboxId": "932be8eaf4bca21568cd29b59a689202f66e883a71a193590a3adfc5997cb835"
+    "inboxId": "932be8eaf4bca21568cd29b59a689202f66e883a71a193590a3adfc5997cb835",
+    "installations": 2
   },
   {
     "accountAddress": "0x6ba7a563231353f13e32c6fc240a2cbbeb12e88c",
     "walletKey": "0x58fc6f25e06903b92a8acc2cac65b8e710d25a449043feb03adeef3a0ca5a6d8",
     "dbEncryptionKey": "12c0248bf685c48ba5cfdd86da315ee9532141fee6a0fe66d3b7cf1dc6677338",
-    "inboxId": "a9d88e2ec1ac5f53de0ee1ae62b9dc37e43f0a2f72c4a2296f5957dec5a5765b"
+    "inboxId": "a9d88e2ec1ac5f53de0ee1ae62b9dc37e43f0a2f72c4a2296f5957dec5a5765b",
+    "installations": 2
   },
   {
     "accountAddress": "0x26de466ea0649a9ca69da43f80b0d02c5af2dccd",
     "walletKey": "0xe81e130588dfaa0bbb28cff301b648bfaf0253c04d7553141a049056557815d9",
     "dbEncryptionKey": "24b7ce9e7cde2314ddda1b8073c5148fef0c591f869f3c8bc7cb50ca7847d083",
-    "inboxId": "6218e0ecd692252f4e1b4daa54661b061a35c04d407d102f9cbf046d71973e15"
+    "inboxId": "6218e0ecd692252f4e1b4daa54661b061a35c04d407d102f9cbf046d71973e15",
+    "installations": 2
   },
   {
     "accountAddress": "0xe34707b08424acf6a30c14742fed4affbc770dac",
     "walletKey": "0xcc0e3e1564fb40d354c0f9c0cf36258c81a19c5f97270f67cb1d2ac5e5dc4ad3",
     "dbEncryptionKey": "be82cd62fa6ae1e754d8cd62c66bbdbe260c8592fb4002532f80a7f148063331",
-    "inboxId": "997484720d3cacd39bc50acb3081f5f6ba4e7ace0bc013236ac36b54ddf62438"
+    "inboxId": "997484720d3cacd39bc50acb3081f5f6ba4e7ace0bc013236ac36b54ddf62438",
+    "installations": 2
   },
   {
     "accountAddress": "0xea04f03d14b98b04612ba84cc4d98be4f1cea919",
     "walletKey": "0xf7de73e64aee740bf7a1bb8df52fc4f0b7dc5837cf43408088be14535738ed4b",
     "dbEncryptionKey": "32c719469ea8331ec5b2ffe0f6060607f6faa852809a98df144b503a55617aa9",
-    "inboxId": "251a9feae0f1b3034cb6a3e5c0fe84ea0b88e50912e10cf51ed50befc82a51c9"
+    "inboxId": "251a9feae0f1b3034cb6a3e5c0fe84ea0b88e50912e10cf51ed50befc82a51c9",
+    "installations": 2
   },
   {
     "accountAddress": "0xa45eebd3f29ee5713a318bd3ea55fab347998373",
     "walletKey": "0x9c1fb31d5275d83b087d10b208733f496ac0fc7b693320fe1d036d6ce5bcf2b6",
     "dbEncryptionKey": "bdd126c1f27f34b06778d18fd0e05b65fbe5da0237c8582f4a0d76b0c8d7382f",
-    "inboxId": "68280285cb0f0fbc0eda0fab661593129c1b31854ad4b5938a878d51d4a14f32"
+    "inboxId": "68280285cb0f0fbc0eda0fab661593129c1b31854ad4b5938a878d51d4a14f32",
+    "installations": 2
   },
   {
     "accountAddress": "0xdb64c0a9b58a913aeb462a720df4cb7753334e04",
     "walletKey": "0x0f6e1b92f678f0086a65bbc222a1f21d8728c8184d1e7c9666fc17c50719e470",
     "dbEncryptionKey": "b9cedf4b67029fb2e43d5206133e4919d898f5c9626db613496cf74b0fb0027a",
-    "inboxId": "6ab62a33a31924e67a0d1c94571c665fa72565a4bd3a1377e8293e9e2329703f"
+    "inboxId": "6ab62a33a31924e67a0d1c94571c665fa72565a4bd3a1377e8293e9e2329703f",
+    "installations": 2
   },
   {
     "accountAddress": "0x784749137d6a586154b0f8222bd14437580d0d08",
     "walletKey": "0x05acbf1279c99ab702e6358926287dcb021f669a90c0774f5ea9eb2114d5972e",
     "dbEncryptionKey": "c3aaea8cfe10fec32e4e3c56ab54c71c2b04749ef0d835eb3ff6a1e0e67cbfd0",
-    "inboxId": "ef13e23c4748d58f9af88bb60fc0d2dd32266001f28e5de26c2dcb58efc9fa0d"
+    "inboxId": "ef13e23c4748d58f9af88bb60fc0d2dd32266001f28e5de26c2dcb58efc9fa0d",
+    "installations": 2
   },
   {
     "accountAddress": "0x85aa5683b1622d720b68f41d58213b2f8f6c51e6",
     "walletKey": "0xe98bd6703f4c20a19232fd707912173a44a6767113467674c62d6deccaf827ca",
     "dbEncryptionKey": "3dab3ff76865f6807e0a4e214b4683c628dde7d2a1e799f4fccd66d8a7464d49",
-    "inboxId": "d4d41f71cb51b1d87b9cdc443cb491b6b42d4961b3a70b6e166aa53509acc10e"
+    "inboxId": "d4d41f71cb51b1d87b9cdc443cb491b6b42d4961b3a70b6e166aa53509acc10e",
+    "installations": 2
   },
   {
     "accountAddress": "0x303ce3351b92adf9f93b7de87f35a2ff864c0ed4",
     "walletKey": "0xc8e65b85d74e68cb12a5884564ab8dd743d70cbb85c7338b045fd87c96f8c34a",
     "dbEncryptionKey": "eb13bd6f5ab94c60293770c271dae4dd387b494d053d2f87d395f94ce1cc1239",
-    "inboxId": "4ba00825dde67083b7376fabd3419a1d85bd8f448a1dbdf5ec3be1b4b9302ffa"
+    "inboxId": "4ba00825dde67083b7376fabd3419a1d85bd8f448a1dbdf5ec3be1b4b9302ffa",
+    "installations": 2
   },
   {
     "accountAddress": "0x66c958cdd0a0df46369b6d345f64d27964acebd9",
     "walletKey": "0x0e7bc699a45dd08ce0dd9a573349e6fc8be5ccbf4a20179e06da0ecb3a8b6640",
     "dbEncryptionKey": "797917cc18316badda00687955148d21e3e5a3e383ab12ff7f787eaf85e70a7a",
-    "inboxId": "6aea363b6dc6323aa282d941e1d861941a17491cc86acd8b7eb7ecc06dbf7e1b"
+    "inboxId": "6aea363b6dc6323aa282d941e1d861941a17491cc86acd8b7eb7ecc06dbf7e1b",
+    "installations": 2
   },
   {
     "accountAddress": "0x337a0506fb193e434da547b59076c85b33b58767",
     "walletKey": "0xf6c7c69e853cdbd5650dd2b2dbd01c5ce0934f9e08adbbb2b83f5e8dc45b7e83",
     "dbEncryptionKey": "9ebda0b516cd90b52d7f0e84220677dfd48fbfea98b60260847cec18e062f081",
-    "inboxId": "6907ddbba589df3fbff13e8687a2c7f8a3969162aba2b7e13165b9673f39221c"
+    "inboxId": "6907ddbba589df3fbff13e8687a2c7f8a3969162aba2b7e13165b9673f39221c",
+    "installations": 2
   },
   {
     "accountAddress": "0xe4b66243c9fc901a587203ef1893489581fe9c01",
     "walletKey": "0xff57e42dc8ccba7cf9b082531b06010f5cf7b77fb1875e451555839817149263",
     "dbEncryptionKey": "744f5484a41d1572692d5fd3bc81a2ab5cf8555f636d7498582bffc4527fdfd9",
-    "inboxId": "a018a2d55c5f3629c593b6db345e3051a39577a8ab88df50116bfe6fd2a097cd"
+    "inboxId": "a018a2d55c5f3629c593b6db345e3051a39577a8ab88df50116bfe6fd2a097cd",
+    "installations": 2
   },
   {
     "accountAddress": "0xbdd1eec41e8c2355929b932ac13156ce4214bb89",
     "walletKey": "0x109a8ad4fb45bdbbd04cb372febd9cc9232d8a8dca2dbc0bc64565e3c15d5c78",
     "dbEncryptionKey": "0ea73190fcafd1281275c18f661d929fd090fc1484a7711affea172d96a0faf9",
-    "inboxId": "dcad0daf72f44eceb21875d5697703d0bdf12e29921f7780f66de7fb92571a73"
+    "inboxId": "dcad0daf72f44eceb21875d5697703d0bdf12e29921f7780f66de7fb92571a73",
+    "installations": 2
   },
   {
     "accountAddress": "0x7f7883f8b5c6059275b4c2b009602739edbd466f",
     "walletKey": "0x4d99d0a35095f5585afe26a402ec9e61069e9360b4026b73d753e861a7f04a42",
     "dbEncryptionKey": "62584a321ad695078ef490eb417aad7cd4bf16f7c5e396344b76f1b05c5d4708",
-    "inboxId": "8df5a1a8c13138ef56e684ae10788b35e0e11f74e183206c43ca7ffe7dbba94d"
+    "inboxId": "8df5a1a8c13138ef56e684ae10788b35e0e11f74e183206c43ca7ffe7dbba94d",
+    "installations": 2
   },
   {
     "accountAddress": "0x7cec0f8b3f54a1288dc8f6891d87a5352bcd4a6c",
     "walletKey": "0x14594bcfa88f9b29d4ead051581c36bd43180238049b6e54533740f0c829fc52",
     "dbEncryptionKey": "7a16dcb508ba8826fa9c63f2990a8acd515100717410974e051d4f4cfb43ee72",
-    "inboxId": "5fa262b0f806ad3dbefce597e62a0b87a8ee24b519a3354e380a619f7a1a6979"
+    "inboxId": "5fa262b0f806ad3dbefce597e62a0b87a8ee24b519a3354e380a619f7a1a6979",
+    "installations": 2
   },
   {
     "accountAddress": "0x3954db1d2d18d719543f4181a0504d65c3553cbe",
     "walletKey": "0x8a61ca95ff4488b52c86e37ba97c34d85cc275a38fcbec04dbd55daef01533af",
     "dbEncryptionKey": "9e3f091d28ce4bff35d058445232e02bdcc1be3cdf7f89541e63287f07cc5b06",
-    "inboxId": "3baa7b65d98a0e603d05ffe6d22dc78e0ec9e6d86c4e354fcdfd9866a60aa546"
+    "inboxId": "3baa7b65d98a0e603d05ffe6d22dc78e0ec9e6d86c4e354fcdfd9866a60aa546",
+    "installations": 2
   },
   {
     "accountAddress": "0x9be996b0d4eea93c0d40f9c6ae97a2ee327bcfe8",
     "walletKey": "0xd162e66aa45eb6b5e16d9c229d4894a7d61ee508842913dc668350bd6bcb8919",
     "dbEncryptionKey": "1d26dfee19da5d28721a5b972e66366d94bdfb97dbc5d6d4a35d6a75867fee9c",
-    "inboxId": "93ecdb07d14e31381abc6a23111aa2d4e26ae31911489d7b23d9b7e15fc5ff4b"
+    "inboxId": "93ecdb07d14e31381abc6a23111aa2d4e26ae31911489d7b23d9b7e15fc5ff4b",
+    "installations": 2
   },
   {
     "accountAddress": "0xedd2ef38fa8106bb9fe8e2844643111de55ccc20",
     "walletKey": "0x3029d1e474baf61a68b4094e096cb0db15b8f8c2df7523d757fca77cf9797a52",
     "dbEncryptionKey": "0c1ab7acc462801e7edf6e2836cc3725497c043e207588790ceaab37e7403c1e",
-    "inboxId": "ed6ed52e6625d6b20cbed96de874cebd56dc119625501dafd588d2620eb71e39"
+    "inboxId": "ed6ed52e6625d6b20cbed96de874cebd56dc119625501dafd588d2620eb71e39",
+    "installations": 2
   },
   {
     "accountAddress": "0x574d1c8da9b665cae69a5206a1355ca9c4639ea9",
     "walletKey": "0x224af10b861f864f1642d558c0357d63c149dc6a141f94f5c0cbdef9871a2bed",
     "dbEncryptionKey": "baffe0da71b96e9bf53d7f7cad01b3384e35427aebef41c4b91ab9c5c9ac1868",
-    "inboxId": "97fc35b01fca007bc990b9c7e5dbbf0287e86a0a9e63801dba68ba9b721a38c6"
+    "inboxId": "97fc35b01fca007bc990b9c7e5dbbf0287e86a0a9e63801dba68ba9b721a38c6",
+    "installations": 2
   },
   {
     "accountAddress": "0xdf8daf3b04ff26af5bed8e7c27917c15e14e0efc",
     "walletKey": "0x7ec2df5e36866141ced1a60edea49ecff13a02a375c59a923f9efc239304a541",
     "dbEncryptionKey": "3ccb155bd4c89c92b384be1bbf39fd079b5005a6e72bc7b81ad578ab722fb318",
-    "inboxId": "f6bb40d6c7dc2573644941314aebf202d0cb4222afaef8ab7df09a9694e74112"
+    "inboxId": "f6bb40d6c7dc2573644941314aebf202d0cb4222afaef8ab7df09a9694e74112",
+    "installations": 2
   },
   {
     "accountAddress": "0xbe48e8e18e28eba179c1472d3ffe792fbe21c7a1",
     "walletKey": "0x1121b0dbae5d6c158bb93a11a167a43b7b4a8110ea2ad9510c3f92b49e181586",
     "dbEncryptionKey": "3f094c4616214c4e4a00bc8a6c6cabaf66c766eadc448026c01ac505be41018f",
-    "inboxId": "c7d6e4bbdc4ab2e1d4c05057a4ecb30115514b2fb9d5697f09872c8784ddf8c4"
+    "inboxId": "c7d6e4bbdc4ab2e1d4c05057a4ecb30115514b2fb9d5697f09872c8784ddf8c4",
+    "installations": 2
   },
   {
     "accountAddress": "0x8f4ea713f5c123aa4d640ca7ee7abe3698495425",
     "walletKey": "0x395edbdcbbb2642061149af78ab9c0fe1eeaf666ceb34045aa1c609d6cf221ee",
     "dbEncryptionKey": "1fa5b92c79c31892cc418fbc654a0834810b70dcdd1917ac25fc8623c29cd820",
-    "inboxId": "085a4f7f699ed7ca36b87f57039c750fecc587e4ebbc8fd573d16448fed6fc12"
+    "inboxId": "085a4f7f699ed7ca36b87f57039c750fecc587e4ebbc8fd573d16448fed6fc12",
+    "installations": 2
   },
   {
     "accountAddress": "0xdfabd157d6b76aa9014d13ee6da8934063e1b6d4",
     "walletKey": "0xb1426c6e9c986d6ffaeb7b90b2617d66063949632b60001905409579d72afb3b",
     "dbEncryptionKey": "2c397442b0703fc513d34088c6d9c8e8c537f149a7de68a760d4df61fe7b85d1",
-    "inboxId": "ede856537732739328fe97a6d877296d45a1e893402aac170c8a247105af3757"
+    "inboxId": "ede856537732739328fe97a6d877296d45a1e893402aac170c8a247105af3757",
+    "installations": 2
   },
   {
     "accountAddress": "0x1a98fa2d586b3f42e6ac2dfe4b5d9e93cef0b787",
     "walletKey": "0x30f0d5aa5b45d46cd61c5f23208b8d52fcba578bb50ba857226608eaede76f36",
     "dbEncryptionKey": "1b4083113e7f505279dc00133d817ed3ff52f2eadb9d61333272cf7a31624605",
-    "inboxId": "540777029568e8162b5e18e76867aae1e18fa0584f392c2b81aa85ec6d140756"
+    "inboxId": "540777029568e8162b5e18e76867aae1e18fa0584f392c2b81aa85ec6d140756",
+    "installations": 2
   },
   {
     "accountAddress": "0x7b8412a4ecb49c81dd8175c5f28d135349403461",
     "walletKey": "0x675db993913a4ffa8dc94421ca5c89ad25d221ac0a9245b493c908e7e3809f75",
     "dbEncryptionKey": "75b3097d86bfd3076746deafc4cf5c5ac9722e5528efd830c095f1906dddf438",
-    "inboxId": "c9aee1b7b939ca390c0e01f0e7973568ff6f51c75559e9994b299b6325189768"
+    "inboxId": "c9aee1b7b939ca390c0e01f0e7973568ff6f51c75559e9994b299b6325189768",
+    "installations": 2
   },
   {
     "accountAddress": "0x7b7fe1d18084e5ba1af610e2cf9177965376a510",
     "walletKey": "0x8c58acfb0e487d708fb45c636ef46b9fa00455d1fcfcd1b57b97b7cf8a70e1a0",
     "dbEncryptionKey": "a82d0b4c59888f79b09976e7e9732fd165125dfb9d4961fa87e3b89e0224e2ce",
-    "inboxId": "705775af9574111282f5a021e8765777a87dae13878cd0d30d2a71752b31e46c"
+    "inboxId": "705775af9574111282f5a021e8765777a87dae13878cd0d30d2a71752b31e46c",
+    "installations": 2
   },
   {
     "accountAddress": "0x7a62116ca44986cb1ea9534e488e84025364e32f",
     "walletKey": "0x7b298920bceaa52b9d85b52a0f5c785d0a50f4923c3a7827d6529442a513f914",
     "dbEncryptionKey": "a71d6bf261e0e1e6962e21e54e50c2a62ecd1b571fd893b2e90c6ae37b81c99a",
-    "inboxId": "b8de3794379608cfe70961484bbbf1e08c3772caeb4410e2e422a6bfef38a295"
+    "inboxId": "b8de3794379608cfe70961484bbbf1e08c3772caeb4410e2e422a6bfef38a295",
+    "installations": 2
   },
   {
     "accountAddress": "0x1218dd15fd912dc5bda11c1fe4e4d2b5621b67f1",
     "walletKey": "0x1bd3fbe2b7e0c1ffea259970e52c9e35d3309310315088b417c2c10ac4916a89",
     "dbEncryptionKey": "20fa23dc3c1f490dd9165e25747adb1e2db9cec3ebe19dec58387819a07bc63f",
-    "inboxId": "fd05dd1cfd5efeefb3bd22da1cc766c02794f3cddbe5a20f3f048c370754ed11"
+    "inboxId": "fd05dd1cfd5efeefb3bd22da1cc766c02794f3cddbe5a20f3f048c370754ed11",
+    "installations": 2
   },
   {
     "accountAddress": "0xd8a418ff907dd1e2cc0cdf18197ea9ecbd9e4f5b",
     "walletKey": "0x712e89a4fc83bff06467eca4640aaa339d92712bc6eb138f023c23c11cba1d37",
     "dbEncryptionKey": "725a08db4fd6da065c2c8514d294a08db26845b8742c841d59eda4156deaddfd",
-    "inboxId": "737ee326ac087086d43c9e522d9f55856eba2349d3dbd69ff1a5f577a3333eb9"
+    "inboxId": "737ee326ac087086d43c9e522d9f55856eba2349d3dbd69ff1a5f577a3333eb9",
+    "installations": 2
   },
   {
     "accountAddress": "0x226c2b282d3f777f8f1407680ff29793b7573928",
     "walletKey": "0x7016071cd91782f35f2b872258d9f4ca5a54a920d3fa46ebd8fc9c28cd10d712",
     "dbEncryptionKey": "eef32bca8494f11fd63fe7e795d7356f2d933665a26c01ce37740a99da335e67",
-    "inboxId": "c26cf6a259c806e1a333d2c92899703e078f19c84c294e3220324e375459a0c8"
+    "inboxId": "c26cf6a259c806e1a333d2c92899703e078f19c84c294e3220324e375459a0c8",
+    "installations": 2
   },
   {
     "accountAddress": "0x848d30494be6aece101336e78876f9fc4ae5f86e",
     "walletKey": "0xa191d0b71e703c9132f050f012eb59d8e226b49713eceac8d40c7492a82436c0",
     "dbEncryptionKey": "01c54b13f90b335e1bdcff8f75213fa5be733a349dd256fcf404c09a5e3f0052",
-    "inboxId": "9d63edc53f5012d1a87a0b667bec1a4ec565d8f343c6c2ba6223d02bec75558d"
+    "inboxId": "9d63edc53f5012d1a87a0b667bec1a4ec565d8f343c6c2ba6223d02bec75558d",
+    "installations": 2
   },
   {
     "accountAddress": "0xb9d8a2541339c56c034049813bceeab3c4fd4029",
     "walletKey": "0x4e6d3387183849cf26672c8e5f77ce8d908b358dfb2a135d6076e31c8dc820d4",
     "dbEncryptionKey": "0cf3e5a1696a17e14efaae1e9042b940d74d468e6529f22b092ce6fa85e5bdbf",
-    "inboxId": "f085f1a4682e916c269be405ee61285be9e7bace5ade9108e296254ef525a3d6"
+    "inboxId": "f085f1a4682e916c269be405ee61285be9e7bace5ade9108e296254ef525a3d6",
+    "installations": 2
   },
   {
     "accountAddress": "0x6b105c0433c807310b2ffe0fe9630d4a89e6f868",
     "walletKey": "0xc7720aa901626162a4c32c0d7818c563b129e30fd586a9094f06e76f39d75db1",
     "dbEncryptionKey": "66b5d7ec440fa49313ddde504d096d19c89990a6c84dfd1d98a57af4da6637be",
-    "inboxId": "3c22e814c8b9df23730a618be44e35e5f8df4a7daac3dbfaf4b6812b3cfef018"
+    "inboxId": "3c22e814c8b9df23730a618be44e35e5f8df4a7daac3dbfaf4b6812b3cfef018",
+    "installations": 2
   },
   {
     "accountAddress": "0xbb804f984dd5b91fc5a893ae1088b7e26b040dd7",
     "walletKey": "0xa7afab0f82f0e631649cd50893c022c2b34c0c8306697181b02c22665c6b2d58",
     "dbEncryptionKey": "13dea76701c49b80244fcbb8af7fc60f3073814332d30bd323ddc243219f98a9",
-    "inboxId": "a302c10adb94ebf001fc364a37e4446d576c8278aa2835a1258456aabe4eb83a"
+    "inboxId": "a302c10adb94ebf001fc364a37e4446d576c8278aa2835a1258456aabe4eb83a",
+    "installations": 2
   },
   {
     "accountAddress": "0xd618129c3a72a21cca8444f245f5faae5da399dd",
     "walletKey": "0x5fb04e8f1ee00f50133c7cd6185b08d50c96555f81e7f9b7d26dd9593806b0fd",
     "dbEncryptionKey": "0670bda48c15b9cb1f7de91f620aaac83a36eeb45d3ce83eac97edc4ac836baf",
-    "inboxId": "c2e16514c3231e6b3738ba0e2cfd19aae4aee036774595a9bbc27259ea1f2876"
+    "inboxId": "c2e16514c3231e6b3738ba0e2cfd19aae4aee036774595a9bbc27259ea1f2876",
+    "installations": 2
   },
   {
     "accountAddress": "0xd5514920fce34fbd2f16efa81d4dd4986d406df6",
     "walletKey": "0x55fa68bcb1133ff479906f6546aabe9366d6cd5ee870b6a11702c94efbda7c60",
     "dbEncryptionKey": "0436bd23afdd03d14f6a77d8c23b930e90b921d316c8abc4564d785315f59581",
-    "inboxId": "c7356fc2a799df28936d8ff5fc29ee9beb94226d93ce9a6b84b792e802a6cf6d"
+    "inboxId": "c7356fc2a799df28936d8ff5fc29ee9beb94226d93ce9a6b84b792e802a6cf6d",
+    "installations": 2
   },
   {
     "accountAddress": "0xccfb62411e0f87735c4b275b9e65901ff6482a06",
     "walletKey": "0x65c45844f94e42765a8f63abf2e7d3603ccf88ca1eb82d63cbda45fb7ea14993",
     "dbEncryptionKey": "91f2d1572be2b19ad6c4484a13eb6aa1591bcbbf30f5c89d5aa23a4a7b205c32",
-    "inboxId": "7d1c5e14cb1097d719a0104a74823e85b8713dc8e8f59718cd1eaa1d7ddd76a3"
+    "inboxId": "7d1c5e14cb1097d719a0104a74823e85b8713dc8e8f59718cd1eaa1d7ddd76a3",
+    "installations": 2
   },
   {
     "accountAddress": "0xb27313caaa73422460f63c26c745bdb0578d3d7d",
     "walletKey": "0x58a1f27d156795e828b1f81d5b752dc8cbf48957ce55bfd1448e875977e9665e",
     "dbEncryptionKey": "a91a83e78f5fa5a5f2eb0cafa62b8015d465d38f83a94edf46617406136f43c1",
-    "inboxId": "ba01d2d02b62990d5e72cf09c43c8b953be70cf7948a6098ce42a43a1fef73de"
+    "inboxId": "ba01d2d02b62990d5e72cf09c43c8b953be70cf7948a6098ce42a43a1fef73de",
+    "installations": 2
   },
   {
     "accountAddress": "0xf1794d29aa9ca7124ebc47cc465be3d24770d74a",
     "walletKey": "0xd4aea0903cee37ab3689948acc4a639fc04235e55c0d9c00b500f210c213188d",
     "dbEncryptionKey": "8525113473c1c7ea46aed6de5bfb089860ce7a5952274e9dc7d261e2f1f3fd54",
-    "inboxId": "ce5069482513854fe132284c5b505724c1333f48cfc957fd6425df90f0a134ce"
+    "inboxId": "ce5069482513854fe132284c5b505724c1333f48cfc957fd6425df90f0a134ce",
+    "installations": 2
   },
   {
     "accountAddress": "0xb137fa9614d999bc441ef3075401232a7feb9d13",
     "walletKey": "0xac5413c83e5ea7eb1d4b716abfccebbe17c545f1165f54aeb7b4e1df785574c3",
     "dbEncryptionKey": "0fdf503236e831bcf190b9e0f6af998345eedd38fa978ec776b4e834b1356967",
-    "inboxId": "54c24530d0bb9ca3e79c842a44d1b9aa3a73c9f2fadc65b2a91c225b900b84d9"
+    "inboxId": "54c24530d0bb9ca3e79c842a44d1b9aa3a73c9f2fadc65b2a91c225b900b84d9",
+    "installations": 2
   },
   {
     "accountAddress": "0xa3a8036b959781f2f9fc7794fa29acd6f3900ad5",
     "walletKey": "0x082c791104e05be3b391b4fcbee19b3b80845f68a2949d05556e7e9bbb8d18a3",
     "dbEncryptionKey": "92643a4c94cea919852676eed3169d46bf81160c3be6fd353a6c3096f1d53eaf",
-    "inboxId": "b29c04979a9229c908cde6a093a387d4de60b1c3d882de64057f21337463faf6"
+    "inboxId": "b29c04979a9229c908cde6a093a387d4de60b1c3d882de64057f21337463faf6",
+    "installations": 2
   },
   {
     "accountAddress": "0xc963117cac65450eef1beb786bd88c860e80ae09",
     "walletKey": "0x08f50430d9adbd7810f4d2795f01c83af8f348c5b1d151170968338e5d290726",
     "dbEncryptionKey": "e3fb9b760c9a1141f75a367eb050b68be0cb2cb6b619a13fdf2d3379b91fdadb",
-    "inboxId": "b6683d0623fd9baeb0bc9977fccd7d10fba2b4d0db3ad0fa29a5d55a1b1219d8"
+    "inboxId": "b6683d0623fd9baeb0bc9977fccd7d10fba2b4d0db3ad0fa29a5d55a1b1219d8",
+    "installations": 2
   },
   {
     "accountAddress": "0x2bff36554429a47bf5a3c4d3990c9404b7fe0e8d",
     "walletKey": "0x653a90c6fbcd3635d2918fca214b9f1ea4390e53ecb08a7d8a224d0f14a881a6",
     "dbEncryptionKey": "ef8aa1343edcf9227ae3396f23d1acb663bea7fd7ee779d9da675badd6703e1c",
-    "inboxId": "ded290cede00913b4c54b6fd6e61e5695a9d4df7909ea820326b85f914edfe69"
+    "inboxId": "ded290cede00913b4c54b6fd6e61e5695a9d4df7909ea820326b85f914edfe69",
+    "installations": 2
   },
   {
     "accountAddress": "0x50c7dd4c44f17975532e6e1863d0a5eb962d8d5d",
     "walletKey": "0xfaf4cab67cd459e75a014add2b1870bc331289437a00e1d60b913e89c19f2470",
     "dbEncryptionKey": "adaa411f488ae39a39a7c49d60042049b9926877589f47b74adc7e7252e7c323",
-    "inboxId": "a6ff1829fa3c393775d30ceef4989242f3356e0435f89394b5b31ab0097747ff"
+    "inboxId": "a6ff1829fa3c393775d30ceef4989242f3356e0435f89394b5b31ab0097747ff",
+    "installations": 2
   },
   {
     "accountAddress": "0x61d1f08d13223021ed84ec2c986242317780a7ea",
     "walletKey": "0xc88f52d16e0040595affc3828a5abde1af087508aeca26afbbabc9393fa703d7",
     "dbEncryptionKey": "1ba42b87a17664979bc2b88d7f448a5cfe212bfb77e106ed1b434082ff4e93b2",
-    "inboxId": "b999eb7aff4541a284fa4de9b840dd26f7f6a3c4bf48d6e6c3cd172cfd4dae05"
+    "inboxId": "b999eb7aff4541a284fa4de9b840dd26f7f6a3c4bf48d6e6c3cd172cfd4dae05",
+    "installations": 2
   },
   {
     "accountAddress": "0xc57daf4d1f679bce5424c66a29dc9985bd72ff57",
     "walletKey": "0x1893a34a88b4f844e2cfb876705b812b477321b1c306d1ac30f4f5fe3f848686",
     "dbEncryptionKey": "a24f616f49e0ac28fe1a627acb01bcf225b4c2764c51c5f6431143c72c737a6f",
-    "inboxId": "bed862c9f02278e44b1d037d88e987ca3eb1ba62f0567b3e352edc61185f9a6a"
+    "inboxId": "bed862c9f02278e44b1d037d88e987ca3eb1ba62f0567b3e352edc61185f9a6a",
+    "installations": 2
   },
   {
     "accountAddress": "0x0793ab7226df702a9ccfd9b39ee7e78725c30b6e",
     "walletKey": "0x11b4abf58546b39255765bb5592f4832b60966ab7d746d24a3c4f3956e091e57",
     "dbEncryptionKey": "0726fd339d1892a53a059b4797fd87c1df06cc8acffa2fb4efbd713bf6bd4fa3",
-    "inboxId": "433f1752580933f2d94561191141380744831990f0cb66d8d82e5c6ab303a936"
+    "inboxId": "433f1752580933f2d94561191141380744831990f0cb66d8d82e5c6ab303a936",
+    "installations": 2
   },
   {
     "accountAddress": "0x8848d0e3609d71e219d0f1818f2a9f3eabfdc426",
     "walletKey": "0x537360bcfcbb7ce0855b5d9841eaa7867294e2bf94462049d26a418aebc43038",
     "dbEncryptionKey": "38d85bb2dd152673f1d3f24e70bd5c4502f9f76e14b5f9fd3ec8065443b67da6",
-    "inboxId": "b5f0d123d5953f2eb4692bb61400984006d049e76179073993a7688fdd01de1d"
+    "inboxId": "b5f0d123d5953f2eb4692bb61400984006d049e76179073993a7688fdd01de1d",
+    "installations": 2
   },
   {
     "accountAddress": "0x85f8152a21da42b6e68b56657976f85a99222b80",
     "walletKey": "0x6e27fe1185edfc2444cd295c369ac584a9f1fcbc9f62674e8d9609472de79302",
     "dbEncryptionKey": "042ef7900a43e972d825723e3976eb87be8d4140d7509dc06b3268c6a0e41a4d",
-    "inboxId": "b2a1efe986620c8f6c499e30dacae876d334a36a4b4e34ebc85101be2ae02ec7"
+    "inboxId": "b2a1efe986620c8f6c499e30dacae876d334a36a4b4e34ebc85101be2ae02ec7",
+    "installations": 2
   },
   {
     "accountAddress": "0x4e7d56c7d20d92046e431e7e2655a81b5cdc2a58",
     "walletKey": "0xfe9fbea982d1b4432a25790bc5bc21be1c0cf64e7713bd0743fa4015a73ae0e7",
     "dbEncryptionKey": "5220ddef5aeb7c553aefc48063ecd0b5c6b2fba5dd44acf1920bc695e55906cf",
-    "inboxId": "7712d099ddc3cf162e11dbe95bf3254e1ac10eccc274256da8fd43617b99b6c4"
+    "inboxId": "7712d099ddc3cf162e11dbe95bf3254e1ac10eccc274256da8fd43617b99b6c4",
+    "installations": 2
   },
   {
     "accountAddress": "0xd8a4cb3680cb506d66a5b71e18f4d620e16d3655",
     "walletKey": "0x332f84405a9bb147d5b20fc407be5f899dc7ec0f987ab59ae023b5e94b60040b",
     "dbEncryptionKey": "a9761ee8bc7532d8d669e5a5e15ae0ce4ae394f75db8b51dc3a251e2773254b2",
-    "inboxId": "3dcc62df14f049016780d05d056804d13da13ce80a7856edd5f73f6b64d8b31a"
+    "inboxId": "3dcc62df14f049016780d05d056804d13da13ce80a7856edd5f73f6b64d8b31a",
+    "installations": 2
   },
   {
     "accountAddress": "0x38aa941da2340c59230cd2dc30a3b6bbade72c4d",
     "walletKey": "0xac2eb6015b2fad41421352cfd1772f6ce668a1548e1588098a9fc30fbd5c3079",
     "dbEncryptionKey": "2bcf511acc0406855ff9a20752f67834fafe1c766e0ccc2e93a598977ef85f79",
-    "inboxId": "36d5b170a8f1f3f14789a82a6a2b481269b52d9361511b5ba4b068ef61a82970"
+    "inboxId": "36d5b170a8f1f3f14789a82a6a2b481269b52d9361511b5ba4b068ef61a82970",
+    "installations": 2
   },
   {
     "accountAddress": "0xfc8a506aa2db2557125a5e38608c08b03ceada51",
     "walletKey": "0x434ed834cfc4034fac8e1724ee6d487ffac45800073435a2b5f4cf21893d65d4",
     "dbEncryptionKey": "c73fb843cd336fb657c0c630f3f4e4f48e5f235657dd79e02359ae434c7c2eed",
-    "inboxId": "fc509dccf91eb3267ee7361d262ab4b2959ecc0666a99922bcb6d600d9801526"
+    "inboxId": "fc509dccf91eb3267ee7361d262ab4b2959ecc0666a99922bcb6d600d9801526",
+    "installations": 2
   },
   {
     "accountAddress": "0x5e75292c3fda4df0afda514236186aab30e01cd8",
     "walletKey": "0x33f3dd64110d756f6ee7e45815505d8f1a444e9b1ec0754bd6cba3a434195513",
     "dbEncryptionKey": "0e9988a131d9895c121b03f306812aa4963ceaef83269190fb9f7087a2989f01",
-    "inboxId": "bb12b484deba2fe03a306c576547c99c5a779a5dd0fa0956f2a75a76be863d03"
+    "inboxId": "bb12b484deba2fe03a306c576547c99c5a779a5dd0fa0956f2a75a76be863d03",
+    "installations": 2
   },
   {
     "accountAddress": "0x93b80c4dd32f96b90c63f531bc898f2135605a9f",
     "walletKey": "0xf4ac539f771185c7450af47fee0c13ad705d8ad47a5b49e0aa020f0fc3dd3a4d",
     "dbEncryptionKey": "0a5e2a77d8b15ea6d96db0dd5ab97f10ab1f37c9b9e187d1052c030737970537",
-    "inboxId": "44ccc4dad11d7a14d9972fe8c30c6e0807ffff83cc2457161cf637e0000541b1"
+    "inboxId": "44ccc4dad11d7a14d9972fe8c30c6e0807ffff83cc2457161cf637e0000541b1",
+    "installations": 2
   },
   {
     "accountAddress": "0xbce5bb18850eea8765d864404658639545cf7b04",
     "walletKey": "0xe35775a7cae9d9d1278d23036d49f6bf22b541ecef34ccbcfbc7243764639053",
     "dbEncryptionKey": "808a8f96e81839d8ba17e4b89dbc95eaf2026c4d9fffd0f42f05055a1c6aa9d0",
-    "inboxId": "6dca05532f071a151240d26b66de149b5bbd711d1e6c5c7e409a9bc8aa6dab32"
+    "inboxId": "6dca05532f071a151240d26b66de149b5bbd711d1e6c5c7e409a9bc8aa6dab32",
+    "installations": 2
   },
   {
     "accountAddress": "0x16c938cb5d95509a74c795bc93c90bd65610d20a",
     "walletKey": "0xea897ffdf96b697743fb50765693f81ffb97cf397e8918a1aef2e40c3c653422",
     "dbEncryptionKey": "c714cec98e8a004a0bbf3d8d771e57989816663ae51949d82a1fccc17a3aa20a",
-    "inboxId": "361fbcb8a105a1f16056a7d10d37def30b0e9ee09fedd3a664d5f9969838fc06"
+    "inboxId": "361fbcb8a105a1f16056a7d10d37def30b0e9ee09fedd3a664d5f9969838fc06",
+    "installations": 2
   },
   {
     "accountAddress": "0xeebcc9af6610cbcf5696a47fd163e0161fe35999",
     "walletKey": "0x99b0f1924d91e1ccba653cf983b1c2dc44ad9f8a3cd4aa681088afaef24c65c9",
     "dbEncryptionKey": "cc8f08089263620c1224a41ab15cba8f823c7a4211f02bf0ffe6dd4667c96c53",
-    "inboxId": "e3ed796a657a623757208e26f56d4eb9cd7f972ee6053336fc7d08e208a82004"
+    "inboxId": "e3ed796a657a623757208e26f56d4eb9cd7f972ee6053336fc7d08e208a82004",
+    "installations": 2
   },
   {
     "accountAddress": "0x7cc8ac688cfb4f4674ff5d342f63d8673544f00f",
     "walletKey": "0xced7a805ea105494de63138def25eb6f0eb61bce7224d126cedf46087ca81020",
     "dbEncryptionKey": "3c0a9c055429e18da70bca9358a7a16323776c641b076ffc12a7c4a1b6ff4360",
-    "inboxId": "5ff49f51e6a850f64375b24fcc0b7431579734e41a7925437c49ecc2655962bf"
+    "inboxId": "5ff49f51e6a850f64375b24fcc0b7431579734e41a7925437c49ecc2655962bf",
+    "installations": 2
   },
   {
     "accountAddress": "0xab04f8d2d29f4e0967220f34dd8238d2dee5888e",
     "walletKey": "0x462f9d6767fce562bcc0f0c8ce0f3473edc4d6c8ee2142b7d39514edd77128be",
     "dbEncryptionKey": "5fb13b3eba6281d2501218d606af7eaac682372d50ac0d4e0e0736411d0cd057",
-    "inboxId": "ed4a91354611accaa9bec1123f1aeb33006112ff195ac672ac2c1355f2623160"
+    "inboxId": "ed4a91354611accaa9bec1123f1aeb33006112ff195ac672ac2c1355f2623160",
+    "installations": 2
   },
   {
     "accountAddress": "0xc40093d48792f7896eecc12aee88e6814e7b5cdb",
     "walletKey": "0x220a847a508f9385030b3e90beaaf68131f0848d199120222c28aef41c667e44",
     "dbEncryptionKey": "1a13fa134b9f70b606f9d67b6ac0a4eb9f15a7e6c732748b0f7ac290d8686cbb",
-    "inboxId": "219cc2997c05c9901389983de16a1fc2924d9980273eb44798a23888747e0876"
+    "inboxId": "219cc2997c05c9901389983de16a1fc2924d9980273eb44798a23888747e0876",
+    "installations": 2
   },
   {
     "accountAddress": "0x584ccbcb87dee0b8e6f91da1776cb507862bafd4",
     "walletKey": "0xc9b46b01f710712125e083b28021381e5cd9f2c5b7fe092d776283d308747419",
     "dbEncryptionKey": "9d180c5b3903fc372b9586413f358a8d636595f2e277f4c37730789e4a0c7ac6",
-    "inboxId": "4333e53e365299ea94610c45e0a127aa57ebcb572c72044234a687f049d5e9ef"
+    "inboxId": "4333e53e365299ea94610c45e0a127aa57ebcb572c72044234a687f049d5e9ef",
+    "installations": 2
   },
   {
     "accountAddress": "0xbce44024fc1d4b861e94cf2596eb5ea80ed0d860",
     "walletKey": "0xd4a3330482a030fc37701c34e8d3415b22610e8e3c433eb6eef385f6942fc984",
     "dbEncryptionKey": "b41c513630a67e8cfc680c5caeb53fe5b480030b5e282ad1c1e097c75fe141ba",
-    "inboxId": "c40feb480190239c11baeadc189004356037845d5ecd839031c4af73cff29b1c"
+    "inboxId": "c40feb480190239c11baeadc189004356037845d5ecd839031c4af73cff29b1c",
+    "installations": 2
   },
   {
     "accountAddress": "0x701e7d9c7e9fc44d19b76b820f270bacb39662d0",
     "walletKey": "0x9c3a8493ce2e8564ccd1563f03b861d27157e46c02845e7ec791f307c3a5a221",
     "dbEncryptionKey": "5d5fbd34111a8ca53a51f4f17e4778694069ca85bf92eb5e48f6762ed2f61afe",
-    "inboxId": "17e6fc9245a522344fa62925e3d892c11005ba5a816c277473340ad3d473535f"
+    "inboxId": "17e6fc9245a522344fa62925e3d892c11005ba5a816c277473340ad3d473535f",
+    "installations": 2
   },
   {
     "accountAddress": "0x6fc16eeffdabe71922317235dea2d83f6cfbd17a",
     "walletKey": "0x2ca593ec9a802a0a27b93bbcf39105fdd9af02c502655beb2056de189c228436",
     "dbEncryptionKey": "4c3b2e0f40ceddeec10c2ea312fdc4f11625cdedda5e18d220aecc27e918da47",
-    "inboxId": "15c953543e6296fbc934e0f51db7c0b92832e10b849c52b4bd396d0a2ce71f0f"
+    "inboxId": "15c953543e6296fbc934e0f51db7c0b92832e10b849c52b4bd396d0a2ce71f0f",
+    "installations": 2
   },
   {
     "accountAddress": "0x0e42204d9faa6d2fede1764ddac8c4dbad92c3fb",
     "walletKey": "0x68b771dadfa446b0d56817e630a9809722bd955e38355e80050417ad56751181",
     "dbEncryptionKey": "09a23f59aeb0aec3bae8083b808fe0b1db21e4c834e49d16af7a3636972a5403",
-    "inboxId": "69c5a2ed40c8b52a0e800e5fc21c194c2913e846eac415b8a7f6e178f9f9efab"
+    "inboxId": "69c5a2ed40c8b52a0e800e5fc21c194c2913e846eac415b8a7f6e178f9f9efab",
+    "installations": 2
   },
   {
     "accountAddress": "0x804b9aa2caef18f3f719a91ec5f8f17ea6a24171",
     "walletKey": "0xcce49f946453aba36ca973bf78510c62656549c9571bb70afc9b99fb46ef6bbb",
     "dbEncryptionKey": "6bd9bb826146cd1b4ab0320f330b173570837195b11c186e7505e8f8bc555008",
-    "inboxId": "c818e1efc314cdd18f32bb61ff7356bdc65d5ba7460f9118d8dea08daa55e0a1"
+    "inboxId": "c818e1efc314cdd18f32bb61ff7356bdc65d5ba7460f9118d8dea08daa55e0a1",
+    "installations": 2
   },
   {
     "accountAddress": "0x67baee5085a0d79ea6fb8ec6b2a232a48b2274d0",
     "walletKey": "0x8443087896aeb010e9b7a40ceb5b9774274d4e6eccd1b8f6367df3029f4143dc",
     "dbEncryptionKey": "f82921a3a1d9cb8f799c4eae0a0f4b024da3b3446f607487915e2307d4f60728",
-    "inboxId": "391acd936c7cfb2e76da4b9e52294b86fb33af4639f16955802a2e500a4edd63"
+    "inboxId": "391acd936c7cfb2e76da4b9e52294b86fb33af4639f16955802a2e500a4edd63",
+    "installations": 2
   },
   {
     "accountAddress": "0x603c647329a404fa99642636ed5b8f0389e5a230",
     "walletKey": "0xa2256267eaec50fcf7fc6e4422bd4072fad3268f09e9833c677198e7ddc002a6",
     "dbEncryptionKey": "8868bfe645e0da9f7356718ca74b4d0dc034600fd4638d2ce5a18e4f63d0c243",
-    "inboxId": "e928468fc969c1b52a1f785d4f5a500ed308cb3fd4e2681edd8c4733a2dbb70b"
+    "inboxId": "e928468fc969c1b52a1f785d4f5a500ed308cb3fd4e2681edd8c4733a2dbb70b",
+    "installations": 2
   },
   {
     "accountAddress": "0x8eb5e58e62e336694cc0450b23641158b84ef4ee",
     "walletKey": "0xf1fa8989056b55770741aec148402dcaca9df433ac640379972d7ffdb5fdaf4f",
     "dbEncryptionKey": "37606a5cf2860f68bb4ebce0b14633aa10251f05573e5c1897b771c099ccae41",
-    "inboxId": "d766e53f79211febc1a39bc6eaaefce7d863f29ef241534da4bbf0fadd10236b"
+    "inboxId": "d766e53f79211febc1a39bc6eaaefce7d863f29ef241534da4bbf0fadd10236b",
+    "installations": 2
   },
   {
     "accountAddress": "0x80663269b2664cb6aa58d5d685d9a60c907d0ccb",
     "walletKey": "0xb87190c2984bfb5eb70998b26df14517d75d017404e0334e79ea73ce93b9fe05",
     "dbEncryptionKey": "f9b005c5a1e4e338f967bf713083d27a192d236f47b87b5487c84e181f7396af",
-    "inboxId": "2a0e564e0409719eebfc27fc54bf7706b70bc911227f6a433d42b9f639b7f7c6"
+    "inboxId": "2a0e564e0409719eebfc27fc54bf7706b70bc911227f6a433d42b9f639b7f7c6",
+    "installations": 2
   },
   {
     "accountAddress": "0x91a3059a8d7c913b88f72b050885e50106c44847",
     "walletKey": "0xadd25a4a01ef63f577ab33302f6a6f7005b697fdceaba09bd55452db19bf4cb5",
     "dbEncryptionKey": "75cf063f86c0d383ef11f83bb285ceec2cac0f6754fab66c2cf66ff21c3bfd13",
-    "inboxId": "544bad4facc7b53d76285d9602abcd455e1f9c93c4662a0adb76ba71b126a385"
+    "inboxId": "544bad4facc7b53d76285d9602abcd455e1f9c93c4662a0adb76ba71b126a385",
+    "installations": 2
   },
   {
     "accountAddress": "0x98d7e20610c395dcdf69792f00f94ed61337a2f5",
     "walletKey": "0xbb09f81db8fe72decb98c3f96835a7454a2ef1b848734dceb69754f4e443b161",
     "dbEncryptionKey": "a83f79f248beff53189a7e38722074104d770f133495d6dbd348b31fb2f5a417",
-    "inboxId": "9231e71fc97873c7a5993fdbdac413a5c23e2d7d8d24b1d4e14bd340aab87938"
+    "inboxId": "9231e71fc97873c7a5993fdbdac413a5c23e2d7d8d24b1d4e14bd340aab87938",
+    "installations": 2
   },
   {
     "accountAddress": "0x5a65d353b5041f41e009c0e4844d6d9270d38ab9",
     "walletKey": "0x7d93d48cb3454a91b12150bed1464b9a8ded7c026ee416c75f991e0375b721b6",
     "dbEncryptionKey": "ab34533326383b96e5e88ab1904b15fee4972cb56c1d3418b8ccf6a909e333e6",
-    "inboxId": "9ad0d40cbe617b09fc80c93725e8a91c7671d8e56c5ac0fd660c01f6187346be"
+    "inboxId": "9ad0d40cbe617b09fc80c93725e8a91c7671d8e56c5ac0fd660c01f6187346be",
+    "installations": 2
   },
   {
     "accountAddress": "0xc75f3d5f6e99c89ce938288bc35716be5a95a10f",
     "walletKey": "0x511bccd935e4b3cf441f12fa2c903a78a1b6c37e2aff13dcbe457b89fa8bb7b2",
     "dbEncryptionKey": "f78a8f0999e34a6ff2117d97041b4997069cd0fe7577634432a5efd65f602a98",
-    "inboxId": "9251a04a3b59960ecc6ad1ab90be5a0faf5310d007c801ea330ab7e4183d0f32"
+    "inboxId": "9251a04a3b59960ecc6ad1ab90be5a0faf5310d007c801ea330ab7e4183d0f32",
+    "installations": 2
   },
   {
     "accountAddress": "0x71b21608de5d08be0732fec513df6f7b5d7b9490",
     "walletKey": "0xa31f19441ff3edd2babe04fa46ee4522d6b6e0f6b7388824c2d6736e796f2b60",
     "dbEncryptionKey": "8cf4fd3f6102c6efaa9f95ab61836e7b92093c488bb0110acab9ade098d580d8",
-    "inboxId": "f0b56dc19a5efe11c57a3ff4e41d59c9469e49f8c70f4baeba0b82f2d53e0a3c"
+    "inboxId": "f0b56dc19a5efe11c57a3ff4e41d59c9469e49f8c70f4baeba0b82f2d53e0a3c",
+    "installations": 2
   },
   {
     "accountAddress": "0xa3b12222768f8aa34a0143f06d4250eaf5f000da",
     "walletKey": "0x234c6a93edb9304c5df7df2e941176db17b3bfb320928c3586d575cbf1715684",
     "dbEncryptionKey": "87f503bd1ae58e11f9ab04f4dbf5f994590a3b5ead201f43207c548354a983d9",
-    "inboxId": "b3f2151da1cb45efb14523692c474873a4da294ee5690e80f6d3bbd97b99773b"
+    "inboxId": "b3f2151da1cb45efb14523692c474873a4da294ee5690e80f6d3bbd97b99773b",
+    "installations": 2
   },
   {
     "accountAddress": "0x4a04d82f5745dddd6e3aba09ec826095433241a9",
     "walletKey": "0xa0a84a83c184a893bab6772f467b3546632305fa9c2eeeb0fceb3324c9b59da9",
     "dbEncryptionKey": "13f6a0a40ae04d39025e6a32e6154b0145242602fdeed6d8e9eaa673c7da202b",
-    "inboxId": "dbd52462e608b72c6a266bdef56583c2d38ec7facdf6685f3149f592f7f527e4"
+    "inboxId": "dbd52462e608b72c6a266bdef56583c2d38ec7facdf6685f3149f592f7f527e4",
+    "installations": 2
   },
   {
     "accountAddress": "0xac0002424a665bb1c5141c46b3af7f20b72a3c23",
     "walletKey": "0x18dc2f89787e3fb743cec661adb4fd54a41e9f050aecc5d51990aed4ea3b9f42",
     "dbEncryptionKey": "050915e57ebb5ed5df48d91891a88d0a09d03f82471a550d48eae73d32db8153",
-    "inboxId": "510a2c21b9097b87b363deb7a0b709fe7ba2af69a4f29eafcad14ff2a3a169b3"
+    "inboxId": "510a2c21b9097b87b363deb7a0b709fe7ba2af69a4f29eafcad14ff2a3a169b3",
+    "installations": 2
   },
   {
     "accountAddress": "0xc2e9d135f889d38dde385faeb33160be204acfae",
     "walletKey": "0x8d4854650f1faef3dfc14ac287885d344b02bc16872cf5a76bdcc5fbff07d704",
     "dbEncryptionKey": "5635986996f278490f67b62a47e5c9f01f25ef515054de740eda4ad6401baf03",
-    "inboxId": "cceb187a9a4235c1e8b718ec772391d5976c979ce27d338af5b0015b87b58de2"
+    "inboxId": "cceb187a9a4235c1e8b718ec772391d5976c979ce27d338af5b0015b87b58de2",
+    "installations": 2
   },
   {
     "accountAddress": "0x5baa7c9c276eb06ce9caab78be60adbe096b493d",
     "walletKey": "0xa692bad678f6bdffb3f838cf1de8369d19027c05883c68b62a44ace1e59bc10a",
     "dbEncryptionKey": "2b6e6c301fa48041f3998e585f4462986b326847bde1413f4d8be22dc3400540",
-    "inboxId": "7d8e76c7b1aa5fd161afd5f1402dad21c028bcf6ffb6d5b62055a144739724e5"
+    "inboxId": "7d8e76c7b1aa5fd161afd5f1402dad21c028bcf6ffb6d5b62055a144739724e5",
+    "installations": 2
   },
   {
     "accountAddress": "0x590a3d379e956d753026c3a8f90179b6e6f8f460",
     "walletKey": "0x48cafa0cb1f1e3c5c4e8d095c7752c86866fbe1c5544de4b0bcb5df9bf69751c",
     "dbEncryptionKey": "f7f91d4b13ca1fd7580a2b02479de9e0251e942ab641ce6bdee418474356b8a8",
-    "inboxId": "61b920879de14bfc725624608a4df594a33217fc12a5d2e8c691e0ab0639fb7b"
+    "inboxId": "61b920879de14bfc725624608a4df594a33217fc12a5d2e8c691e0ab0639fb7b",
+    "installations": 2
   },
   {
     "accountAddress": "0x4b6a74d300be66bd4a0e0301cb18fe3a8ac0b4d8",
     "walletKey": "0x6b6b0d51368b4029f5f8eb109fb72f1f3f4a22bfa45717929256625aea95fe1a",
     "dbEncryptionKey": "21d4e891780369fe9488fa27f19dd7a9cec423d11e4ef01f174eeefb87012fd8",
-    "inboxId": "c36aae5b54daac912065cb6aa56c46996e2d7e38fde30f8855430768dfeebac6"
+    "inboxId": "c36aae5b54daac912065cb6aa56c46996e2d7e38fde30f8855430768dfeebac6",
+    "installations": 2
   },
   {
     "accountAddress": "0x6c116680f805b24068106b8dbb56e73f8c23e8c0",
     "walletKey": "0x55ee2c1d07b48f3d61547182ab58f3754190cffb2ae0c8acc99b30a98d08693f",
     "dbEncryptionKey": "65346b6caf92bdad7bbc0693611840e2360bea2d1ac134fdf138c7c495c312fa",
-    "inboxId": "01f380ffc5e6c29a60456007f4b72bef84563c7d40a3d2d0ce37f13496464f60"
+    "inboxId": "01f380ffc5e6c29a60456007f4b72bef84563c7d40a3d2d0ce37f13496464f60",
+    "installations": 2
   },
   {
     "accountAddress": "0xac0fa6319d01e9371972950774df927da4358063",
     "walletKey": "0xd7c35f9a325b84aa67080897fd370828693317d84c31cafaeb8b2a7139780498",
     "dbEncryptionKey": "a39c87faabec2bcfacd11def32e908886f8c077aa558d06967c5984db9a5416e",
-    "inboxId": "d49192e50b5422cf55788d97a68b1f55310ceb8757938ec5182226b66cabccf4"
+    "inboxId": "d49192e50b5422cf55788d97a68b1f55310ceb8757938ec5182226b66cabccf4",
+    "installations": 2
   },
   {
     "accountAddress": "0xc035d7ebda6abcf614a2bf5398bc54066240cf3d",
     "walletKey": "0x2b682449d59b755e7a27db1ea40d4dca8752a0b3345579e05ff6f937fb4d1589",
     "dbEncryptionKey": "7b11c48751c5658a9bb07c5937da357f82effbd904c079b0a0e468951512efca",
-    "inboxId": "57b4fe0287a289ed888c83b5544f1fda48d60a18f3e983720e716034ca744ab4"
+    "inboxId": "57b4fe0287a289ed888c83b5544f1fda48d60a18f3e983720e716034ca744ab4",
+    "installations": 2
   },
   {
     "accountAddress": "0x082e1820e5d47aa9fdd2b4cdd897ae0643975d82",
     "walletKey": "0x12731428175159913743d1ad9fc6a4c432e0550b3da1c149738381a88bd5bf3b",
     "dbEncryptionKey": "52a0569b277f4c9c44ed5c00b72b0388802e913483205fc525f931851651913d",
-    "inboxId": "ecd0d6ba8b09d1c18c934ef60cc62746e348384710c91a08ec5b56cf302b6353"
+    "inboxId": "ecd0d6ba8b09d1c18c934ef60cc62746e348384710c91a08ec5b56cf302b6353",
+    "installations": 2
   },
   {
     "accountAddress": "0xd333409e6a066a2c816d40e13a7466af676d4e8e",
     "walletKey": "0x0652e01c30e4dfa4f402ba410c1fdbd9852e463f1097a042fc8fb5633754772d",
     "dbEncryptionKey": "5810eb071852e14760c569046d3bb0d0b46231fd1b9725b65eed0a81a60a1d76",
-    "inboxId": "29479beee76278d993168e44cd6af6295b7fb53df9a7d66e29c01a6f2b99f5f7"
+    "inboxId": "29479beee76278d993168e44cd6af6295b7fb53df9a7d66e29c01a6f2b99f5f7",
+    "installations": 2
   },
   {
     "accountAddress": "0x1f7980214b7d4f38113175b808b44b633e13e850",
     "walletKey": "0x9a390a3f12c951266437cc87438a7df12efd8b23509f540f2de5904d31eb874b",
     "dbEncryptionKey": "39e7a68542b7d2c544b309f7660bdc4a95b54f838fbd01e308ae53b413e375c8",
-    "inboxId": "969c1bb29963d06913e91f739b9db1dcf6457893b81e96973a64090c41cf5d61"
+    "inboxId": "969c1bb29963d06913e91f739b9db1dcf6457893b81e96973a64090c41cf5d61",
+    "installations": 2
   },
   {
     "accountAddress": "0x102853c3d2962cf3fb28cbe232fc0b1e635ec428",
     "walletKey": "0x6d38362ce632cf3e9d690f748ad4419eab51867af13366859e4ac4da88984d8f",
     "dbEncryptionKey": "dfb9b68ade52eebe7194fef0d838aae5256e0c9fa7fbed2b8fa2d24926eeea5a",
-    "inboxId": "bab776f7a1e107fbfc46aa4fabb9434038a95a7e69569c4484bfc76926f555a8"
+    "inboxId": "bab776f7a1e107fbfc46aa4fabb9434038a95a7e69569c4484bfc76926f555a8",
+    "installations": 2
   },
   {
     "accountAddress": "0xd162e0d02482b65cbfc82ddcdcb6a668707d5663",
     "walletKey": "0x22c9ab66a5e122b885abd3316ef6fcc3897b50bd2035e226a3d772e56d2783ab",
     "dbEncryptionKey": "6e589cf3846fab3b62b40debf61755e1b7005d3b529491b0032a64a1ef077da6",
-    "inboxId": "205a71d8c11034b9f5522fbb5139ad0912e59b1dc8d7274bd2d5f44e8821cffc"
+    "inboxId": "205a71d8c11034b9f5522fbb5139ad0912e59b1dc8d7274bd2d5f44e8821cffc",
+    "installations": 2
   },
   {
     "accountAddress": "0x54747d9ccc06af16cb621ecc3dea006630912d4e",
     "walletKey": "0x66a6c034a801438bfce6fb547d38126ac0152150b128facfe7b93a895067cd51",
     "dbEncryptionKey": "d34791434cccd2d3df9aa0f33a1b2abf23693ae9cc8a550473c20223f40d9254",
-    "inboxId": "1810467134692954fbea7bc982d44a487607de469f83550e46cdfa246b5b86d0"
+    "inboxId": "1810467134692954fbea7bc982d44a487607de469f83550e46cdfa246b5b86d0",
+    "installations": 2
   },
   {
     "accountAddress": "0xd57660e3c7723ed84f12c7574c291a56a93fd454",
     "walletKey": "0x77ba88bd0c7871f78d7b62892ec76dd77f747b01142f793619b078376de0c60d",
     "dbEncryptionKey": "11e95502322ea433153a47729fc4f986c42d962674a7940a5f1b465f014f079e",
-    "inboxId": "25eb1e486263e12c9ab44ad73a361a48371db9f280fcaee7d1d72790cf856f3a"
+    "inboxId": "25eb1e486263e12c9ab44ad73a361a48371db9f280fcaee7d1d72790cf856f3a",
+    "installations": 2
   },
   {
     "accountAddress": "0x32f78dd63d05fba533b5c97dbe885700b9a4a016",
     "walletKey": "0x4289cd38a16f6bdb471362f7dffbff8da296b41dd40ab2fa74317733e33e89b2",
     "dbEncryptionKey": "863c2aaba98934f9bb8bbd172d85a3c0043da0fff8f725feb698110a9bb56e24",
-    "inboxId": "3d7f313286a7cfe2e906db16a183b7ab08462545e52d788fc9ddc9aaa7f03408"
+    "inboxId": "3d7f313286a7cfe2e906db16a183b7ab08462545e52d788fc9ddc9aaa7f03408",
+    "installations": 2
   },
   {
     "accountAddress": "0x3f83923f3637cdbeb216102f6ab2397555ab9b55",
     "walletKey": "0x0656d8264e58bffdb97b1b8d6ab34982620dd8a235b27a7ff99d24bd0f077089",
     "dbEncryptionKey": "76e9ff4114497345f39e56ad824435c1a2b53a828c6220dec651232f295bd7ce",
-    "inboxId": "a36a24d34f075cd8cc2447bdfbcb6094b8dfd178391864b5f9ac9880b01d2788"
+    "inboxId": "a36a24d34f075cd8cc2447bdfbcb6094b8dfd178391864b5f9ac9880b01d2788",
+    "installations": 2
   },
   {
     "accountAddress": "0x0c34bfa85f7e817a79cdbeff63f677394abeb0e3",
     "walletKey": "0x82a620c208148d7b6466206703b8c1b61bbe8b9457f6302ada5953735fa4eb5d",
     "dbEncryptionKey": "3be9af77623dd2542ec7fb853f7c299c5e5cbd73f04cfe12de8d5039211d7adb",
-    "inboxId": "45132cd136c1a90c93af514da48c076bf51eacc3eb22a5456d867d6347d3b37f"
+    "inboxId": "45132cd136c1a90c93af514da48c076bf51eacc3eb22a5456d867d6347d3b37f",
+    "installations": 2
   },
   {
     "accountAddress": "0x6abaeeded6400e263d5690c724f9251021fcdc8c",
     "walletKey": "0x107f3ef90ce68b739cb964d106275ab2635a2fd4a486d22ab03b4bb0bfb48382",
     "dbEncryptionKey": "6a3921031deb47427cf58a17f188081aae4cff0b54028244dc86867a8adb3292",
-    "inboxId": "e14ee0bbfa785ed48c072a80934aa2b17acb84e3153199f6b65c10e745adb27a"
+    "inboxId": "e14ee0bbfa785ed48c072a80934aa2b17acb84e3153199f6b65c10e745adb27a",
+    "installations": 2
   },
   {
     "accountAddress": "0xa01c0c09297ac2979403db5c7373f9f9ee849341",
     "walletKey": "0xb69aeba60e9cd7fdb87b171f63177908b7121b7dcbe78949cf2a15d01ce5fe9c",
     "dbEncryptionKey": "1d9687fc30558752490413adab52abde9c1a9bdb21a2e1302eba8ed82d9546b3",
-    "inboxId": "73736d0287dc114bc1930426d9cb76b83a6586af94bf3114da31d83b4745aedb"
+    "inboxId": "73736d0287dc114bc1930426d9cb76b83a6586af94bf3114da31d83b4745aedb",
+    "installations": 2
   },
   {
     "accountAddress": "0xd37ea10200eb8829cf000407c08208c88c61a4f9",
     "walletKey": "0xc5fbbe495312c0fd0434d3f9244e035231a82383ae43d34d757be9f8f54346d5",
     "dbEncryptionKey": "e54e857c5ff893210393f23c904cd25cb3cc2651b51eb546eb0f2afea65e0c1b",
-    "inboxId": "4838b32c77faa259b743d5a9e5afd249fd1c2b0e2a3a87e307394472ebf4365d"
+    "inboxId": "4838b32c77faa259b743d5a9e5afd249fd1c2b0e2a3a87e307394472ebf4365d",
+    "installations": 2
   },
   {
     "accountAddress": "0xf61a1253c1ee54e12a79af005d4b5aa10a9e2087",
     "walletKey": "0x4723c72ceaff4b0d2a98e5f2fe207deb30032b997ca7644506cfa9260ddf0ad3",
     "dbEncryptionKey": "473ad29ac845f2d0419b18ac4a91a82204666cbf116c862e969396ff2a8e1802",
-    "inboxId": "d48949eb956c25562e42193d72cf2093ec623c985d468458e89369cb952864b9"
+    "inboxId": "d48949eb956c25562e42193d72cf2093ec623c985d468458e89369cb952864b9",
+    "installations": 2
   },
   {
     "accountAddress": "0x6d92b1033b4a0bc96c68c9c53ce6900eb22debe4",
     "walletKey": "0x2dab80ca2329c063d31a0224e88ea4f79535353e4eda0f3b73c1b72081d6a5b6",
     "dbEncryptionKey": "6b4cf7ee34cf750cc69ff8304c866bb5b8490723ad2238db390b3f35165b6bbf",
-    "inboxId": "0c67d59a032d656bcd106ab0e2221e4f989b5e49b4c6e5b127079348f4720c94"
+    "inboxId": "0c67d59a032d656bcd106ab0e2221e4f989b5e49b4c6e5b127079348f4720c94",
+    "installations": 2
   },
   {
     "accountAddress": "0xf30fb93a73694e81b5c45183aa51820392a03f8c",
     "walletKey": "0x311f7a64b6c9682b9302e5e0cfdf8de77f217f71adf7063dd26ee519cdaf1cf9",
     "dbEncryptionKey": "3e4a2bac0d12f741bb4e365f47254aea0c3529e2bbd8428de5ee20dd39309742",
-    "inboxId": "acea310937b071e9ce374c486369f149b245b84fedab706effc89502d94f1e82"
+    "inboxId": "acea310937b071e9ce374c486369f149b245b84fedab706effc89502d94f1e82",
+    "installations": 2
   },
   {
     "accountAddress": "0x0bd01e777edc60292f0f3d4efa07ae1b1bfe4687",
     "walletKey": "0xf97f6cbcf3da6360f36781da004339d3404f1c8e65fe1b2cce66bc479792bb46",
     "dbEncryptionKey": "4d65393efdf84761dba3419b7a6cd35c4acd8bc21e417da71b21a4aa1f75c33c",
-    "inboxId": "b34052abcb87a00f716e3e08d54f433291e5e0cf008b6923f2213eaabd862484"
+    "inboxId": "b34052abcb87a00f716e3e08d54f433291e5e0cf008b6923f2213eaabd862484",
+    "installations": 2
   },
   {
     "accountAddress": "0x7b08153338996ffa0238491edf7ad1037bc03328",
     "walletKey": "0x424f65a5288d8b74f252fe8390f401c1306b3d581f0fecbec0128e4eab9bf06f",
     "dbEncryptionKey": "ebd2c16a50f9e6d31def3ee68310c019ce22d26063d79f2433cdfe436b8c0d0a",
-    "inboxId": "311ba8e0c1a63f25eea85503da4c77eb4b1a3e77b71e4ffc34c630ee77bbde94"
+    "inboxId": "311ba8e0c1a63f25eea85503da4c77eb4b1a3e77b71e4ffc34c630ee77bbde94",
+    "installations": 2
   },
   {
     "accountAddress": "0x92c7e791a7a6d44efbc570c76ec273eb7126a959",
     "walletKey": "0x3aa59516a30ca1f38351b60cc26c40af31e0e168843bb866c9e298e9834be344",
     "dbEncryptionKey": "8b095132363025a97eed71603ac15f3eed6d136ad5385b6a97792d0d92e5b9a8",
-    "inboxId": "81ccbae8ebb9de93be94672a608d99d9ced8514f14f0cd6efb0cf16f1e62bf5d"
+    "inboxId": "81ccbae8ebb9de93be94672a608d99d9ced8514f14f0cd6efb0cf16f1e62bf5d",
+    "installations": 2
   },
   {
     "accountAddress": "0x63341bfd122748f1888263a6474fb7ba41858404",
     "walletKey": "0xb603e7c0563f5e0ac86bd9dc2853611c8413b6af109302d68c0387ecd5ce5dc5",
     "dbEncryptionKey": "72f9f91d06eb26f5cc2cc7aaeb7e463b313cc8c9b56bbe9f9a2364d023ca10b6",
-    "inboxId": "c5de3b19998f2fb544cb95a66c9c465d94f9f06235e0e37416b40c332167d2f5"
+    "inboxId": "c5de3b19998f2fb544cb95a66c9c465d94f9f06235e0e37416b40c332167d2f5",
+    "installations": 2
   },
   {
     "accountAddress": "0xc5c1bcdd4e0657be06a42a8f144427ce905a2d0f",
     "walletKey": "0x8bbce9afc19caba03b377a346abcb4fd4b920fa6e84e8e40751028ff01981931",
     "dbEncryptionKey": "3ca64168db505bcc5157403f96fd43c95a0a298e20a2b47f8b866b95ce5f0d25",
-    "inboxId": "bc17854b43972742a7c854bf62313a268340e8bd7bf8acdbf492f52f7dd5fe08"
+    "inboxId": "bc17854b43972742a7c854bf62313a268340e8bd7bf8acdbf492f52f7dd5fe08",
+    "installations": 2
   },
   {
     "accountAddress": "0x3d13b6a4fdc48cc7ab485afbac89f5c94bae6cec",
     "walletKey": "0x2c6bff803939b4a1c1b18aedba3a5036af5a92823849aae701a092f241c6ef8a",
     "dbEncryptionKey": "d5d4c240a0da08e4268368ebf096a3c64fb74a6750db936b228f330a88a80002",
-    "inboxId": "5872b06bb84e9660bc0a604323534997cddad15057ec67be5595ce3f0a00d7c3"
+    "inboxId": "5872b06bb84e9660bc0a604323534997cddad15057ec67be5595ce3f0a00d7c3",
+    "installations": 2
   },
   {
     "accountAddress": "0x0b1965995c344fb179eaf7e1f53787d8c1bf3267",
     "walletKey": "0x1b7b60fe26ded33a83df685e06ad4c112e0f25da512878152371575b3610b6e4",
     "dbEncryptionKey": "d2c93be53db49586e9c06dc98316d040222bcb51ee3b589840b640d7c2e9c268",
-    "inboxId": "2c884a799bf405c970e8bedab8b18347793eb3de58bb1c2d601411fbda86153d"
+    "inboxId": "2c884a799bf405c970e8bedab8b18347793eb3de58bb1c2d601411fbda86153d",
+    "installations": 2
   },
   {
     "accountAddress": "0xef8d10a18e08117512ec5452fd0d1d8000591d43",
     "walletKey": "0xde8a08c76ddd42351691904a29c45d8dffe22aa3ab87b778a538d212e05dd9ed",
     "dbEncryptionKey": "e76a83a6690ad9cbdc5be6b057bb678abcd7b93ebec39f12a67f2c7e085305a0",
-    "inboxId": "d278806a777aef99535ae86f4df9b645d4d0c07b5d08f60aa2ae3116cf3a7eb2"
+    "inboxId": "d278806a777aef99535ae86f4df9b645d4d0c07b5d08f60aa2ae3116cf3a7eb2",
+    "installations": 2
   },
   {
     "accountAddress": "0xb42db85a46a0ae25d24f50f6f427b9d8774f0105",
     "walletKey": "0xc887a02cc147f7a9c670cd09a65462208bef0d8d323f656e7895e59da48be0c8",
     "dbEncryptionKey": "c0a0e9dea1fbad45d30934a8d89bf8f3638ad1aae19f31fde5513180a8f0d080",
-    "inboxId": "991c4937d2fc4396431c328278c26b5c64c9246576ae90075a82c5c9329f3a77"
+    "inboxId": "991c4937d2fc4396431c328278c26b5c64c9246576ae90075a82c5c9329f3a77",
+    "installations": 2
   },
   {
     "accountAddress": "0xeebf1e8d856134d4d03921736b8c8aed132becf1",
     "walletKey": "0xa0eb3eb1e9254b70cefc192f43d4113712945760cde2eafc6d8231d5621cc56b",
     "dbEncryptionKey": "5756eca173e8ca40e770d7ea9b850ff5a01535918a6d742dbd3ad76c9f59a569",
-    "inboxId": "dfcbb12934032ea57f42383be767f41d8200e36e076b6c411fa073aa77bd3934"
+    "inboxId": "dfcbb12934032ea57f42383be767f41d8200e36e076b6c411fa073aa77bd3934",
+    "installations": 2
   },
   {
     "accountAddress": "0x60229eafdb7216dc43722fd00d4fc2323389ec7a",
     "walletKey": "0x82ae427f10a393670a3360930aac76215a435c6a82c33efe2f48c788e5e68cf2",
     "dbEncryptionKey": "d1f4247db006da49a69ec359f15fdb8a673e2fe691a15a200c2c56f19b17d021",
-    "inboxId": "14316385087573c35ef809a16bdfba0b70163f26f2abee7b0855810644500d35"
+    "inboxId": "14316385087573c35ef809a16bdfba0b70163f26f2abee7b0855810644500d35",
+    "installations": 2
   },
   {
     "accountAddress": "0x4c42f71a0fb1401061d0790b14e384f5e08f8d09",
     "walletKey": "0x5fd917a703d0824d586171c7e5250ce07813afb129a588be10393ed5b4a75561",
     "dbEncryptionKey": "09d7db38ee003e1c147fc2322c1da90926bc5cbd5f11962c90ee548c70697cd3",
-    "inboxId": "062b653890b6ff052bed8fc7d69b9cacfbca9eebbe8f4f6631bc95a30661975c"
+    "inboxId": "062b653890b6ff052bed8fc7d69b9cacfbca9eebbe8f4f6631bc95a30661975c",
+    "installations": 2
   },
   {
     "accountAddress": "0x417be8a96215369782406a2e2ad002bec6e6b30a",
     "walletKey": "0xf655f891761dd61e462c87932ed68522ddcca1d83b9c313c924b0666138ffbf1",
     "dbEncryptionKey": "5930871e4cfacba536a55e3ab35bea18c9e66bd843e29c0ec8e88ee4a5943008",
-    "inboxId": "11e3c792a4b444b43650827de954a0e6615a65edda1492e2e306530bb13fac96"
+    "inboxId": "11e3c792a4b444b43650827de954a0e6615a65edda1492e2e306530bb13fac96",
+    "installations": 2
   },
   {
     "accountAddress": "0x8cad58ad8ac345d7e79ab30c1d712d8544237694",
     "walletKey": "0xc84987fb2099fd5def5f89c466e1922f50e4710c9badc884b9916679a511848c",
     "dbEncryptionKey": "425f09c5e9dfeb051ce84a660b700ea572c4892e838c2f4ba0b32d8042544b97",
-    "inboxId": "c0d87f03676ad9f91fd4c1a4162fd8c2cfa3c060314fa6bd18f1528257bd6f67"
+    "inboxId": "c0d87f03676ad9f91fd4c1a4162fd8c2cfa3c060314fa6bd18f1528257bd6f67",
+    "installations": 2
   },
   {
     "accountAddress": "0x5cfc6db989ea4437693cf07b681a74b501071331",
     "walletKey": "0x820e75e6c23eb1e48ed23e7abf056b3e8d2bf16b75736346d7faa25b5b76327f",
     "dbEncryptionKey": "76eb68d8c3fd46bc1b268c8a447fc6be465c1639641b0b5de1f8255ae99544b3",
-    "inboxId": "028c38ee2692b8df0d2a19ac38fa1535135d7ca13c90705bafb8d8706f2f9669"
+    "inboxId": "028c38ee2692b8df0d2a19ac38fa1535135d7ca13c90705bafb8d8706f2f9669",
+    "installations": 2
   },
   {
     "accountAddress": "0x11f2b2a10be81e4f5776dfd7f7a5bb0d9cda5f76",
     "walletKey": "0xdf8956f02a2630675d67859bb39d72f69e51c9f516f8134b8e79d3332cbd6ee4",
     "dbEncryptionKey": "0cff472bf6c9734acca0ca9fd12be746e0bfca7c078438933851bcc1337c2df2",
-    "inboxId": "1df3fa45a3a12ba5950bb859352c121be3227eefaaacaf4cd8d228f4691a2f4c"
+    "inboxId": "1df3fa45a3a12ba5950bb859352c121be3227eefaaacaf4cd8d228f4691a2f4c",
+    "installations": 2
   },
   {
     "accountAddress": "0x24db48ac1499ac8c4c12dac764bbd05c80ac4aec",
     "walletKey": "0xec498a163b0f913ac30449b0467179a1ed17582136e196568ffea3e763a6d6d0",
     "dbEncryptionKey": "01726edd0c504e4b0d8601f1f6ae74343adefed7ff2a0a4f749585630ec3f036",
-    "inboxId": "14107fc9da4a865c4113d4cda8cfd27ca96b2c897ecd5b97b55ea3288066e5bf"
+    "inboxId": "14107fc9da4a865c4113d4cda8cfd27ca96b2c897ecd5b97b55ea3288066e5bf",
+    "installations": 2
   },
   {
     "accountAddress": "0x3b5e59210e100448aed68ad813ab779b2d2bfc60",
     "walletKey": "0x1e27c8ecb3e6cc6c225e0ca54f73f9defb12d9a448025f9f92c70de02e3bf752",
     "dbEncryptionKey": "3d763ec323f89610e527b088af8c6e4d21e5b7b042dd65b55c926e449e041bb5",
-    "inboxId": "9958ada11f49ae7ea3820353779740b620807e84447be69cad195ccf48f8635a"
+    "inboxId": "9958ada11f49ae7ea3820353779740b620807e84447be69cad195ccf48f8635a",
+    "installations": 2
   },
   {
     "accountAddress": "0xffaf5fdcfe01283d2cb166272b5ec784196a9898",
     "walletKey": "0x7d47982651072796632b4dd61cc2b22c1e85905957b718d8db99b244c4f40b69",
     "dbEncryptionKey": "0c473f16428d079e2b1e95e42f96a90b5bfbda0c5a19556c173baa6ae0f9d34d",
-    "inboxId": "9d1bb3be3305c60b33825f790d699f1d39ce88b498dd587b9dee87ace44a6dc7"
+    "inboxId": "9d1bb3be3305c60b33825f790d699f1d39ce88b498dd587b9dee87ace44a6dc7",
+    "installations": 2
   },
   {
     "accountAddress": "0x4cf06297308da7180a4a7db4de45c62050b6e8b2",
     "walletKey": "0x8942cce9176ba7c28aff72f39fc9b646b83482ef9a38a519e77757858a217f54",
     "dbEncryptionKey": "6903959caa4313ce42c5a887f6ffb390892afa91ebe0ed4af9d907b0a50e6fe1",
-    "inboxId": "22e29942a351fc6ae89311c3584d2b878edbb7d0f8f9a6345a6a12a372a08054"
+    "inboxId": "22e29942a351fc6ae89311c3584d2b878edbb7d0f8f9a6345a6a12a372a08054",
+    "installations": 2
   },
   {
     "accountAddress": "0x42a5a5b2b0b65cd644c8a9b9232235aebcdaa847",
     "walletKey": "0xd494e076c28b5afce2f9d827fc7a26fda6caac01e95fcdc46a71a5c91100992b",
     "dbEncryptionKey": "8ed05b69a130020381b5b074c1482d6400f75755819be54ed4807d30080dcd6d",
-    "inboxId": "7e6240a67adf8f69cfbc0fbc30148b954fcf9f9423c3feadb5f39cca595b371d"
+    "inboxId": "7e6240a67adf8f69cfbc0fbc30148b954fcf9f9423c3feadb5f39cca595b371d",
+    "installations": 2
   },
   {
     "accountAddress": "0x0f1b8d81a28f99a442cb9f4b280ad26b5ee72814",
     "walletKey": "0xbe013a49e6bf44db6b8d1612c3341d22c9c03c6ec5ed80255bf22a98135b7948",
     "dbEncryptionKey": "932c7296ff4a36c5fb9c339c299328905456cdbf6a46df0ad1552d36f0a03741",
-    "inboxId": "be73f8e3f881ef9db5f2ad0cd46f464ab1ef55e4d6a9d1f2827a403bfa2eca6e"
+    "inboxId": "be73f8e3f881ef9db5f2ad0cd46f464ab1ef55e4d6a9d1f2827a403bfa2eca6e",
+    "installations": 2
   },
   {
     "accountAddress": "0x9d4ce81533ef874a76eeaa5b9e42c7c876a3df88",
     "walletKey": "0xce4149554de096456d40e0c7d3f63022d6d7722ba6e139c932bf9f63e365714a",
     "dbEncryptionKey": "029d021c4d1e0940a24267ba1472b51f24690c46c61924a65defe00bdba3c031",
-    "inboxId": "9761098684a1d626009070765e129df7537ec247e9933460cbb3015df9db98c3"
+    "inboxId": "9761098684a1d626009070765e129df7537ec247e9933460cbb3015df9db98c3",
+    "installations": 2
   },
   {
     "accountAddress": "0x9bc6f2c7eba78d9dc01f5dd1798a5713aabdc0ce",
     "walletKey": "0x6ccd85c5ef2aee474273dfff718faf1c5c9d17be535346c47fe847157f175a0b",
     "dbEncryptionKey": "fda883e8092d30cf414a76e874391fd0228dd7e26b8e9a7c48ba64f4d7fa9171",
-    "inboxId": "9e0ad51a425206feab3734d696cb626116a42dee07b06fe6c435825766a5c062"
+    "inboxId": "9e0ad51a425206feab3734d696cb626116a42dee07b06fe6c435825766a5c062",
+    "installations": 2
   },
   {
     "accountAddress": "0xd9b98ee7dbef80c7a7432607e9ac818d737ff887",
     "walletKey": "0x186402c64bd40a2ab93b820c00cb84d00bc52d9366b3f47f6f59c524861cb008",
     "dbEncryptionKey": "433e2dd15e48994f550a2297becf66a51355cfda662841b16855d3b40fe80d7d",
-    "inboxId": "3b1a75b8c149f7b7e20458f92af578a195ace27a76d77132c343d93055539a8d"
+    "inboxId": "3b1a75b8c149f7b7e20458f92af578a195ace27a76d77132c343d93055539a8d",
+    "installations": 2
   },
   {
     "accountAddress": "0x1a70866545162a2cf6f680f5564a199e86532760",
     "walletKey": "0xfb2c4921f86f4b2641d4e8c3b866cd81d0c2011d2e171e115d279f000cbfec53",
     "dbEncryptionKey": "57c356b82c5ab4e0aa22f7bb41a5ca76c8c4ea95c8615d521fd7f7e494b2aaf5",
-    "inboxId": "3f42f83f3972ea2b988ac1f6efce83986f69dca5c347f6911dee7eb53fbf45f6"
+    "inboxId": "3f42f83f3972ea2b988ac1f6efce83986f69dca5c347f6911dee7eb53fbf45f6",
+    "installations": 2
   },
   {
     "accountAddress": "0x4141fbcd33fb030dec49ee9c51f2e2166409dcf8",
     "walletKey": "0x981b29082d8b20e1436523b30dbafd19d36b5a9810e23101adc636475ab0c8b6",
     "dbEncryptionKey": "da31eb67a334558e38d9b8b3d3a3700d8cb4d0a36a0c8a85033e7acc9053a40b",
-    "inboxId": "6599ad9c1703602b62e389211e4e5e78e8d283d475c2330a9a4a9acaa979aa4f"
+    "inboxId": "6599ad9c1703602b62e389211e4e5e78e8d283d475c2330a9a4a9acaa979aa4f",
+    "installations": 2
   },
   {
     "accountAddress": "0x9c32dffb5632c8aa589a66b06796a281bad30b74",
     "walletKey": "0x307c721b9a0369c9b367b039693f9773b5fa1e97a71853b4cd606d79d3839090",
     "dbEncryptionKey": "ac5ba7ba7ad9cc8386458090c4efd7d29bf8abee253100e4faa42e26dbe8bc67",
-    "inboxId": "92e785bda0d4aed1233af715ebe91e48719904fb445de6c31f448eda8ce43d27"
+    "inboxId": "92e785bda0d4aed1233af715ebe91e48719904fb445de6c31f448eda8ce43d27",
+    "installations": 2
   },
   {
     "accountAddress": "0xe0bb43d91ecc5962f413e058268c9027d67f7229",
     "walletKey": "0x3839eec70be911ed36456b638150dad306ffaf10a6138c6c72abe113df45bc5b",
     "dbEncryptionKey": "72f83f4dd02f1ec8ca23239b8d87a17182a8ef14fed2ea45de8f6f15696a8e19",
-    "inboxId": "a8e0a4fbb8fe2a43a4889246c3ac4104b04ca68ac0892a59b65ecfd16878b0ac"
+    "inboxId": "a8e0a4fbb8fe2a43a4889246c3ac4104b04ca68ac0892a59b65ecfd16878b0ac",
+    "installations": 2
   },
   {
     "accountAddress": "0xd35d83aa24f8bf5fb4a24c8bba36da4ef4ed5481",
     "walletKey": "0xaf52cf08c0ca3acb1874e5365809dbc0993d7130fa61207d1973ddd77db4a40d",
     "dbEncryptionKey": "bc174c08dac091a15d600ea880c3ffbba99dc5b5b647de3c048d2f0e4fed4dae",
-    "inboxId": "190b9b8f0b2c83d298d68f821a772706681b605861401d1a59067ca3e491e2da"
+    "inboxId": "190b9b8f0b2c83d298d68f821a772706681b605861401d1a59067ca3e491e2da",
+    "installations": 2
   },
   {
     "accountAddress": "0x987cb06466ea1d52d870bc25d23ab366eadacc5b",
     "walletKey": "0xb2d2b0a30b1ffc1ea3e845780d81d9bc1a4350bb7a2dbd0ab170c7749474da0e",
     "dbEncryptionKey": "813a37280cb4ce7bc08b6b103bf8de0d3fc92b4cd1a19a55ceb13cff4f2293b1",
-    "inboxId": "c28ceda90f8ddcf833e083c58db7df9480491fbc56946d0dea0a1a7f5d7539e8"
+    "inboxId": "c28ceda90f8ddcf833e083c58db7df9480491fbc56946d0dea0a1a7f5d7539e8",
+    "installations": 2
   },
   {
     "accountAddress": "0xa0edd964db167a3632be5a19063dd741106c96dd",
     "walletKey": "0x6d2a03cee8ae5e8b50bb5212951d9692d2e311ed89492d4c9cce614a8c6b403a",
     "dbEncryptionKey": "5cde942162df112705eb9cfc4bad54b0c979e2465e114bc8b55ee7d0a8437d8d",
-    "inboxId": "afe3732f0f1c19560ae02021b64b62ee49ed6bb2bb2f13bd55f9b257dd50edcf"
+    "inboxId": "afe3732f0f1c19560ae02021b64b62ee49ed6bb2bb2f13bd55f9b257dd50edcf",
+    "installations": 2
   },
   {
     "accountAddress": "0x26409acc3c650519c8e96d6ea45e8f2ccb13d932",
     "walletKey": "0xbbd24f2e53cad2efb5ebbf140b894e1cd6d33938cda8deb18a2d3ee0f3863cba",
     "dbEncryptionKey": "12f2a2a65864896ef868082df4bb818c7e0f97abdb9d925f6af9d85d1aa464f3",
-    "inboxId": "26d2fee58ffa4b024312ea03d0cae32535d63cc3f43d0936dab185de57ef7fbe"
+    "inboxId": "26d2fee58ffa4b024312ea03d0cae32535d63cc3f43d0936dab185de57ef7fbe",
+    "installations": 2
   },
   {
     "accountAddress": "0x1cc041636820149f086f6bedcb6094f1adea0812",
     "walletKey": "0xf16345e5bc3b67603c1e93b6b705c84f74d2649682ffe17270ea19655d0f736b",
     "dbEncryptionKey": "d2d6589ddccd58d0e494e9ef3d01abe63ed3a9e870508f0f656f8bf75b91b303",
-    "inboxId": "15ef195749852eff5131a3e642b5e98ddc2413a77758bcbd3d14f395d22b1245"
+    "inboxId": "15ef195749852eff5131a3e642b5e98ddc2413a77758bcbd3d14f395d22b1245",
+    "installations": 2
   },
   {
     "accountAddress": "0x6cb54c1e5fb09cc8e6dffdf893aa9cf2f161ce25",
     "walletKey": "0x2742e88b0e2fcdafe1666ca8f9f860ee7bc046b3cf2c785140abd1f0d28f01ef",
     "dbEncryptionKey": "758c2990cb40b91db2b68ac7c4ca2bd9bb1399a0eac6f04573393151fc918ad2",
-    "inboxId": "05ba53b5e73b96962068fd920ff2a84f376c61db26f3c82af5c44a9aa0f56168"
+    "inboxId": "05ba53b5e73b96962068fd920ff2a84f376c61db26f3c82af5c44a9aa0f56168",
+    "installations": 2
   },
   {
     "accountAddress": "0x05a81999dea10599d85d26f66d9fbf8751ad1534",
     "walletKey": "0x60f2291cb05e43b35c4f26df9be1e7d6f631719578b3d195170bcb971a7de5c1",
     "dbEncryptionKey": "5de0f093f4eaa1a64bd0472c56efd80b58a6cd11626a85c7e1b0018497d25ac1",
-    "inboxId": "f86902dfc1842e292e0d993383b92ad0308e5fd3634898d3c1b4e8baa1cac889"
+    "inboxId": "f86902dfc1842e292e0d993383b92ad0308e5fd3634898d3c1b4e8baa1cac889",
+    "installations": 2
   },
   {
     "accountAddress": "0x0b00b36d7c5ee5656fbc955cf326b09bfefed33e",
     "walletKey": "0xa7b203f02f09ca7289a5c1709c271d0bb7601218c996cd805afaf3fc0660e27f",
     "dbEncryptionKey": "1b5e93e856684c924a9e508baaff263589bdfa2b93430497aaa4936a6eeaaf79",
-    "inboxId": "3fe2b80fa0c5e17a0a1e6f6b4d2382dcef7355a8664205a26dfc233968d90e39"
+    "inboxId": "3fe2b80fa0c5e17a0a1e6f6b4d2382dcef7355a8664205a26dfc233968d90e39",
+    "installations": 2
   },
   {
     "accountAddress": "0x696fa10a79c4f4d114617a45e7b85ca3fa356e67",
     "walletKey": "0x0c175f2bcd5824355b1da4bd28b451b05cc3721baa389280f18116bfb01add4b",
     "dbEncryptionKey": "51e0a85aaf03d5924ef4957106c4f0580f47985af765cddedd484a9261d4fa21",
-    "inboxId": "15f207e3a89dfba0ca4cc87e4d09f26caa82ddc64e6b8757a1997361b2318de5"
+    "inboxId": "15f207e3a89dfba0ca4cc87e4d09f26caa82ddc64e6b8757a1997361b2318de5",
+    "installations": 2
   },
   {
     "accountAddress": "0x57a59ee8ff488a6a1d7274ba6c157ffbfc9369aa",
     "walletKey": "0x97b73b2420842d7e25cb44be8ab5c9a19a68870a752b6fd71b12b6742b9a1e31",
     "dbEncryptionKey": "1304cd746bd56be859649f564162a82e81655dcf6416a28ec8a2941514ec21dc",
-    "inboxId": "f3183ea29d0caa63ba08e08b7016e525c180333edb85c6f02da2a0a851e5f08f"
+    "inboxId": "f3183ea29d0caa63ba08e08b7016e525c180333edb85c6f02da2a0a851e5f08f",
+    "installations": 2
   },
   {
     "accountAddress": "0x755a881679cfc9a1793a4f1058b4a203a9d41981",
     "walletKey": "0x4a0cedcdb99aab3fefbe2f1cf4b917b5b507bbc73aec41e78b31f97cc44d7f47",
     "dbEncryptionKey": "b93d31f2e5ad2816f117497c0cf0e6b3b9c4f6f40a42f4c22132e348559a0e12",
-    "inboxId": "4b489198d344b2cb285d8b1750a37c72a1508c2d3644fa2969dbe62f79d64d3e"
+    "inboxId": "4b489198d344b2cb285d8b1750a37c72a1508c2d3644fa2969dbe62f79d64d3e",
+    "installations": 2
   },
   {
     "accountAddress": "0xf08f9888b81ad8c4f048d558a5c13b70393968fc",
     "walletKey": "0xeb7fbae5d137f911715606cb0ac69df28ca6ca2c92decd5cada85aa3ea387268",
     "dbEncryptionKey": "88dcc2bf489c4a27a3b0258a53de82765cb8eeb67619c04b5caa5ef7d76bb681",
-    "inboxId": "d8f84b9e1a6d559b1cd56a2aeea4a7cfaee893771dff2c76fd14dfbb38f724fd"
+    "inboxId": "d8f84b9e1a6d559b1cd56a2aeea4a7cfaee893771dff2c76fd14dfbb38f724fd",
+    "installations": 2
   },
   {
     "accountAddress": "0x2d2c6ed5d20f7b7c6532177b21924e5a071a8797",
     "walletKey": "0x34a8ce2786534a945d69be71d564e4c3adff1ab1207cc92546e94258c436294f",
     "dbEncryptionKey": "2a2180ba63988ad7a4440b231334be8c23d8e5d10b6b95a88e280fda6c85f887",
-    "inboxId": "93dab6359deaa1f33ef8b11fb3e97f6ac90c568b7ef940c125b8d5293579aa7b"
+    "inboxId": "93dab6359deaa1f33ef8b11fb3e97f6ac90c568b7ef940c125b8d5293579aa7b",
+    "installations": 2
   },
   {
     "accountAddress": "0xdf9a963fc64201ab1306557cc9d435856c2b8a8b",
     "walletKey": "0x3b620ae1a088ffe05553392605fb1a73bd26e44979260b5d06c4a692f36cb2e3",
     "dbEncryptionKey": "68de7bf55e53e0a998408f267bf38b46cc63cf27dec8e41373415e95e81d0bc8",
-    "inboxId": "37292c96c5089bd9abcdca2213983b95897df0711da04dfaa5686c8e2fb362d7"
+    "inboxId": "37292c96c5089bd9abcdca2213983b95897df0711da04dfaa5686c8e2fb362d7",
+    "installations": 2
   },
   {
     "accountAddress": "0x1a7f4ebcd1680bedb779a984eef986a2498924bf",
     "walletKey": "0xfa19d7086d901431abd6bbf0a38e997145dc06ffdba19796b2a7822a1750da7c",
     "dbEncryptionKey": "282ddf1af7b80e86af1c6c1492c44dd6150382c920c2f88ccc3540bb1c3642db",
-    "inboxId": "4f22e347b5b269ad81ede2f5c1ad5646475fe554fc282d8464a27b0c78450000"
+    "inboxId": "4f22e347b5b269ad81ede2f5c1ad5646475fe554fc282d8464a27b0c78450000",
+    "installations": 2
   },
   {
     "accountAddress": "0xa650e6237318fd4d4e5253667709f3a02113a2a8",
     "walletKey": "0x3b7ffcd801803ab85fe3e65de16a5d6cac776bffdb3d0fb9b63092b9c543a041",
     "dbEncryptionKey": "0f0a5b4d2f40a5d6b5f35d16c1974f25c66c4c3805328312aee8fa9a1ac8e9bc",
-    "inboxId": "0839b8434a4e31c4cd4f220ddc1f9e4d9ef26c28c36a077ccb19315982e6fcd2"
+    "inboxId": "0839b8434a4e31c4cd4f220ddc1f9e4d9ef26c28c36a077ccb19315982e6fcd2",
+    "installations": 2
   },
   {
     "accountAddress": "0xd25ff32f7ab9501f369687e1b831a00d14e0ec42",
     "walletKey": "0x14acd966769f32a0f15eca7aeb3a0bfc89238784e20ec47368dd6b3bbbc37781",
     "dbEncryptionKey": "58a0f68d988e52417bdf490ac1de7a8d71083fb7355eb19b26223406f6d00270",
-    "inboxId": "c855add569084ec5490fe7bccfd84119012f682e1b7d174d1d39f047554efdba"
+    "inboxId": "c855add569084ec5490fe7bccfd84119012f682e1b7d174d1d39f047554efdba",
+    "installations": 2
   },
   {
     "accountAddress": "0xff5b1921bb1665224ae5a997098592696cfe6237",
     "walletKey": "0x47e2b8b91c04490aee73a11431f3381f24876dd05f05b8170681841bdf52b039",
     "dbEncryptionKey": "25d026cab4ba0ab1af14a8a53d9db27e7c9efc67c2c99793e0434331ba18466a",
-    "inboxId": "b0811a3c9de67b10481e98e531088eae56cedf7a6a83cc6f36c8d80b3d1b19b7"
+    "inboxId": "b0811a3c9de67b10481e98e531088eae56cedf7a6a83cc6f36c8d80b3d1b19b7",
+    "installations": 2
   },
   {
     "accountAddress": "0x01523cd0bd63b234267aeb24bc87eb57607f1bbc",
     "walletKey": "0x28c53bb9fc071031287a00e5fad2bcf12c08832d6f9af9446dbf0ba4cdb9316e",
     "dbEncryptionKey": "3c13ecfcd2391f29cd46bf94e21a13e3a97a847bdc244dcec382cea387dae925",
-    "inboxId": "95b99dfa8b247dd69fdfb5c28983bcbcddbef4d66615edbc1c59a66fd4fc83c6"
+    "inboxId": "95b99dfa8b247dd69fdfb5c28983bcbcddbef4d66615edbc1c59a66fd4fc83c6",
+    "installations": 2
   },
   {
     "accountAddress": "0x50d3800b1022bbe062499698be791105dea1dde1",
     "walletKey": "0x0b9144fe9564008d9178adeb020e6c85b2cb659c2662c3bc6851752ce8b3b05f",
     "dbEncryptionKey": "1c9f26ab71aeff4d77b89380c6d4c2e81ad8690ab9be694ce2614ca34d2651bd",
-    "inboxId": "ad9cdaa18624a135ebadc800de90381467b2047c28fc7878c0735d69d8f98f69"
+    "inboxId": "ad9cdaa18624a135ebadc800de90381467b2047c28fc7878c0735d69d8f98f69",
+    "installations": 2
   },
   {
     "accountAddress": "0xf1e6a770aa1cad2ca82aa6c0633c6e9ac3429528",
     "walletKey": "0x99625d58ccad59a96650815b89cc55c7e9402bd76691d8a120743f77e5d6b199",
     "dbEncryptionKey": "7d820e2e2b62e9c687ecb2b8927ef8b97844699639cb1ae4238b4d5748d8feae",
-    "inboxId": "c8cc5d8a0e6bf1fb711419cb87d024ebdee068e1ae66e0a70a06d5c31b531456"
+    "inboxId": "c8cc5d8a0e6bf1fb711419cb87d024ebdee068e1ae66e0a70a06d5c31b531456",
+    "installations": 2
   },
   {
     "accountAddress": "0x0de23940275369d1919eb53ef8cd7c02724302aa",
     "walletKey": "0x108bd528f25653019a09e13c6976b05203f4255ea730a2ac7fcdff8dff75e64d",
     "dbEncryptionKey": "21feb9e4fc5b16e1b236fc26f1e4705849a1b0be3e8521b224bda38b4ad1361b",
-    "inboxId": "73748b538ad1796298be10499733d794ff22071a69ecc71f773a414b9115f84c"
+    "inboxId": "73748b538ad1796298be10499733d794ff22071a69ecc71f773a414b9115f84c",
+    "installations": 2
   },
   {
     "accountAddress": "0x3f72e1c18e2e0fb811ff9bc53c924114bba9984b",
     "walletKey": "0x25a299a9d3febbeaae86ce9c46dadd798fbf07195f112131acc6ed7199437cc3",
     "dbEncryptionKey": "ea3348ec548509dc4c2b9057fd8e171ea30a3fd861aa13a8025f5acf530b5c86",
-    "inboxId": "31c8ac8bb3962fbbb82afc845bfb5475325595cdc1bf6992c7fa8bf64f808430"
+    "inboxId": "31c8ac8bb3962fbbb82afc845bfb5475325595cdc1bf6992c7fa8bf64f808430",
+    "installations": 2
   },
   {
     "accountAddress": "0x8a5fb07d44f4fb7694144d32583043f3e8d1e678",
     "walletKey": "0xaa5ff0d0e816bbf4973d6a85e0d5af0a91777f556d68a3bf8f7d6e327da31012",
     "dbEncryptionKey": "9f16acb01cd3ae6f10e1ea210b00261434efdba07cfaeffdf43f8610ffeeffea",
-    "inboxId": "81d6bd909eafc5c6cd01636ff13ca3e0a2ca162581f3cbbad0b9e231898862fc"
+    "inboxId": "81d6bd909eafc5c6cd01636ff13ca3e0a2ca162581f3cbbad0b9e231898862fc",
+    "installations": 2
   },
   {
     "accountAddress": "0xb8bb50a784b5a201bba11f15405b91baaa059a99",
     "walletKey": "0x55f49a824a87807aee31abe6705c5fb9665b49fa2b3ea2105d2b02e08d10cb39",
     "dbEncryptionKey": "a70fdb3428a90ddc3372f102fc79a9748bd6491b823c4332e634e3de19f7d77a",
-    "inboxId": "1da45e0f68837a9b34bc46f1c555d8e1b9e61c62cf7d39bd3678aa8c4cc3c650"
+    "inboxId": "1da45e0f68837a9b34bc46f1c555d8e1b9e61c62cf7d39bd3678aa8c4cc3c650",
+    "installations": 2
   },
   {
     "accountAddress": "0xe2c43c4272aea82a2bb078a94f6d20e52a9f447b",
     "walletKey": "0xd5a3bb3fb90b9f80bc9fc58c7077229dcdbef7b4413604a57e54f64eba72b6bb",
     "dbEncryptionKey": "2d2ff863bc424e9af4221bd443ef409151a1d9674afa4b96a43afdaa2f714a52",
-    "inboxId": "a9488f3a5194c213a089a8af06365de0bf303d115673e7d04b4bdffcaa6efacb"
+    "inboxId": "a9488f3a5194c213a089a8af06365de0bf303d115673e7d04b4bdffcaa6efacb",
+    "installations": 2
   },
   {
     "accountAddress": "0x1b4eec0ea2d578bf323706231c3cc79628193caf",
     "walletKey": "0xc8c3bfcd970f80bf178b64cd17b093024235c1d46e9002699705b46ea6db30be",
     "dbEncryptionKey": "123f710ffa532e41598d965dc7620eee203fb495c8fa96b9466b2817c1ce4fe0",
-    "inboxId": "b1aafbe54b29d47cfbae45c990e6bb6817fb72ee934f44d36973042348198c1a"
+    "inboxId": "b1aafbe54b29d47cfbae45c990e6bb6817fb72ee934f44d36973042348198c1a",
+    "installations": 2
   },
   {
     "accountAddress": "0x9111b452e77c4dc7630e28fb6337e95cfd33eff9",
     "walletKey": "0xe754c5bb2736721e51ee46198cf004946b54281498a60b14e6259a04bc477f37",
     "dbEncryptionKey": "871cc940b56851242485403a7ae1870ba9557474f6e9d270b37779cbb3fe9b1b",
-    "inboxId": "a17446c704bed5fd2cf3078e33010102e6cd239926393c78a9d69dfbed64165b"
+    "inboxId": "a17446c704bed5fd2cf3078e33010102e6cd239926393c78a9d69dfbed64165b",
+    "installations": 2
   },
   {
     "accountAddress": "0x2261aa9b4b360e2cfef95f17e2ba766a1295bd58",
     "walletKey": "0x53646f89533579d91ab765a475b0b9a26e2c7f2f79766e8049f76789ecb9236d",
     "dbEncryptionKey": "8252d053e1cca0d1d91c94d4cf95bd385e707b4b0d554da1537c2afae403fe9d",
-    "inboxId": "6d556b0589b30b2fa4611cedcc9e179f8f97fae465791204fde117d78c37c84d"
+    "inboxId": "6d556b0589b30b2fa4611cedcc9e179f8f97fae465791204fde117d78c37c84d",
+    "installations": 2
   },
   {
     "accountAddress": "0x4c5ab0e6a96fd0bcf086140a8c3dfdc0e94044d0",
     "walletKey": "0xda6cea5eed75e44cf1af093457851d372d7463955158cdbc602773c0dedb9ea2",
     "dbEncryptionKey": "894c36da5e567959d92538e3bc45f2fb6ff358d3fba94d444a62dce21310c801",
-    "inboxId": "6a676f9aa900a5ca7708cb81efd091b45334d6397440ea3f515a32ee1303bc9b"
+    "inboxId": "6a676f9aa900a5ca7708cb81efd091b45334d6397440ea3f515a32ee1303bc9b",
+    "installations": 2
   },
   {
     "accountAddress": "0xf535ff204738d8cb3d8c1f6765cc74b7c9903376",
     "walletKey": "0xa5694e79a6c3a553c0b64b76b6ccc88a91880a32921be752c23f58a5604a8e5f",
     "dbEncryptionKey": "43e63334245f52bf1015ae9304aca0f88f8f1979c53f17f80632aecab3d04260",
-    "inboxId": "a17f24ab754a18c4d48a70ca15271741ecdabc4517289391546ec0e4e279c7f3"
+    "inboxId": "a17f24ab754a18c4d48a70ca15271741ecdabc4517289391546ec0e4e279c7f3",
+    "installations": 2
   },
   {
     "accountAddress": "0xacfc9c6b300af15205d9adfe523ce813f8d5e451",
     "walletKey": "0xa7a8e75b0a865f659c7e978de437bddef62931da8b541184ff7d3eda0c6e9892",
     "dbEncryptionKey": "b4561715401fa6898905c7382ecd1aa5ee914a9dd48c48eb3a9667f3775a84d8",
-    "inboxId": "77ec8aa3853696d57ff65c3e9c9fe6ced2ae81448a7188353774d56e16df2022"
+    "inboxId": "77ec8aa3853696d57ff65c3e9c9fe6ced2ae81448a7188353774d56e16df2022",
+    "installations": 2
   },
   {
     "accountAddress": "0xb6c435643ce82a8092ef57a45f66ffb9e3b1a627",
     "walletKey": "0xb742c13a723e11821ba539a29c58c698a98398d285392344e4ff425866eecd88",
     "dbEncryptionKey": "59fb646299a9dc3d443849884f392893cb78026b9463ab3f5cfcaed227825a64",
-    "inboxId": "ce3da43f70fb829b15ceb5dfdb52c345de7f2a292ee565feeb6976b61a8c3bc7"
+    "inboxId": "ce3da43f70fb829b15ceb5dfdb52c345de7f2a292ee565feeb6976b61a8c3bc7",
+    "installations": 2
   },
   {
     "accountAddress": "0x79904e67227ad6d2046a54c1bb22ceaf33687c50",
     "walletKey": "0xcc3b8f51c5ca21e883ba28594d364f67cbcf80d69b22f49735c9c7a4d91009b7",
     "dbEncryptionKey": "fbae833a7f29596a78516ca8af8dec838a7cb7b67bb18b6b7b9aa90585667b6e",
-    "inboxId": "eb7b2ca72c09f310f3d0e15cbdb5a8d3aa26761ac397a6e86b63d57728c71b27"
+    "inboxId": "eb7b2ca72c09f310f3d0e15cbdb5a8d3aa26761ac397a6e86b63d57728c71b27",
+    "installations": 2
   },
   {
     "accountAddress": "0xefef8f169579bdad12a1eb0d9d9d814d968d4d39",
     "walletKey": "0xc0da50d175484e26c92e4797e9e5ed87f5fe79e1d42138769cddc66f8d272d38",
     "dbEncryptionKey": "b7fd255df7c7fe7a5adffd6467660040c34325131af32cf7b87ba8a43a548da9",
-    "inboxId": "583db3f766c152e9fec756ec79988a7ea3eb436de19e07d253eaf71cd6f9383f"
+    "inboxId": "583db3f766c152e9fec756ec79988a7ea3eb436de19e07d253eaf71cd6f9383f",
+    "installations": 2
   },
   {
     "accountAddress": "0xc019f16d10eec130fa99970f51fb8417762a44d3",
     "walletKey": "0x604ab0f73fbed1e1e70b69bd72086f35a8be4df5a52c582410eaef8f77bd8311",
     "dbEncryptionKey": "3ff0751bf98dc44640ad5ccaa7e19d97e17a93efff1e7f7eb58c4713eceb617a",
-    "inboxId": "378ba1f097a0fc79c158cf65c8bcccd61f6946b1cb177747a291b5fcb46b9f1b"
+    "inboxId": "378ba1f097a0fc79c158cf65c8bcccd61f6946b1cb177747a291b5fcb46b9f1b",
+    "installations": 2
   },
   {
     "accountAddress": "0xe2a83c566f31e138dd0c60abf8518fdf4615d401",
     "walletKey": "0x74c631f2a57ce81b2eb23e3f6c613a9fe5b17f2329b8777d561dae24fd8fe34a",
     "dbEncryptionKey": "da4120ef8e10ca6ffd585bc094b9c79151e172c158089802cfecd8f306aa9640",
-    "inboxId": "16275227c06ebd8bcdcc591f34aae8d5e85ed7c79c3253b1872bef725f39ac7b"
+    "inboxId": "16275227c06ebd8bcdcc591f34aae8d5e85ed7c79c3253b1872bef725f39ac7b",
+    "installations": 2
   },
   {
     "accountAddress": "0x2e9395c07bc1fe94302fda71fa5d03122135125e",
     "walletKey": "0xd3ea27cc70ddcdea7a3b2f578de26d35529a209a02b132fc8a8a808c6618420c",
     "dbEncryptionKey": "d749a41f21a964bfafe439e59f73b8231b65d628a991afe49126be14e172ed6d",
-    "inboxId": "c1b9cf27446331c7ee11c4f507b2835e356684db2ca05cf475b6389927c3d147"
+    "inboxId": "c1b9cf27446331c7ee11c4f507b2835e356684db2ca05cf475b6389927c3d147",
+    "installations": 2
   },
   {
     "accountAddress": "0x4f98588ddd6c3d26e1ba34b145aa81c439eaba86",
     "walletKey": "0xdc78a63a8c48156344d3a01a31d7e08f9ce8ce04a1887afcce95811b61b06e40",
     "dbEncryptionKey": "a765d32b0f879af4e629edc52aa539b96d663d3b0528aa9b1abf6e10e7bdb02e",
-    "inboxId": "51bfe8ce608f5b5dd212c4af2ce54f69f84b1aba22d5851b7074ce43915f0045"
+    "inboxId": "51bfe8ce608f5b5dd212c4af2ce54f69f84b1aba22d5851b7074ce43915f0045",
+    "installations": 2
   },
   {
     "accountAddress": "0x66c14478df4f8feaeac6600cd89da90bb60b12db",
     "walletKey": "0xc874a6cb673c757e7c33e4a48e510db2f5c603de708dd9c94820eed2c6c38689",
     "dbEncryptionKey": "0cb6981dd4dde5d7e30039b621ac0382e8fd09379fe468cfea60c0bafda7eef0",
-    "inboxId": "7e20be75689fe553debf4569cd2775b442ac4de0ba5777bd9a975736c83b9ae2"
+    "inboxId": "7e20be75689fe553debf4569cd2775b442ac4de0ba5777bd9a975736c83b9ae2",
+    "installations": 2
   },
   {
     "accountAddress": "0x01c5bbf0ec328872f1ff5e62fcfcedad99cb5e92",
     "walletKey": "0xc4956a9a0bd5f3e63053f2bf879ce30eaaa18c26e93bf4a0b131439f6a5ad050",
     "dbEncryptionKey": "2bebfbc3dee21ffa46c3da73c1601bce0bb7efb79ec4eb20eba2741b83274d26",
-    "inboxId": "48c49138cfdf4f1743e56808326aade4e2d1ab37a9ad50b12daa7575c3d6ab14"
+    "inboxId": "48c49138cfdf4f1743e56808326aade4e2d1ab37a9ad50b12daa7575c3d6ab14",
+    "installations": 2
   },
   {
     "accountAddress": "0x284711b740d8c6f0dc13b1e915079f760ae04907",
     "walletKey": "0x6e518d6638f7773b1e37e88b47d1a9e07cda636168f941be7b85b9c3ef34a732",
     "dbEncryptionKey": "0b61acbcfff03952e045d1f4ff18d5843d7b282a3c6c397db3e38e1cea10d60e",
-    "inboxId": "4e87d29f9adabd29fc70f0dd02113194c8de73e79a75f1251fc1fa662e52ad5e"
+    "inboxId": "4e87d29f9adabd29fc70f0dd02113194c8de73e79a75f1251fc1fa662e52ad5e",
+    "installations": 2
   },
   {
     "accountAddress": "0x93347ef4294ecf07cccfa377c29f585737dfb82b",
     "walletKey": "0x1707a614413505d2133a1c9ad7ec6795af1371204687f1c521a293c6e664eb94",
     "dbEncryptionKey": "6037c162009060ecf42b8e07729c3095bb17016c5905ec0ff387048ea2471b68",
-    "inboxId": "aa0f3719593ada267993d7bd0ff7f0cc5c748c4a5cc8f947b2040be2d9830918"
+    "inboxId": "aa0f3719593ada267993d7bd0ff7f0cc5c748c4a5cc8f947b2040be2d9830918",
+    "installations": 2
   },
   {
     "accountAddress": "0x2a09019ca69e8721ae36eb183e63e4ca644a5a88",
     "walletKey": "0xdd3b9a955884a4105ab5cf836add63b310120acdb9307bfa1491af81201ce82a",
     "dbEncryptionKey": "8f72562c5554a7239bba3e04f0b072d7d78087b6e8719cd7e67c85127484010c",
-    "inboxId": "2d6abbcafa41e24440b079f8b008af2914c0818aed40073b98a917f7604a0412"
+    "inboxId": "2d6abbcafa41e24440b079f8b008af2914c0818aed40073b98a917f7604a0412",
+    "installations": 2
   },
   {
     "accountAddress": "0xfd14d4a067c8a6d7a7c62d9da9c07c18e792b465",
     "walletKey": "0xd61639dded785e54d5d7f38b68ca0221f3d5efb6c1b3aeb6165775b2f9658a3d",
     "dbEncryptionKey": "a013c5fcc04c336cc994d6ce2f7c26228b33fa5d31ef0898a969f9481b42967c",
-    "inboxId": "e3e23e2563b7a7ed894c36ae5afd773fe547e5411b6a4ec73431ff474d423653"
+    "inboxId": "e3e23e2563b7a7ed894c36ae5afd773fe547e5411b6a4ec73431ff474d423653",
+    "installations": 2
   },
   {
     "accountAddress": "0xc827d25e75eeb804bdd26bde0e58f848fc000285",
     "walletKey": "0x025ec6f49c444ea7ea558fd105237e43ef43ba2a8247fdb543445fe141b10721",
     "dbEncryptionKey": "713c666ed8396408103a390468cd53298e7967d51b9cc204628f7532bd5be986",
-    "inboxId": "6dd235438030ce2ca4b88587905b98ccd3b53fbcd38f2a2b11146546e38eaab0"
+    "inboxId": "6dd235438030ce2ca4b88587905b98ccd3b53fbcd38f2a2b11146546e38eaab0",
+    "installations": 2
   },
   {
     "accountAddress": "0xd295e6633406066bb514b5c718a7cac3cb5cdba3",
     "walletKey": "0x4623fdd35841416add305d79734a3f1cc9e382cc8cd402fe063fe1c268998f1d",
     "dbEncryptionKey": "dc8e62fdc13ceecf5eaa43519aa9fc2aebca457a13a4c02319fb5de44dea2b90",
-    "inboxId": "77f75ba7a3fbf054d1931b951a76ffd42096620e8dfd59ef028b88b381fafb9d"
+    "inboxId": "77f75ba7a3fbf054d1931b951a76ffd42096620e8dfd59ef028b88b381fafb9d",
+    "installations": 2
   },
   {
     "accountAddress": "0x93f65daba98f7ef5e00b8f1e783af4a4d6a792ce",
     "walletKey": "0x903eb67535d54dbf792574b2c939ce8d00e4f7db568a574ecae0627972f75623",
     "dbEncryptionKey": "c37292d589ce22fed06aab16031c7e88129f645827f0e406cb2b92fb7007d236",
-    "inboxId": "2b6feb45ec3346cbb6006ebe806a2c3b6bb271f4eab6f5e710b19ba95af977ea"
+    "inboxId": "2b6feb45ec3346cbb6006ebe806a2c3b6bb271f4eab6f5e710b19ba95af977ea",
+    "installations": 2
   },
   {
     "accountAddress": "0x873f3d88a57e0bc43fc00ae9a246d70970f2259d",
     "walletKey": "0xa22ba9027c222b66ea961e4c04a9be57d10dc579fb0479fbcbc236ffc3292c19",
     "dbEncryptionKey": "6d6e9f57eb0d301d8fa97656934dfc65534238e10eaea4a9a0aa63d77dfd5527",
-    "inboxId": "1632e92fc89c8d859439061bb391c773edd16624dd5257e17eb8db074887363c"
+    "inboxId": "1632e92fc89c8d859439061bb391c773edd16624dd5257e17eb8db074887363c",
+    "installations": 2
   },
   {
     "accountAddress": "0x867fdc42842094045b586fd50821bdf5b6a64cae",
     "walletKey": "0xcd411b5b873250c6ad27446c7b422bb19eddaf434f3e5d98ff561d88ac9a36fc",
     "dbEncryptionKey": "1959c2a61e7d57a93880c1c121be2f33e591c44a43f8c98209c6e178429eba86",
-    "inboxId": "4681b543f7370515e584c1a6271d42e35ef34460902e812a4bbf5bf41bddb2ea"
+    "inboxId": "4681b543f7370515e584c1a6271d42e35ef34460902e812a4bbf5bf41bddb2ea",
+    "installations": 2
   },
   {
     "accountAddress": "0x8025f7e8b9801a991b173e398cb5da363532e2ba",
     "walletKey": "0x80ad27669257e35b0d508478f2767330c7298a188fae5d9197c6b74147f41fca",
     "dbEncryptionKey": "1eba8082773b22e0681acfedea989ea4b9f547dfa9e8102e047a4459301caa40",
-    "inboxId": "e9eb1e179e4b8f1aab311cfc615f1c5acb81cb0e5593af4ad4a5a4bd013bb340"
+    "inboxId": "e9eb1e179e4b8f1aab311cfc615f1c5acb81cb0e5593af4ad4a5a4bd013bb340",
+    "installations": 2
   },
   {
     "accountAddress": "0x3621f116795e0eaa9e75e037480a45afaddf36f3",
     "walletKey": "0x05866cfc70a95ef46700812699ab22401b7e20c2fcea4e5f1259c7c44429baf7",
     "dbEncryptionKey": "69cd1f9b9f8d387a7c6c5bf4591d776300d22603ea810c0071a0c30f7b9bee89",
-    "inboxId": "f4ce9a458336f33ae20d614344966fca8bec60030de5cd615e2f3cfed10549fb"
+    "inboxId": "f4ce9a458336f33ae20d614344966fca8bec60030de5cd615e2f3cfed10549fb",
+    "installations": 2
   },
   {
     "accountAddress": "0x8710ec8c5eb024e7c13aa48034bffe43338e827d",
     "walletKey": "0x9aa4c404c94d99d10716c93476df8999e286856cac1ed66119ed0d0119b6e96e",
     "dbEncryptionKey": "4cdadf6f056398396c9835ee627d8325c8c1dfb38a3d8700e7f3dbf5efcf38c7",
-    "inboxId": "0c41a2b1525a7a42e6f6272e1ed493cd3ab6ad1f45dc2ffd08f910b77709ee3a"
+    "inboxId": "0c41a2b1525a7a42e6f6272e1ed493cd3ab6ad1f45dc2ffd08f910b77709ee3a",
+    "installations": 2
   },
   {
     "accountAddress": "0xfa2b964f3fca3b4a29df4b0c12aaa47c860cca33",
     "walletKey": "0x60887bf0874323dcdb8400706b3acaf85ab3c38cf0110dfb0a56786f0819de8e",
     "dbEncryptionKey": "51a59a0bcfc3d29f4e6526a9f039da788bcf32f5339e13a865bea97cf739ded7",
-    "inboxId": "dfe0fa04d2c2d792be88df2173655d68ac1f2f86924a3af109e316d48893cb4e"
+    "inboxId": "dfe0fa04d2c2d792be88df2173655d68ac1f2f86924a3af109e316d48893cb4e",
+    "installations": 2
   },
   {
     "accountAddress": "0x2fed57125ebaf38cf0cd56bece4185ba7c014f6c",
     "walletKey": "0xccf6ecb394d8e49eb55567deebbf7eab15e3fc1f0ce176f22784d1967623d3ed",
     "dbEncryptionKey": "33bdbc0c67a538c44a5aa0888333edb91e24e513ae965b702d779c8cd1225c4c",
-    "inboxId": "5be19391f66f0b4df210bc646cb033ef7be20b57d6b002b0dc748b261b9ddf29"
+    "inboxId": "5be19391f66f0b4df210bc646cb033ef7be20b57d6b002b0dc748b261b9ddf29",
+    "installations": 2
   },
   {
     "accountAddress": "0xb37439e9c7d02c2bc27aee66d1ea3a74e53dd7c4",
     "walletKey": "0x4879e4bb94e3908ef01ec2529bed725a6bea6bc8e59e14772c2ce3f6ccbc6b9b",
     "dbEncryptionKey": "23d31b233996e758c4d05dbbc6456176bce24f8419f684eb95e4734fc92ec190",
-    "inboxId": "36dcedfdd9f86c5c33e5d3b6dc21f3bc9d14bd9bb32be307fe692e359dcfdbc4"
+    "inboxId": "36dcedfdd9f86c5c33e5d3b6dc21f3bc9d14bd9bb32be307fe692e359dcfdbc4",
+    "installations": 2
   },
   {
     "accountAddress": "0x0b10c8597cf397e236c1394f4be58ef2c10b4fb8",
     "walletKey": "0x5b772cc4ca4de15ebda64cc1a0f0f846abca8aef62892cd6f50c0105a8dd3b8c",
     "dbEncryptionKey": "2e816dee6615de6305980d5284a5bb5d96114769e9f48ffd4a6589147b13805e",
-    "inboxId": "001ba805a9d904ba1b67cf681d5b02d6c7db904c1c1c343445f4cf3349a876b3"
+    "inboxId": "001ba805a9d904ba1b67cf681d5b02d6c7db904c1c1c343445f4cf3349a876b3",
+    "installations": 2
   },
   {
     "accountAddress": "0xfe914ca9d811645a5b8ddb60334822fb4a8b9afc",
     "walletKey": "0x19e3844cc67f4f195a1e22703a570a1984bfd09f22be5264a3b59294dcfdebcf",
     "dbEncryptionKey": "1130f1ca485d3f914a88c48b790517d0a2872359b42b19055b4e575613285d1d",
-    "inboxId": "34672f02a817ec3394f6a6c631e1aad9812149f4207b5636619a00cd4a51f2ef"
+    "inboxId": "34672f02a817ec3394f6a6c631e1aad9812149f4207b5636619a00cd4a51f2ef",
+    "installations": 2
   },
   {
     "accountAddress": "0xe4cb732486659ada144eae5ae7472df13f3b6c80",
     "walletKey": "0x6113cba1bd1c5443cf297f403d2a0f4ac3c4c62227168e54464b0ec739e2c754",
     "dbEncryptionKey": "04f8f7e067022b496467af2a3ce2acedbbaccfb0a9153962e0a43eb98c578b23",
-    "inboxId": "c5aee18197ae2bbaa4b91745bc0fef418a54f51168c038426da94d039aac9169"
+    "inboxId": "c5aee18197ae2bbaa4b91745bc0fef418a54f51168c038426da94d039aac9169",
+    "installations": 2
   },
   {
     "accountAddress": "0x7e497ea7d0fc895a683f6fd9b769312b1128cb9d",
     "walletKey": "0x9f09616da84ef8309f073d9bf88523d00d9cfa51b0375d7da14f9d7160711241",
     "dbEncryptionKey": "21a4596262c38399702a286a4cbdf083445f10fc4fdfbe951ef0dcd016288b65",
-    "inboxId": "bc3689d6449e2af5f3521abbeb69bac2b68e389005ac554ac6100e54b998c867"
+    "inboxId": "bc3689d6449e2af5f3521abbeb69bac2b68e389005ac554ac6100e54b998c867",
+    "installations": 2
   },
   {
     "accountAddress": "0xb915887c9e0ccb2d8d47be55a6f9eb3049c4a9f5",
     "walletKey": "0x2c69b131b89b0599bcf8c72c980f6d1d234edf928db32a00bb193e3c4a3552ca",
     "dbEncryptionKey": "87260b4d26ac7fc148d47cb2893f058018540d2292bd9685cd1edafc168f616e",
-    "inboxId": "f345f3237c82085c13027b666960027046214456bc33d2c97ecadab9c84d94dc"
+    "inboxId": "f345f3237c82085c13027b666960027046214456bc33d2c97ecadab9c84d94dc",
+    "installations": 2
   },
   {
     "accountAddress": "0x88ce9b5ccba770985c412b5294da6c58db9ddfdf",
     "walletKey": "0xbfb1ed9a4437cf3650005e695e549a1581398329593f9ee6e27defef94112088",
     "dbEncryptionKey": "64d89c40d57a869156c8440062cb5995d1e4aed9952c910a54669547edd821a9",
-    "inboxId": "4b62ec2f0b311df784dc855f1fd328cc6c8500be4191e641e8741edebd64e09e"
+    "inboxId": "4b62ec2f0b311df784dc855f1fd328cc6c8500be4191e641e8741edebd64e09e",
+    "installations": 2
   },
   {
     "accountAddress": "0xa7a9477d0a3d0cb25af2ce42948fd3e34a7a5387",
     "walletKey": "0xfaf45a80d3cb3d9ba154cb7fb771a079734a6e9e0f91ca83b1e16f6f912953c2",
     "dbEncryptionKey": "9e7c1483fdd596f02a6cc6e1a6e78eebe07efc38c80a609cededbef6b1cad8b4",
-    "inboxId": "13067bf82e5d740eac45813598032ba72077afed14a42009c9e15515416d3f64"
+    "inboxId": "13067bf82e5d740eac45813598032ba72077afed14a42009c9e15515416d3f64",
+    "installations": 2
   },
   {
     "accountAddress": "0xcaf559e0bc0f59697baf63a252c6460d084d15b4",
     "walletKey": "0x1c54dde4cf563439824b644e11ad02ac01d3c40a76080ef178f68a507b4a2a01",
     "dbEncryptionKey": "f667af58963f50c8dc3612dc40d89286acd555a79d2947329026342b73f25879",
-    "inboxId": "b8a53b5629afdeff40d0e9deb56f3204ae0ee7071f8f9642088cabf43ac2dd88"
+    "inboxId": "b8a53b5629afdeff40d0e9deb56f3204ae0ee7071f8f9642088cabf43ac2dd88",
+    "installations": 2
   },
   {
     "accountAddress": "0x6b18d2d6a0d5004a0faed63281c518d7ccaf3c4c",
     "walletKey": "0xdb8fd2526eb4a4f18ef405229bd1b6fc0bff8ec3dff0d3d55f06c4323ba31379",
     "dbEncryptionKey": "a5f5fd4942addb06be13bdc6c1f039544025c2eb366db94413323390e7d7ac67",
-    "inboxId": "5a83c8577981458f25dbaff10ace327fb7f23e60b7075214e4e03af974f59e05"
+    "inboxId": "5a83c8577981458f25dbaff10ace327fb7f23e60b7075214e4e03af974f59e05",
+    "installations": 2
   },
   {
     "accountAddress": "0x16c07772b720383d24ab54e97d7eb6ac85703c26",
     "walletKey": "0x005e9c0a9f0d36beecee499a07e2b5a2d70e599190084fcf65904eec7d8aaa6e",
     "dbEncryptionKey": "27d1efad75f183cad9bc24db82b41c0ef573807fa14c76974884ed11170d2327",
-    "inboxId": "9bff703159cd5d7b18170868bd752dfa5ca887b282b9ad6bd68fa76c4579672e"
+    "inboxId": "9bff703159cd5d7b18170868bd752dfa5ca887b282b9ad6bd68fa76c4579672e",
+    "installations": 2
   },
   {
     "accountAddress": "0x520937be9f1ecc8cfcec80292b648831032f4f22",
     "walletKey": "0x55bc69b6b451f4590f38e3c8bfdec1d583dffabcf1b6766a66dd0613dcb41373",
     "dbEncryptionKey": "39a14558dbb8ed55b193c80101beb5fdd994ab05fbdd38cc5e1cfa1135dcb846",
-    "inboxId": "8c870364c00d6cbe37846e9c67db9f31fd8d1f35e984b99bd4f4ced6ae027185"
+    "inboxId": "8c870364c00d6cbe37846e9c67db9f31fd8d1f35e984b99bd4f4ced6ae027185",
+    "installations": 2
   },
   {
     "accountAddress": "0x7c44d4df6f2045f9edc1d62e4b4730a8af743e22",
     "walletKey": "0x217893ddf3333e7a585b715ca27cc9593791ce2eda7f8a2be3e479c4d66a1318",
     "dbEncryptionKey": "1c59c4c363e449adbca855117b6a25fd0f5e6b199efc630d6d1118116e1a0a5c",
-    "inboxId": "4559f865a1eb5bdec2d6ba8e9942f4f956bb4f6a63e20a167dcabd5181a389f0"
+    "inboxId": "4559f865a1eb5bdec2d6ba8e9942f4f956bb4f6a63e20a167dcabd5181a389f0",
+    "installations": 2
   },
   {
     "accountAddress": "0xf44b30cfe275f9fc586f0c6c5fd34cfeba04ded9",
     "walletKey": "0x9ecee412c730fd25c7017aa8d11c22b4ee85f2045ac03ce8a15f092275ebcd03",
     "dbEncryptionKey": "316ce59ab4502921d0cada230095e4d288e2a26a627bc46c726ead00973b9b52",
-    "inboxId": "597b289bbfbaa6dc6846ffdbfa30b027b15837e4308a729ba801aa2c176bc3c7"
+    "inboxId": "597b289bbfbaa6dc6846ffdbfa30b027b15837e4308a729ba801aa2c176bc3c7",
+    "installations": 2
   },
   {
     "accountAddress": "0xded93116cc94e28d3f43a3c2f953debbedf38e3d",
     "walletKey": "0x74a5d6a5dfe29692f70af94369f531a33cfeed5ecfbe5afbe8b07840cc2c7fab",
     "dbEncryptionKey": "541a5c034aeb4d2841dc4f25223a21fc6a47cd3ca6a9c6dea5deebcbddb618d6",
-    "inboxId": "3b149434eaca4570293f61f7d7df1a7afaddad2277f5bbebfdd8473763aa7889"
+    "inboxId": "3b149434eaca4570293f61f7d7df1a7afaddad2277f5bbebfdd8473763aa7889",
+    "installations": 2
   },
   {
     "accountAddress": "0x4dd2c74e53d06c2147e06c9326975d8de86c1edf",
     "walletKey": "0xfb3209a5572ea766317663cbefe18d713bf12601d60bbc9cae04311cc855549f",
     "dbEncryptionKey": "edb218ba00c02c07609dcdc84b4259325aee52cff053d1d5602369efba97f11d",
-    "inboxId": "40fb0315299e6a9d7a67b366eecd868923bbd0873ce9d0e7987a730e9a464f1e"
+    "inboxId": "40fb0315299e6a9d7a67b366eecd868923bbd0873ce9d0e7987a730e9a464f1e",
+    "installations": 2
   },
   {
     "accountAddress": "0x6bffebae3aa5c57d78d12cdc340289d2c6766da0",
     "walletKey": "0xc8dd8f841109959ca1f7e00d52cdfc495be67ff47dad7fdc6fa8a75af1f3be36",
     "dbEncryptionKey": "cd5734ae61cd6aa0e1bbdf0b93702642e07ed1138d663f01403ea9b5aae84eb8",
-    "inboxId": "c3ad267b61d59f83dd9d5fe09a6666597ef782fce6ee52a11b260c2ba4885eaf"
+    "inboxId": "c3ad267b61d59f83dd9d5fe09a6666597ef782fce6ee52a11b260c2ba4885eaf",
+    "installations": 2
   },
   {
     "accountAddress": "0xf7f4a2e13d5840198a9953e2ec46632c249dbb7d",
     "walletKey": "0x281908b2eaae7dba8361a399fc45dbe4848e8d75571614060dc119ef54aaa68f",
     "dbEncryptionKey": "e712ec5069e0f445a34bc5e28fcc8c50072f781e1c544bf56383ac5126f49a78",
-    "inboxId": "a71b2008c64357e01a0fbe5f7aafd5fbc2748ae76c6c7121fcccdda2f080013e"
+    "inboxId": "a71b2008c64357e01a0fbe5f7aafd5fbc2748ae76c6c7121fcccdda2f080013e",
+    "installations": 2
   },
   {
     "accountAddress": "0x98cf42f1d06212c6c4ae3774e06c0ca46c97dd95",
     "walletKey": "0x936c052e2a7d84a537ea4d868d0025c23085d1070245c341c3eac89cc8bf0261",
     "dbEncryptionKey": "c42439332a68ce404456412f9a383fcdc1762b6e9880690a3bb0225b5b6f76f1",
-    "inboxId": "1a21c4fbb9f6ffebd29d75e0214fe2c58bb4f2fcf12d68f2f8f5cdce84713729"
+    "inboxId": "1a21c4fbb9f6ffebd29d75e0214fe2c58bb4f2fcf12d68f2f8f5cdce84713729",
+    "installations": 2
   },
   {
     "accountAddress": "0xf15ddbdf8190b65aaefdd4adbea77129a5bec35a",
     "walletKey": "0x3c724912346597e9e7b8a0f66cf174341b61516f8d5e516aa3d0d615ffc91dc7",
     "dbEncryptionKey": "e0828afe4f14b50c85386366ab454a1c384e114680bb17692a703345d313d62b",
-    "inboxId": "ebb35fb8a5a3b76eb6140eebe6814ebb532b1aff5bec36be12f5fcac2a4c1d84"
+    "inboxId": "ebb35fb8a5a3b76eb6140eebe6814ebb532b1aff5bec36be12f5fcac2a4c1d84",
+    "installations": 2
   },
   {
     "accountAddress": "0xe1434141af96995f207e498854a84deb35b1a169",
     "walletKey": "0x9b488de52db6444d4556d74d3fa45440eb7b2ebf11fa545bd5641fe85a96fd33",
     "dbEncryptionKey": "653e665eafd0f8ea5ea6f482b00e881b27dbdaece36eb10fb8a76132719c56d9",
-    "inboxId": "d12d8c08061af70bb161ead41f5ab3b0fcf943432e01fda1292851f19ed4ebe0"
+    "inboxId": "d12d8c08061af70bb161ead41f5ab3b0fcf943432e01fda1292851f19ed4ebe0",
+    "installations": 2
   },
   {
     "accountAddress": "0x2cabfd411089e633f37eb53ab03a13f2fb2712c7",
     "walletKey": "0x997a740376e97ec5573f5da0d2a1e7d7fd1a01437788224afbc7865e926b9055",
     "dbEncryptionKey": "b783572825346f3f289b792568034a49fc71a677d46c712d61862cf5fb5c3e0c",
-    "inboxId": "4f55e759683c59ecfdd26aa2950665094548228fd6f31454d68d754a0e7b87be"
+    "inboxId": "4f55e759683c59ecfdd26aa2950665094548228fd6f31454d68d754a0e7b87be",
+    "installations": 2
   },
   {
     "accountAddress": "0xefb80f595ae6fedf371134f7062fc912347124b4",
     "walletKey": "0x36d735367f5f632943b241f0ce4a5cc4ac22e508c21bbfca741b3c051883cb56",
     "dbEncryptionKey": "fa137491d633fbe0c23b784f060a379f1c659ac5aa2cd3805876593cd8b6b8ad",
-    "inboxId": "078029b10b0a39670744f17a68c2fd541cd69217191175d94802b90e67cddb9f"
+    "inboxId": "078029b10b0a39670744f17a68c2fd541cd69217191175d94802b90e67cddb9f",
+    "installations": 2
   },
   {
     "accountAddress": "0x6d35c299e3e37f8fe7f0c3bb19b0ae2bb88088b0",
     "walletKey": "0x6396d28e1ca74c991da184c09141842114a2f245a6685a5df78f1d8794638d3a",
     "dbEncryptionKey": "fee9f3b51e70d484c34cce6ca91a6ea6d8798605345b962b8485bd8a4d4144c8",
-    "inboxId": "9dabba32ac30a08ec3071ac00cb9d05369bc0b6fc97b29e3abe5bb19a016ce82"
+    "inboxId": "9dabba32ac30a08ec3071ac00cb9d05369bc0b6fc97b29e3abe5bb19a016ce82",
+    "installations": 2
   },
   {
     "accountAddress": "0xbbd5a1f73c3e861b615171de99e8669fcd3b1af6",
     "walletKey": "0x4acee6703ce37d25fc1aee5f5e86d09029cd1d16f42ace8ebe6427bbd57bc8e5",
     "dbEncryptionKey": "f358ef9e6f3880944220c70c4d21583d37dd9829163fa88ebc977dcd3547672f",
-    "inboxId": "2c6ef09975f2b805c128b617a934269574d1368ecfc859796b2ce31dd229122a"
+    "inboxId": "2c6ef09975f2b805c128b617a934269574d1368ecfc859796b2ce31dd229122a",
+    "installations": 2
   },
   {
     "accountAddress": "0xaa3c3463e68247ca7fcd3042fa8393ffdb03b8d2",
     "walletKey": "0x1a1f2a331cff4d759284228040c7b7cb3795da536614cf396746a520530b8818",
     "dbEncryptionKey": "c45bc265d2f6ca359be84dce5d8d9b7b49d0354860e1180732ddcbff3caa295f",
-    "inboxId": "d120cbc71923d586bb824f8d916eff013fde966de3ae0e1d18a6734843f9abd0"
+    "inboxId": "d120cbc71923d586bb824f8d916eff013fde966de3ae0e1d18a6734843f9abd0",
+    "installations": 2
   },
   {
     "accountAddress": "0x9bf67bd24f0b8aefd5b942f8069146667d079235",
     "walletKey": "0x07a75e622a4b538aed3fba7ffe93041849c78578df83bc4e51c340d46167042c",
     "dbEncryptionKey": "80b820ccd312fb97de4d6600e425604ce156ba12402f4c96b72b0033f4885748",
-    "inboxId": "1edab278020647d9d661aacfc5887548f57e47fa69df08605186acfd1be06cde"
+    "inboxId": "1edab278020647d9d661aacfc5887548f57e47fa69df08605186acfd1be06cde",
+    "installations": 2
   }
 ]

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -316,9 +316,9 @@ export function extractErrorLogs(testName: string): string {
       }
     }
 
-    console.log(errorLines);
+    console.debug(errorLines);
     if (errorLines.size > 0) {
-      return `\n\n*Error Logs:*\n\`\`\`\n${Array.from(errorLines).join(
+      return `\n\n*ERROR*\n\`\`\`\n${Array.from(errorLines).join(
         "\n",
       )}\n\`\`\``;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -420,7 +420,27 @@ async function main(): Promise<void> {
           : additionalArgs;
 
         const { testName, options } = parseTestArgs(allArgs);
-        await runVitestTest(testName, options);
+
+        // Check if this is a simple test run (no retry options)
+        const isSimpleRun =
+          options.maxAttempts === 1 &&
+          !options.explicitLogFlag &&
+          !options.noFail;
+
+        if (isSimpleRun) {
+          // Run test directly without logger for native terminal output
+          const command = buildTestCommand(
+            testName,
+            options.vitestArgs,
+            options.parallel,
+          );
+          console.debug(`Running test: ${testName}`);
+          console.debug(`Executing: ${command}`);
+          execSync(command, { stdio: "inherit" });
+        } else {
+          // Use retry mechanism with logger
+          await runVitestTest(testName, options);
+        }
 
         break;
       }

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -339,13 +339,10 @@ async function runVitestTest(
       console.debug(`Executing: ${command}`);
 
       const { exitCode, errorOutput } = await runCommand(command, env, logger);
+      console.debug("EXIT CODE", exitCode);
+      console.debug("ERROR OUTPUT", errorOutput);
 
       console.debug("Tests passed successfully!");
-      // Extract meaningful error information
-      const errorLines = errorOutput
-        .split("\n")
-        .filter((line) => line.trim())
-        .slice(-10); // Get last 10 non-empty lines
 
       if (attempt === options.maxAttempts) {
         console.error(

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -339,10 +339,19 @@ async function runVitestTest(
       console.debug(`Executing: ${command}`);
 
       const { exitCode, errorOutput } = await runCommand(command, env, logger);
-      console.debug("EXIT CODE", exitCode);
-      console.debug("ERROR OUTPUT", errorOutput);
 
       console.debug("Tests passed successfully!");
+      // Extract meaningful error information
+      const errorLines = errorOutput
+        .split("\n")
+        .filter((line) => line.trim())
+        .slice(-10); // Get last 10 non-empty lines
+
+      const errorMessage =
+        errorLines.length > 0
+          ? `Command failed with exit code ${exitCode}:\n${errorLines.join("\n")}`
+          : `Command exited with code ${exitCode}`;
+      console.debug("ERROR MESSAGE", errorMessage);
 
       if (attempt === options.maxAttempts) {
         console.error(
@@ -351,6 +360,7 @@ async function runVitestTest(
 
         // Extract and send Slack notification with error logs
         const errorLogs = extractErrorLogs(logger.logFileName);
+        console.debug("ERROR LOGS", errorLogs);
         await sendSlackNotification({
           testName,
           errorLogs,

--- a/scripts/gen.ts
+++ b/scripts/gen.ts
@@ -21,25 +21,14 @@ Usage:
   yarn gen --mode <mode> [options]
 
 Modes:
-  --mode generate-inboxes         Generate new XMTP inboxes
-  --mode local-update             Initialize local inboxes from a JSON file
-  --mode generate-installations   Generate multiple installations for a single account
+  --mode generate-inboxes         Generate new XMTP inboxes with optional installations
+  --mode local-update             Initialize local inboxes from helpers/inboxes.json (uses defaults)
 
 Options for generate-inboxes:
   --count <number>                Number of accounts to generate
   --envs <envs>                   Comma-separated environments (local,dev,production)
+  --installations <number>        Number of installations per account per network (default: 1)
   --output <file>                 Output file (default: logs/db-generated-...)
-
-Options for local-update:
-  --input <file>                  Input JSON file (default: @helpers/inboxes.json)
-  --env <env>                     Environment (default: local)
-
-Options for generate-installations:
-  --walletKey <key>              Private key (0x...)
-  --encryptionKey <key>           Encryption key (hex)
-  --count <number>                Number of installations
-  --env <env>                     Environment (default: dev)
-  --output <file>                 Output file (default: logs/generated-installations.json)
 
   --help                          Show this help message
 `);
@@ -91,14 +80,19 @@ async function askForEnvironments(): Promise<XmtpEnv[]> {
 async function generateInboxes(opts: {
   count?: number;
   envs?: XmtpEnv[];
+  installations?: number;
   output?: string;
 }) {
-  let { count, envs, output } = opts;
+  let { count, envs, installations, output } = opts;
   if (!count) count = await askForAccountCount();
   if (!envs) envs = await askForEnvironments();
+  const installationCount = installations || 1;
 
   console.log(`Using environments: ${envs.join(", ")}`);
-  const folderName = `db-generated-${count}-${envs.join(",")}`;
+  console.log(
+    `Creating ${installationCount} installations per account per network`,
+  );
+  const folderName = `db-generated-${count}-${envs.join(",")}-${installationCount}inst`;
   const LOGPATH = `${BASE_LOGPATH}/${folderName}`;
   if (!fs.existsSync(`${LOGPATH}${DB_PATH}`)) {
     console.log(`Creating directory: ${LOGPATH}...`);
@@ -108,6 +102,9 @@ async function generateInboxes(opts: {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const outputFile = output || `${LOGPATH}/inboxes-${timestamp}.json`;
 
+  let totalCreated = 0;
+  let totalFailed = 0;
+
   for (let i = 0; i < count; i++) {
     const walletKey = `0x${Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("hex")}`;
     try {
@@ -116,17 +113,41 @@ async function generateInboxes(opts: {
       const accountAddress = identifier.identifier;
       const dbEncryptionKey = generateEncryptionKeyHex();
       let inboxId = "";
+
+      console.log(`\nProcessing account ${i + 1}/${count}: ${accountAddress}`);
+
+      // Create installations for each environment
       for (const env of envs) {
-        const client = await Client.create(signer, {
-          dbEncryptionKey: getEncryptionKeyFromHex(dbEncryptionKey),
-          dbPath: `${LOGPATH}${DB_PATH}/${env}-${accountAddress}`,
-          env: env,
-        });
-        inboxId = client.inboxId;
         console.log(
-          `Created client in ${env} environment for account ${i + 1}/${count}: ${accountAddress}`,
+          `  Creating ${installationCount} installations on ${env}...`,
         );
+
+        for (let j = 0; j < installationCount; j++) {
+          try {
+            const client = await Client.create(signer, {
+              dbEncryptionKey: getEncryptionKeyFromHex(dbEncryptionKey),
+              dbPath: `${LOGPATH}${DB_PATH}/${env}-${accountAddress}-install-${j}`,
+              env: env,
+            });
+
+            if (j === 0) {
+              inboxId = client.inboxId; // Use the first installation's inboxId
+            }
+
+            console.log(
+              `    Created installation ${j + 1}/${installationCount}: ${client.installationId}`,
+            );
+            totalCreated++;
+          } catch (error) {
+            console.error(
+              `    Failed to create installation ${j + 1}/${installationCount}:`,
+              error instanceof Error ? error.message : String(error),
+            );
+            totalFailed++;
+          }
+        }
       }
+
       accountData.push({
         accountAddress,
         walletKey,
@@ -135,29 +156,26 @@ async function generateInboxes(opts: {
       });
       fs.writeFileSync(outputFile, JSON.stringify(accountData, null, 2));
     } catch (error: unknown) {
-      console.error(`Error creating XMTP client for account ${i + 1}:`, error);
+      console.error(`Error processing account ${i + 1}:`, error);
     }
   }
+
+  console.log(`\n=== Generation Summary ===`);
+  console.log(`Successfully generated ${accountData.length} accounts`);
   console.log(
-    `Successfully generated ${accountData.length} accounts with XMTP clients`,
+    `Target installations per account per network: ${installationCount}`,
   );
+  console.log(`Total installations created: ${totalCreated}`);
+  console.log(`Total installations failed: ${totalFailed}`);
   console.log(`Data saved to ${outputFile}`);
   console.log(`All data stored in folder: ${LOGPATH}`);
 }
 
-async function localUpdate(opts: { input?: string; env?: XmtpEnv }) {
-  let inputFile: string;
-  if (opts.input) {
-    inputFile = opts.input;
-  } else {
-    // Use require.resolve only if it returns a string
-    try {
-      inputFile = require.resolve("@helpers/inboxes.json");
-    } catch {
-      inputFile = "helpers/inboxes.json";
-    }
-  }
-  const ENV: XmtpEnv = opts.env || "local";
+async function localUpdate() {
+  // Use defaults only - no options
+  const inputFile = "helpers/inboxes.json";
+  const ENV: XmtpEnv = "local";
+
   loadEnv("local-update");
   let generatedInboxes;
   try {
@@ -239,59 +257,6 @@ async function localUpdate(opts: { input?: string; env?: XmtpEnv }) {
   }
 }
 
-async function generateInstallations(opts: {
-  walletKey?: string;
-  encryptionKey?: string;
-  count?: number;
-  env?: XmtpEnv;
-  output?: string;
-}) {
-  let { walletKey, encryptionKey, count, env, output } = opts;
-  if (!walletKey) walletKey = await ask("Enter private key (0x...): ");
-  if (!encryptionKey) encryptionKey = await ask("Enter encryption key (hex): ");
-  if (!count) count = parseInt(await ask("How many installations? "), 10);
-  if (!env)
-    env = (
-      await ask("Enter environment (local,dev,production): ")
-    ).toLowerCase() as XmtpEnv;
-  if (!validEnvironments.includes(env)) env = "dev";
-  const signer = createSigner(walletKey as `0x${string}`);
-  const dbEncryptionKey = getEncryptionKeyFromHex(encryptionKey);
-  const installationData = [];
-  let accountAddress = "";
-  try {
-    const identifier = await signer.getIdentifier();
-    accountAddress = identifier.identifier;
-    console.log(`Using account address: ${accountAddress}`);
-    for (let i = 0; i < count; i++) {
-      const client = await Client.create(signer, {
-        dbEncryptionKey,
-        env,
-      });
-      const inboxId = client.inboxId;
-      const installationId = client.installationId;
-      installationData.push({
-        accountAddress,
-        inboxId,
-        installationId,
-        env,
-        installationIndex: i,
-      });
-      const outputFile = output || `./logs/generated-installations.json`;
-      fs.writeFileSync(outputFile, JSON.stringify(installationData, null, 2));
-      console.log(`Created installation ${i + 1}/${count}: ${installationId}`);
-    }
-  } catch (error: unknown) {
-    console.error(`Error creating XMTP clients:`, error);
-  }
-  console.log(
-    `Successfully generated ${installationData.length} XMTP clients for account ${accountAddress}`,
-  );
-  console.log(
-    `Data saved to ${output || "./logs/generated-installations.json"}`,
-  );
-}
-
 async function main() {
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.includes("-h")) {
@@ -307,6 +272,7 @@ async function main() {
   if (mode === "generate-inboxes") {
     let count: number | undefined;
     let envs: XmtpEnv[] | undefined;
+    let installations: number | undefined;
     let output: string | undefined;
     args.forEach((arg, i) => {
       if (arg === "--count") count = parseInt(args[i + 1], 10);
@@ -314,37 +280,12 @@ async function main() {
         envs = args[i + 1]
           .split(",")
           .map((e) => e.trim().toLowerCase()) as XmtpEnv[];
+      if (arg === "--installations") installations = parseInt(args[i + 1], 10);
       if (arg === "--output") output = args[i + 1];
     });
-    await generateInboxes({ count, envs, output });
+    await generateInboxes({ count, envs, installations, output });
   } else if (mode === "local-update") {
-    let input: string | undefined;
-    let env: XmtpEnv | undefined;
-    args.forEach((arg, i) => {
-      if (arg === "--input") input = args[i + 1];
-      if (arg === "--env") env = args[i + 1] as XmtpEnv;
-    });
-    await localUpdate({ input, env });
-  } else if (mode === "generate-installations") {
-    let walletKey: string | undefined;
-    let encryptionKey: string | undefined;
-    let count: number | undefined;
-    let env: XmtpEnv | undefined;
-    let output: string | undefined;
-    args.forEach((arg, i) => {
-      if (arg === "--walletKey") walletKey = args[i + 1];
-      if (arg === "--encryptionKey") encryptionKey = args[i + 1];
-      if (arg === "--count") count = parseInt(args[i + 1], 10);
-      if (arg === "--env") env = args[i + 1] as XmtpEnv;
-      if (arg === "--output") output = args[i + 1];
-    });
-    await generateInstallations({
-      walletKey,
-      encryptionKey,
-      count,
-      env,
-      output,
-    });
+    await localUpdate();
   } else {
     showHelp();
   }

--- a/suites/Large/README.md
+++ b/suites/Large/README.md
@@ -117,19 +117,6 @@ _Base: 220 members, measuring time for existing member B to process "Z was added
 
 ---
 
-## Chart 2: Installation Scaling Recommendations
-
-**"Sweet spot analysis for maximum installations per member"**
-
-| Installation Limit | Realistic Group Size | Total Devices | Processing Time | Recommendation     |
-| ------------------ | -------------------- | ------------- | --------------- | ------------------ |
-| 3                  | 220 members          | 660           | ~200ms          | ✅ **Recommended** |
-| 5                  | 220 members          | 1,100         | ~270ms          | ✅ **Acceptable**  |
-| 10                 | 220 members          | 2,200         | ~450ms          | ⚠️ **Max Limit**   |
-| 15+                | 220 members          | 3,300+        | >650ms          | ❌ **Too Slow**    |
-
----
-
 ## Chart 3: Enterprise Group Scaling
 
 **"How installation limits affect large enterprise groups"**
@@ -142,8 +129,6 @@ _Base: 220 members, measuring time for existing member B to process "Z was added
 
 _Note: Using fewer actual members with more installations to simulate larger groups_
 
----
-
 ## Key Insights These Charts Would Provide:
 
 1. **Sweet Spot**: 3-5 installations per member keeps processing under 300ms
@@ -152,7 +137,3 @@ _Note: Using fewer actual members with more installations to simulate larger gro
 4. **Recommendation**: Set max 5 installations per member for good performance
 
 These charts directly answer: **"What should our installation limit be?"** Answer: **5 installations per member maximum.**
-
-```
-
-```

--- a/suites/Large/README.md
+++ b/suites/Large/README.md
@@ -94,6 +94,14 @@ _Note: `syncAll` is measured only as the first cold start of the client (fresh i
 
 ## Chart 1: Installation Count Impact on Add Member Processing
 
+```bash
+
+MAX_GROUP_SIZE=220
+BATCH_SIZE=55
+WORKER_COUNT=5
+CHECK_INSTALLATIONS=2,5,10,15,20,25
+```
+
 **"How installation count affects existing members processing new member commits"**
 
 | Installations per Member | Total Devices | Existing Member Processing Time (ms) | New Member Processing Time (ms) | Performance |
@@ -144,3 +152,7 @@ _Note: Using fewer actual members with more installations to simulate larger gro
 4. **Recommendation**: Set max 5 installations per member for good performance
 
 These charts directly answer: **"What should our installation limit be?"** Answer: **5 installations per member maximum.**
+
+```
+
+```

--- a/suites/Large/README.md
+++ b/suites/Large/README.md
@@ -42,3 +42,105 @@ yarn test large
 
 - Ensure all required environment variables are set (see project root README for details).
 - The suite uses XMTP helpers and worker abstractions; no manual configuration is needed for test users.
+
+### Group operations performance
+
+#### Sender-Side average performance
+
+| Size | Send message | Update name | Remove members | Create  | Performance  |
+| ---- | ------------ | ----------- | -------------- | ------- | ------------ |
+| 50   | 86           | 135         | 139            | 1329    | ✅ On Target |
+| 100  | 88           | 145         | 157            | 1522    | ✅ On Target |
+| 150  | 95           | 203         | 190            | 2306    | ✅ On Target |
+| 200  | 93           | 193         | 205            | ⚠️ 3344 | ✅ On Target |
+| 250  | 108          | 219         | 237            | ⚠️ 4276 | ✅ On Target |
+| 300  | 97           | 244         | 247            | ⚠️ 5463 | ✅ On Target |
+| 350  | 101          | 264         | 308            | ⚠️ 6641 | ✅ On Target |
+| 400  | 111          | 280         | 320            | ⚠️ 7641 | ✅ On Target |
+
+_Note: This measurments are taken only from the sender side and after the group is created._
+
+#### Receiver-Side stream performance
+
+| Group Size | New conversation | Metadata | Messages | Add Members | Performance  |
+| ---------- | ---------------- | -------- | -------- | ----------- | ------------ |
+| 50         | 687              | 141      | 131      | 401         | ✅ On Target |
+| 100        | 746              | 155      | 117      | 420         | ✅ On Target |
+| 150        | 833              | 163      | 147      | 435         | ✅ On Target |
+| 200        | 953              | 179      | 173      | 499         | ✅ On Target |
+| 250        | 1007             | 187      | 161      | 526         | ⚠️ Concern   |
+| 300        | 1040             | 195      | 167      | 543         | ⚠️ Concern   |
+| 350        | 1042             | 198      | 178      | 581         | ⚠️ Concern   |
+| 400        | 1192             | 214      | 173      | 609         | ⚠️ Concern   |
+
+_Note: This measurments are taken only from the receiver side and after the group is created._
+
+#### Receiver-Side sync performance
+
+| Size | syncAll |      | sync |      | Performance  |
+| ---- | ------- | ---- | ---- | ---- | ------------ |
+| 50   | 366     | ...  | 291  | ...  | ✅ On Target |
+| 100  | 503     | 521  | 424  | 372  | ✅ On Target |
+| 150  | 665     | 727  | 522  | 622  | ✅ On Target |
+| 200  | 854     | 1066 | 653  | 936  | ✅ On Target |
+| 250  | 966     | 1582 | 768  | 1148 | ⚠️ Concern   |
+| 300  | 1225    | 1619 | 861  | 1362 | ⚠️ Concern   |
+| 350  | 1322    | 1846 | 1218 | 2017 | ⚠️ Concern   |
+| 400  | 1292    | 2082 | 1325 | 1792 | ⚠️ Concern   |
+
+_Note: `syncAll` is measured only as the first cold start of the client (fresh inbox). Cumulative sync is measured as the first time all the groups are sync for the first time._
+
+## Other
+
+## Chart 1: Installation Count Impact on Add Member Processing
+
+**"How installation count affects existing members processing new member commits"**
+
+| Installations per Member | Total Devices | Existing Member Processing Time (ms) | New Member Processing Time (ms) | Performance |
+| ------------------------ | ------------- | ------------------------------------ | ------------------------------- | ----------- |
+| 2                        | 440           | 145                                  | 178                             | ✅ Good     |
+| 5                        | 1,100         | 267                                  | 312                             | ✅ Good     |
+| 10                       | 2,200         | 445                                  | 523                             | ⚠️ Concern  |
+| 15                       | 3,300         | 678                                  | 789                             | ❌ Poor     |
+| 20                       | 4,400         | 892                                  | 1,045                           | ❌ Poor     |
+| 25                       | 5,500         | 1,156                                | 1,334                           | ❌ Poor     |
+
+_Base: 220 members, measuring time for existing member B to process "Z was added" commit_
+
+---
+
+## Chart 2: Installation Scaling Recommendations
+
+**"Sweet spot analysis for maximum installations per member"**
+
+| Installation Limit | Realistic Group Size | Total Devices | Processing Time | Recommendation     |
+| ------------------ | -------------------- | ------------- | --------------- | ------------------ |
+| 3                  | 220 members          | 660           | ~200ms          | ✅ **Recommended** |
+| 5                  | 220 members          | 1,100         | ~270ms          | ✅ **Acceptable**  |
+| 10                 | 220 members          | 2,200         | ~450ms          | ⚠️ **Max Limit**   |
+| 15+                | 220 members          | 3,300+        | >650ms          | ❌ **Too Slow**    |
+
+---
+
+## Chart 3: Enterprise Group Scaling
+
+**"How installation limits affect large enterprise groups"**
+
+| Target Group Size | Installation Limit | Actual Members | Total Devices | Processing Time | Feasible? |
+| ----------------- | ------------------ | -------------- | ------------- | --------------- | --------- |
+| 400 members       | 5 each             | 200 members    | 2,000         | ~445ms          | ✅ Yes    |
+| 400 members       | 10 each            | 200 members    | 4,000         | ~892ms          | ⚠️ Slow   |
+| 1000 members      | 5 each             | 200 members    | 5,000         | ~1,156ms        | ❌ No     |
+
+_Note: Using fewer actual members with more installations to simulate larger groups_
+
+---
+
+## Key Insights These Charts Would Provide:
+
+1. **Sweet Spot**: 3-5 installations per member keeps processing under 300ms
+2. **Hard Limit**: 10+ installations per member causes >400ms delays
+3. **Enterprise Reality**: Large groups (400+) need strict installation limits
+4. **Recommendation**: Set max 5 installations per member for good performance
+
+These charts directly answer: **"What should our installation limit be?"** Answer: **5 installations per member maximum.**

--- a/suites/Large/helpers.ts
+++ b/suites/Large/helpers.ts
@@ -3,6 +3,9 @@ import fs from "fs";
 export const m_large_WORKER_COUNT = parseInt(process.env.WORKER_COUNT ?? "5");
 export const m_large_BATCH_SIZE = parseInt(process.env.BATCH_SIZE ?? "5");
 export const m_large_TOTAL = parseInt(process.env.MAX_GROUP_SIZE ?? "10");
+export const m_large_CHECK_INSTALLATIONS = parseInt(
+  process.env.CHECK_INSTALLATIONS ?? "2",
+);
 
 export interface SummaryEntry {
   groupSize: number;

--- a/suites/Large/membership.test.ts
+++ b/suites/Large/membership.test.ts
@@ -6,7 +6,7 @@ import { setupTestLifecycle } from "@helpers/vitest";
 import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import {
   m_large_BATCH_SIZE,
   m_large_TOTAL,

--- a/suites/Large/membership.test.ts
+++ b/suites/Large/membership.test.ts
@@ -6,7 +6,7 @@ import { setupTestLifecycle } from "@helpers/vitest";
 import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   m_large_BATCH_SIZE,
   m_large_TOTAL,

--- a/suites/Large/membership.test.ts
+++ b/suites/Large/membership.test.ts
@@ -3,7 +3,7 @@ import { logError } from "@helpers/logger";
 import { verifyMembershipStream } from "@helpers/streams";
 import { getFixedNames, getInboxIds } from "@helpers/utils";
 import { setupTestLifecycle } from "@helpers/vitest";
-import { typeofStream } from "@workers/main";
+import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
 import { afterAll, describe, expect, it } from "vitest";
@@ -29,6 +29,10 @@ describe(testName, async () => {
     getFixedNames(m_large_WORKER_COUNT),
     testName,
     typeofStream.GroupUpdated,
+    typeOfResponse.None,
+    typeOfSync.None,
+    undefined,
+    2,
   );
 
   let customDuration: number | undefined = undefined;

--- a/suites/Large/membership.test.ts
+++ b/suites/Large/membership.test.ts
@@ -30,10 +30,6 @@ describe(testName, async () => {
     getFixedNames(m_large_WORKER_COUNT),
     testName,
     typeofStream.GroupUpdated,
-    typeOfResponse.None,
-    typeOfSync.None,
-    undefined,
-    m_large_CHECK_INSTALLATIONS,
   );
 
   let customDuration: number | undefined = undefined;

--- a/suites/Large/membership.test.ts
+++ b/suites/Large/membership.test.ts
@@ -9,6 +9,7 @@ import { type Group } from "@xmtp/node-sdk";
 import { afterAll, describe, expect, it } from "vitest";
 import {
   m_large_BATCH_SIZE,
+  m_large_CHECK_INSTALLATIONS,
   m_large_TOTAL,
   m_large_WORKER_COUNT,
   saveLog,
@@ -32,7 +33,7 @@ describe(testName, async () => {
     typeOfResponse.None,
     typeOfSync.None,
     undefined,
-    2,
+    m_large_CHECK_INSTALLATIONS,
   );
 
   let customDuration: number | undefined = undefined;

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -832,12 +832,20 @@ export class WorkerClient extends Worker {
     if (currentCount === targetCount) {
       console.debug(`[${this.name}] Installation count matches target`);
       return currentCount;
-    }
-
-    if (currentCount > targetCount) {
-      // console.debug(
-      //   `[${this.name}] Too many installations (${currentCount}), revoking all others`,
-      // );
+    } else if (currentCount > targetCount) {
+      console.debug(
+        `[${this.name}] Too many installations (${currentCount}), revoking all others`,
+      );
+      await this.addNewInstallation();
+      return currentCount + 1;
+    } else if (currentCount < targetCount) {
+      console.debug(
+        `[${this.name}] Not enough installations (${currentCount}), adding new installation`,
+      );
+      for (let i = 0; i < targetCount - currentCount; i++) {
+        await this.addNewInstallation();
+      }
+      return targetCount;
     }
 
     return currentCount;


### PR DESCRIPTION
### Improve debug logging for test execution results by changing console.log to console.debug in extractErrorLogs function and adding PR test workflow with installation count verification
- Adds new GitHub Actions workflow [PR_Test.yml](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-a0e78d76ece6928158099c0a0a91736b094e894b76358b7a77e5fb3f63b1ab05) that runs `membership.test` on pull requests to main branch with 10-minute timeout and production environment configuration
- Modifies `extractErrorLogs` function in [logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) to use `console.debug` instead of `console.log` and changes error header format from '*Error Logs:*' to '*ERROR*'
- Updates test runner in [cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) to enable verbose logging by default and adds direct `execSync` execution for simple test runs
- Refactors XMTP generator in [gen.ts](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-cd19ab93cbee4312668c3ba08565c6903f23e5d3a07c14c8788d5049832f39f1) to support multiple installations per account through new `--installations` parameter and removes separate `generate-installations` mode
- Adds installation count verification methods `verifyInstallationCount` in `WorkerManager` class and modifies `ensureInstallationCount` in `WorkerClient` class to actively manage installation counts
- Removes `WALLET_KEY` environment variable from [Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) and [Browser.yml](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-f40bdad9c7e38e785fca7315a56007cd25ada68d6627f4f3dac772afadcbe4a7) workflows
- Adds `installations` field with value 2 to all inbox entries in [inboxes.json](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-c04d8d92a518da56aeb4b620dd68bd1b73c171bbe5803af473e22e9f2ff697e6)

#### 📍Where to Start
Start with the new `PR_Test.yml` workflow in [.github/workflows/PR_Test.yml](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-a0e78d76ece6928158099c0a0a91736b094e894b76358b7a77e5fb3f63b1ab05) to understand the automated testing setup, then review the `extractErrorLogs` function changes in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/435/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597).

----

_[Macroscope](https://app.macroscope.com) summarized cea6696._