### PR TITLE
Move retries inside each test for fresh count

### DIFF
--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -12,7 +12,6 @@ const testName = "agents";
 
 describe(testName, () => {
   let workers: WorkerManager;
-  let retries = 3;
   const env = process.env.XMTP_ENV as "dev" | "production";
   beforeAll(async () => {
     workers = await getWorkers(
@@ -36,6 +35,7 @@ describe(testName, () => {
   for (const agent of filteredAgents) {
     it(`should receive response from ${agent.name} agent (${agent.address}) when sending "${agent.sendMessage}"`, async () => {
       try {
+        let retries = 3; // Move retries inside each test for fresh count
         console.warn(`Testing ${agent.name} with address ${agent.address} `);
 
         const conversation = await workers

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -88,7 +88,7 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
 
-        sendMetric("delivery", orderPercentage, {
+        sendMetric("order", orderPercentage, {
           libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
@@ -156,7 +156,7 @@ describe(testName, async () => {
 
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
-        sendMetric("delivery", orderPercentage, {
+        sendMetric("order", orderPercentage, {
           libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
@@ -247,7 +247,7 @@ describe(testName, async () => {
 
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
-        sendMetric("delivery", orderPercentage, {
+        sendMetric("order", orderPercentage, {
           libxmtp: offlineWorker.libXmtpVersion,
           sdk: offlineWorker.sdkVersion,
           test: testName,

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -26,7 +26,7 @@ describe(testName, async () => {
   const amountofMessages = parseInt(process.env.DELIVERY_AMOUNT ?? "10");
   const receiverAmount = parseInt(process.env.DELIVERY_RECEIVERS ?? "4");
 
-  console.log(
+  console.debug(
     `[${testName}] Amount of messages: ${amountofMessages}, Receivers: ${receiverAmount}`,
   );
   let workers = await getWorkers(
@@ -39,7 +39,7 @@ describe(testName, async () => {
 
   beforeAll(async () => {
     try {
-      console.log("creating group");
+      console.debug("creating group");
       group = await workers.createGroup();
     } catch (e) {
       logError(e, expect.getState().currentTestName);
@@ -63,14 +63,15 @@ describe(testName, async () => {
       const receptionPercentage = verifyResult.receptionPercentage ?? 0;
       const orderPercentage = verifyResult.orderPercentage ?? 0;
 
-      console.log(
+      console.debug(
         `Stream reception percentage: ${receptionPercentage}%, order percentage: ${orderPercentage}%`,
       );
 
       // Don't fail if stats are missing or incomplete, just log and continue
-      if (!verifyResult.receptionPercentage || !verifyResult.orderPercentage) {
-        console.log("Warning: No stats were generated for stream verification");
-      }
+      if (!verifyResult.receptionPercentage || !verifyResult.orderPercentage)
+        console.debug(
+          "Warning: No stats were generated for stream verification",
+        );
 
       // Only run expectations if we have values
       if (receptionPercentage > 0) {
@@ -137,7 +138,7 @@ describe(testName, async () => {
       const receptionPercentage = stats.receptionPercentage ?? 0;
       const orderPercentage = stats.orderPercentage ?? 0;
 
-      console.log(
+      console.debug(
         `Poll reception percentage: ${receptionPercentage}%, order percentage: ${orderPercentage}%`,
       );
 
@@ -176,7 +177,7 @@ describe(testName, async () => {
       const offlineWorker = workers.getCreator(); // Second worker
       const onlineWorker = workers.getReceiver(); // First worker
 
-      console.log(`Taking ${offlineWorker.name} offline`);
+      console.debug(`Taking ${offlineWorker.name} offline`);
 
       // Disconnect the selected worker
       await offlineWorker.worker.terminate();
@@ -184,17 +185,17 @@ describe(testName, async () => {
       // Send messages from an online worker
       const conversation =
         await onlineWorker.client.conversations.getConversationById(group.id);
-      console.log(
+      console.debug(
         `Sending ${amountofMessages} messages while client is offline`,
       );
       for (let i = 0; i < amountofMessages; i++) {
         const message = `offline-msg-${i + 1}-${randomSuffix}`;
         await conversation!.send(message);
       }
-      console.log("Sent messages");
+      console.debug("Sent messages");
 
       // Reconnect the offline worker
-      console.log(`Reconnecting ${offlineWorker.name}`);
+      console.debug(`Reconnecting ${offlineWorker.name}`);
       const { client } = await offlineWorker.worker.initialize();
       offlineWorker.client = client;
       await offlineWorker.client.conversations.sync();
@@ -228,7 +229,7 @@ describe(testName, async () => {
       const receptionPercentage = stats.receptionPercentage ?? 0;
       const orderPercentage = stats.orderPercentage ?? 0;
 
-      console.log(
+      console.debug(
         `Recovery reception percentage: ${receptionPercentage}%, order percentage: ${orderPercentage}%`,
       );
 


### PR DESCRIPTION
### Move retries variable declaration inside each test case to ensure fresh retry count for each agent test
- Moves `retries` variable declaration from global scope to inside each test case in [suites/agents/agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/530/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596) to provide fresh retry counter for each test
- Changes metric name from "delivery" to "order" for order percentage metrics in `sendMetric` calls within stream, poll, and recovery tests in [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/530/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916)
- Converts `console.log` calls to `console.debug` for log level consistency in [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/530/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916)

#### 📍Where to Start
Start with the test cases in [suites/agents/agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/530/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596) to see how the `retries` variable is now declared within each test function.

----

_[Macroscope](https://app.macroscope.com) summarized 833180f._