### PR TITLE
Remove unused metric type definitions for clarity

### DIFF
--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn  ${{ matrix.test }} --no-fail --debug
+        run: yarn test suites/{{matrix.test}}/* --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test suites/{{matrix.test}}/* --no-fail --debug
+        run: yarn test suites/functional/* --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn  ${{ matrix.test }} --no-fail --debug
+        run: yarn test suites/{{matrix.test}}/* --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: yarn test suites/{{matrix.test}}/* --no-fail --debug
+        run: yarn test suites/large/* --no-fail --debug
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -25,9 +25,6 @@ interface ParsedTestName {
   members: string;
 }
 
-type MetricSubType = "stream" | "poll" | "recovery";
-type MetricType = "delivery" | "order";
-
 const GEO_TO_COUNTRY_CODE = {
   "us-east": "US",
   "us-west": "US",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier -w .",
     "functional": "yarn test suites/functional",
     "gen": "tsx inboxes/gen.ts",
-    "large": "yarn test suites/large/*",
+    "large": "yarn test suites/large/* ",
     "lint": "eslint .",
     "local-update": "./inboxes/gen.sh --envs local --installations 2,5,10,15,20,25 --count 500",
     "monitor:dev": "httpstat https://grpc.dev.xmtp.network:443",


### PR DESCRIPTION
### Remove unused metric type definitions for clarity and update GitHub workflow test commands to use explicit path patterns
- Updates GitHub workflow test commands in [.github/workflows/Functional.yml](https://github.com/xmtp/xmtp-qa-tools/pull/524/files#diff-a1f32d9141b58464309cfc532a2528f90960df9b7ec194da3b443710e8805b88) and [.github/workflows/Large.yml](https://github.com/xmtp/xmtp-qa-tools/pull/524/files#diff-eeb4321752b07db328a5d02b895bd4286bf8c514fa40da28f800f309287c15a0) to use `yarn test suites/{{matrix.test}}/*` instead of `yarn ${{ matrix.test }}`
- Removes unused TypeScript type definitions `MetricSubType` and `MetricType` from [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/524/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3)
- Adds trailing space to the `large` script command in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/524/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)

#### 📍Where to Start
Start with the removed type definitions in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/524/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to understand the cleanup changes, then review the workflow command modifications in [.github/workflows/Functional.yml](https://github.com/xmtp/xmtp-qa-tools/pull/524/files#diff-a1f32d9141b58464309cfc532a2528f90960df9b7ec194da3b443710e8805b88).

----

_[Macroscope](https://app.macroscope.com) summarized d863502._