### PR TITLE
CI script for merge to main for triggering on test branch

### DIFF
--- a/.github/workflows/NetworkChaos.yml
+++ b/.github/workflows/NetworkChaos.yml
@@ -1,0 +1,75 @@
+name: Network Chaos Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  chaos-test:
+    name: Local Network Chaos Tests Against 4-node XMTP-go cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      max-parallel: 1
+      matrix:
+        test_file:
+          - group-client-partition.test.ts
+          - group-partition-delayedreceive.test.ts
+          - node-blackhole.test.ts
+          - networkchaos.test.ts
+          - keyrotation.test.ts
+          - group-reconciliation.test.ts
+          - dm-duplicate-prevention.test.ts
+
+    env:
+      XMTP_ENV: local
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install Linux Networking Tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iproute2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Initial Docker Setup
+        run: ./multinode/ci.sh
+
+      - name: Run ${{ matrix.test_file }}
+        run: |
+          FILE=suites/networkchaos/${{ matrix.test_file }}
+          echo "Running $FILE"
+          if ! npx vitest run $FILE; then
+            echo "Retrying $FILE after environment reset..."
+            ./multinode/ci.sh
+            npx vitest run $FILE
+          fi
+
+      - name: Upload Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-artifacts-${{ matrix.test_file }}
+          path: |
+            logs/**/*
+            .data/**/*
+            .env
+          if-no-files-found: ignore
+          overwrite: true
+          include-hidden-files: true
+          retention-days: 30
+
+      - name: Tear Down Docker
+        if: always()
+        run: docker compose down
+


### PR DESCRIPTION
### Add GitHub workflow for network chaos testing against 4-node XMTP-go cluster to trigger on test branch merge to main
Creates a new GitHub Actions workflow file [NetworkChaos.yml](https://github.com/xmtp/xmtp-qa-tools/pull/527/files#diff-a08e0fe551d3a4f4ffc224df9c9226ba233075b6b3b8e888d60ed5958f5ed06d) that runs network chaos tests against a 4-node XMTP-go cluster. The workflow triggers manually via `workflow_dispatch` and executes tests in a matrix strategy including group client partition, delayed receive, node blackhole, network chaos, key rotation, group reconciliation, and DM duplicate prevention tests. The workflow installs `iproute2` networking tools, sets up Node.js and Docker, runs tests with retry logic, uploads test artifacts (logs, data, and environment files), and tears down the Docker environment with a 30-minute timeout.

#### 📍Where to Start
Start with the workflow configuration and job definition in [NetworkChaos.yml](https://github.com/xmtp/xmtp-qa-tools/pull/527/files#diff-a08e0fe551d3a4f4ffc224df9c9226ba233075b6b3b8e888d60ed5958f5ed06d).

----

_[Macroscope](https://app.macroscope.com) summarized 2fbcf43._