### PR TITLE
Improve test output clarity for agent responses

### DIFF
--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -33,7 +33,7 @@ describe(testName, () => {
   });
   // For local testing, test all agents on their supported networks
   for (const agent of filteredAgents) {
-    it(`should receive response from ${agent.name} agent (${agent.address}) when sending "${agent.sendMessage}"`, async () => {
+    it(`${agent.name} : ${agent.address} : ${env}`, async () => {
       try {
         let retries = 3; // Move retries inside each test for fresh count
         console.warn(`Testing ${agent.name} with address ${agent.address} `);

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -33,7 +33,7 @@ describe(testName, () => {
   });
   // For local testing, test all agents on their supported networks
   for (const agent of filteredAgents) {
-    it(`${agent.name} : ${agent.address} : ${env}`, async () => {
+    it(`${env}: ${agent.name} : ${agent.address}`, async () => {
       try {
         let retries = 3; // Move retries inside each test for fresh count
         console.warn(`Testing ${agent.name} with address ${agent.address} `);


### PR DESCRIPTION
### Simplify test description format in agent tests to display environment, agent name, and address only
The test description format in [agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/533/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596) changes from a verbose format that included the agent name, address, and message content to a concise format showing only `${env}: ${agent.name} : ${agent.address}`. The test functionality remains unchanged.

#### 📍Where to Start
Start with the test descriptions in [agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/533/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596) to see the format changes.

----

_[Macroscope](https://app.macroscope.com) summarized f97a570._