### PR TITLE
Update SDK version options for regression tests

### DIFF
--- a/suites/regression/regression.test.ts
+++ b/suites/regression/regression.test.ts
@@ -12,7 +12,7 @@ loadEnv(testName);
 
 describe(testName, () => {
   let workers: WorkerManager;
-  const versions = sdkVersionOptions;
+  const versions = ["209", "210"];
   const receiverInboxId = getInboxIds(1);
 
   it("should create a group conversation with all workers", async () => {


### PR DESCRIPTION
### Update SDK version options for regression tests to use hardcoded versions "209" and "210" instead of sdkVersionOptions variable
The `versions` constant in [suites/regression/regression.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/472/files#diff-a57ca7cd74eb0c271dca531c030e099b69a9a37bf3289542e4fbb3b772531138) is modified from using the `sdkVersionOptions` variable to a hardcoded array containing SDK versions "209" and "210". This change limits the regression test scope to these two specific SDK versions rather than using the previously defined variable.

#### 📍Where to Start
Start with the `versions` constant definition in [suites/regression/regression.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/472/files#diff-a57ca7cd74eb0c271dca531c030e099b69a9a37bf3289542e4fbb3b772531138).

----

_[Macroscope](https://app.macroscope.com) summarized 9866d48._