### PR TITLE
Increase stream timeout for improved performance stability

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -797,7 +797,7 @@ export const defaultNames = [
 ];
 
 export const playwrightBeforeSendTimeout = 1000; // 1 second
-export const streamTimeout = 10000; // 10 seconds
+export const streamTimeout = 40000; // 10 seconds
 
 export const formatBytes = (bytes: number): string => {
   if (bytes === 0) return "0 B";


### PR DESCRIPTION
### Increase `streamTimeout` constant from 10000 to 40000 milliseconds for improved performance stability in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/529/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1)
The `streamTimeout` constant value is modified from 10000 milliseconds to 40000 milliseconds in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/529/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1). The associated comment remains outdated, still referencing '10 seconds' instead of the new 40-second timeout value.

#### 📍Where to Start
Start with the `streamTimeout` constant definition in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/529/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1).

----

_[Macroscope](https://app.macroscope.com) summarized da3b17c._