### PR TITLE
remove failing test to improve test suite reliability

### DIFF
--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -202,6 +202,7 @@ export const setupPrettyLogs = () => {
   // Override console.error
   console.error = (...args) => {
     const message = args.join(" ");
+    //logger.error("ERROR " + message);
     logger.error(message);
   };
 

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -15,13 +15,7 @@ export const LOG_FILTER_PATTERNS = [
 ];
 
 // Patterns to match log lines for error extraction
-export const LOG_LINE_MATCH_PATTERNS = [
-  /ERROR/,
-  /forked/,
-  /FAIL/,
-  /Message cursor/,
-  // Add more patterns here as needed
-];
+export const LOG_LINE_MATCH_PATTERNS = [/ERROR/, /forked/, /FAIL/];
 
 /**
  * Remove ANSI escape codes from text

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -202,7 +202,7 @@ export const setupPrettyLogs = () => {
   // Override console.error
   console.error = (...args) => {
     const message = args.join(" ");
-    logger.error("ERROR " + message);
+    logger.error(message);
   };
 
   // Override console.debug

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -290,7 +290,12 @@ export function extractErrorLogs(testName: string): Set<string> {
           if (cleanLine.includes("ERROR")) {
             cleanLine = cleanLine.split("ERROR")[1].trim();
           }
-
+          if (cleanLine.includes("FAIL")) {
+            cleanLine = cleanLine.split("FAIL")[1].trim();
+          }
+          if (cleanLine.includes("forked")) {
+            cleanLine = cleanLine.split("forked")[1].trim();
+          }
           if (cleanLine.includes("//")) {
             cleanLine = cleanLine.split("//")[0]?.trim();
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gen": "tsx inboxes/gen.ts",
     "large": "yarn test suites/large/*",
     "lint": "eslint .",
-    "local-update": "./inboxes/gen.sh --envs local --installations 2,5,10,15,20,25 --count 200",
+    "local-update": "./inboxes/gen.sh --envs local --installations 2,5,10,15,20,25 --count 500",
     "medium": "yarn test suites/medium",
     "monitor:dev": "httpstat https://grpc.dev.xmtp.network:443",
     "prod-update": "./inboxes/gen.sh --envs production --installations 2,5,10,15,20,25,30 --count 200",

--- a/suites/bench/bench.test.ts
+++ b/suites/bench/bench.test.ts
@@ -13,7 +13,7 @@ export const WORKER_COUNT = 3;
 export const BATCH_SIZE = 10;
 export const TOTAL = 200;
 export const CHECK_INSTALLATIONS = [2, 5, 10, 15, 20, 25];
-export const MIN_MAX_INSTALLATIONS = [20, 100];
+export const MIN_MAX_INSTALLATIONS = [1000, 2000];
 
 const testName = "bench";
 loadEnv(testName);

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -93,8 +93,4 @@ describe(testName, async () => {
       throw e;
     }
   });
-
-  it("fail on purpose", () => {
-    expect(false).toBe(true);
-  });
 });


### PR DESCRIPTION
### Remove deliberately failing test case from DMs functional test suite to improve test suite reliability
- Removes a deliberately failing test case "fail on purpose" from [suites/functional/dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/464/files#diff-bf59a0998d74f48f9c0cc7364d9e3f1234650add19ae4908dc573a9064092181) that was asserting `expect(false).toBe(true)`
- Modifies error logging patterns in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/464/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) by removing the '/Message cursor/' pattern from `LOG_LINE_MATCH_PATTERNS` array and updating the `console.error` override to remove the 'ERROR ' prefix
- Updates benchmark test configuration in [suites/bench/bench.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/464/files#diff-d4f60b611ef9d1d33d3f9e529ddd27752b80958f4dd7877ed7b1d849a01de896) by changing `MIN_MAX_INSTALLATIONS` from [20, 100] to [1000, 2000]
- Increments package version from 0.1.23 to 0.1.24 in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/464/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and modifies the 'local-update' script to generate 500 installations instead of 200

#### 📍Where to Start
Start with the removed test case in [suites/functional/dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/464/files#diff-bf59a0998d74f48f9c0cc7364d9e3f1234650add19ae4908dc573a9064092181) to understand the failing test that was removed.

----

_[Macroscope](https://app.macroscope.com) summarized 1210693._