### PR TITLE
Remove redundant job status check for notifications

### DIFF
--- a/helpers/slack.ts
+++ b/helpers/slack.ts
@@ -97,7 +97,6 @@ function shouldSendNotification(
   // Only send notifications for failures on main branch (unless in local development)
   if (
     jobStatus === "success" ||
-    jobStatus === "passed" ||
     (githubContext.branchName !== "main" && process.env.GITHUB_ACTIONS)
   ) {
     console.log(

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "local-update": "./inboxes/gen.sh --envs local --installations 2,5,10,15,20,25 --count 500",
     "medium": "yarn test suites/medium",
     "monitor:dev": "httpstat https://grpc.dev.xmtp.network:443",
-    "prod-update": "./inboxes/gen.sh --envs production --installations 2,5,10,15,20,25,30 --count 200",
+    "prod-update": "./inboxes/gen.sh --envs production --installations 2,5,10,15,20,25,30 --count 500",
     "railway": "railway run yarn test ",
     "record": "npx playwright codegen 'https://xmtp.chat/'",
     "run:gen": "tsx inboxes/gen.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -93,7 +93,4 @@ describe(testName, async () => {
       throw e;
     }
   });
-  it("fail on purpose", () => {
-    expect(false).toBe(true);
-  });
 });

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -93,4 +93,7 @@ describe(testName, async () => {
       throw e;
     }
   });
+  it("fail on purpose", () => {
+    expect(false).toBe(true);
+  });
 });


### PR DESCRIPTION
_Macroscope is automatically generating a new summary of this pull request including the latest commits..._

<picture>
<source media="(prefers-color-scheme: dark)" srcset="https://prasso.ai/static/prassoai-pr-loader-small-dark-no-text.gif">
<img src="https://prasso.ai/static/prassoai-pr-loader-small-light-no-text.gif" alt="_Macroscope is automatically generating a new summary of this pull request including the latest commits..._">
</picture>