### PR TITLE
Increase default stream timeout for better stability

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test ${{ matrix.test }} --no-fail --debug
+        run: yarn test ${{ matrix.test }}
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -2,6 +2,9 @@ name: Agents
 description: "should verify performance of the library in the production network"
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "*/15 * * * *" # Runs every 15 minutes
   workflow_dispatch:
@@ -13,7 +16,7 @@ jobs:
     strategy:
       matrix:
         test: [agents]
-        environment: [dev, production]
+        environment: [dev]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -22,7 +22,6 @@ jobs:
       XMTP_ENV: ${{ matrix.environment }}
       DEFAULT_STREAM_TIMEOUT_MS: 40000
       GEOLOCATION: ${{ vars.GEOLOCATION }}
-      ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         test: [agents]
-        environment: [dev]
+        environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -30,15 +30,18 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: "yarn"
+          cache-dependency-path: |
+            yarn.lock
+            **/package.json
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test ${{ matrix.test }}
+        run: yarn test ${{ matrix.test }} --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: artifacts-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
             .data/**/*

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}
-      DEFAULT_STREAM_TIMEOUT_MS: 20000
+      DEFAULT_STREAM_TIMEOUT_MS: 40000
       GEOLOCATION: ${{ vars.GEOLOCATION }}
       ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Browser.yml
+++ b/.github/workflows/Browser.yml
@@ -18,7 +18,6 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
-      ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:

--- a/.github/workflows/Browser.yml
+++ b/.github/workflows/Browser.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: "yarn"
+          cache-dependency-path: |
+            yarn.lock
+            **/package.json
       - name: Install dependencies
         run: yarn
       - name: Run tests

--- a/.github/workflows/Delivery.yml
+++ b/.github/workflows/Delivery.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: "yarn"
+          cache-dependency-path: |
+            yarn.lock
+            **/package.json
       - name: Install dependencies
         run: yarn
       - name: Run tests

--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: "yarn"
+          cache-dependency-path: |
+            yarn.lock
+            **/package.json
       - name: Install dependencies
         run: yarn
       - name: Run tests

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: "yarn"
+          cache-dependency-path: |
+            yarn.lock
+            **/package.json
       - name: Install dependencies
         run: yarn
       - name: Run tests

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: "yarn"
+          cache-dependency-path: |
+            yarn.lock
+            **/package.json
       - name: Install dependencies
         run: yarn
       - name: Run versions

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -18,7 +18,6 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
-      ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           node-version-file: ".node-version"
           cache: "yarn"
+          cache-dependency-path: |
+            yarn.lock
+            **/package.json
       - name: Install dependencies
         run: yarn
       - name: Format code

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -35,7 +35,7 @@ describe(testName, () => {
   for (const agent of filteredAgents) {
     it(`should receive response from ${agent.name} agent (${agent.address}) when sending "${agent.sendMessage}"`, async () => {
       try {
-        console.debug(`Testing ${agent.name} with address ${agent.address} `);
+        console.warn(`Testing ${agent.name} with address ${agent.address} `);
 
         const conversation = await workers
           .getCreator()


### PR DESCRIPTION
### Increase DEFAULT_STREAM_TIMEOUT_MS from 20000 to 40000 milliseconds for better stability in the Agents workflow
- Doubles the `DEFAULT_STREAM_TIMEOUT_MS` from 20000 to 40000 milliseconds in [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/520/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91)
- Adds pull request trigger for the main branch to the Agents workflow
- Removes `ENCRYPTION_KEY` environment variable from all three GitHub workflows: [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/520/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91), [.github/workflows/Browser.yml](https://github.com/xmtp/xmtp-qa-tools/pull/520/files#diff-f40bdad9c7e38e785fca7315a56007cd25ada68d6627f4f3dac772afadcbe4a7), and [.github/workflows/Regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/520/files#diff-0ac4162fca393e5c27231d40a734df1b3adbe81f0db5d0841144208762aabfa9)
- Modifies test command in Agents workflow by removing `--no-fail --debug` flags

#### 📍Where to Start
Start with the timeout configuration change in [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/520/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) where `DEFAULT_STREAM_TIMEOUT_MS` is modified.

----

_[Macroscope](https://app.macroscope.com) summarized e7a139c._