### PR TITLE
Update prod-update script for broader installations range

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint .",
     "local-update": "./inboxes/gen.sh --envs local --installations 2,5,10,15,20,25 --count 500",
     "monitor:dev": "httpstat https://grpc.dev.xmtp.network:443",
-    "prod-update": "./inboxes/gen.sh --envs dev,production --installations 15,20,25,30 --count 500 --debug",
+    "prod-update": "./inboxes/gen.sh --envs dev,production --installations 2,5,10,15,20,25,30 --count 500 ",
     "railway": "railway run yarn test ",
     "record": "npx playwright codegen 'https://xmtp.chat/'",
     "run:gen": "tsx inboxes/gen.ts",


### PR DESCRIPTION
### Update prod-update script to process installations 2, 5, and 10 and remove debug mode for broader installations range
The `prod-update` script in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/495/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) modifies the `--installations` parameter to include additional values `2,5,10` at the beginning of the existing list and removes the `--debug` flag from the command execution.

#### 📍Where to Start
Start with the `prod-update` script definition in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/495/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized b1d707d._