### PR TITLE
Refine dev-update script for targeted installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf .data/ ||: && rimraf logs/ ||  :",
     "cli": "tsx scripts/cli.ts",
     "count-duplicates": "NODE_OPTIONS='--experimental-specifier-resolution=node' tsx inboxes/utils.ts",
-    "dev-update": "./inboxes/gen.sh --envs dev --installations 2,5,10,15,20,25,30 --count 200",
+    "dev-update": "./inboxes/gen.sh --envs dev --installations 2 --count 200",
     "forked": "./suites/group/run.sh",
     "format": "prettier -w .",
     "functional": "yarn test suites/functional",

--- a/suites/agents/production.json
+++ b/suites/agents/production.json
@@ -56,6 +56,6 @@
     "name": "bankr.base.eth",
     "address": "0x7f1c0d2955f873fc91f1728c19b2ed7be7a9684d",
     "sendMessage": "hey there how are you?",
-    "networks": ["dev", "production"]
+    "networks": ["production"]
   }
 ]


### PR DESCRIPTION
### Refine dev-update script to target installation ID 2 and restrict production agents suite to production network only
- The `dev-update` script in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/487/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) now generates data for only installation ID 2 instead of multiple installation IDs (2,5,10,15,20,25,30), while maintaining the count parameter at 200
- The `networks` array in [suites/agents/production.json](https://github.com/xmtp/xmtp-qa-tools/pull/487/files#diff-889c0e602ab0d80d923900346bed1f2d8824b3fdf4bc5b74a4b217cfba8baed9) removes the "dev" network configuration, leaving only "production" network

#### 📍Where to Start
Start with the `dev-update` script configuration in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/487/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the targeted installation change.

----

_[Macroscope](https://app.macroscope.com) summarized 24c7e91._