### PR TITLE
Add performance test failures to known issues list

### DIFF
--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -13,7 +13,7 @@ export const KNOWN_ISSUES = [
   {
     testName: "Dms",
     uniqueErrorLines: [
-      "FAIL  suites/functional/dms.test.ts > dms > should  fail on purpose",
+      "FAIL  suites/functional/dms.test.ts > dms > fail on purpose",
     ],
   },
   {

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -22,6 +22,15 @@ export const KNOWN_ISSUES = [
       "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
     ],
   },
+  {
+    testName: "Performance",
+    uniqueErrorLines: [
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams",
+    ],
+  },
 ];
 
 // Patterns to track for error deduplication and log filtering

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/slack-bot/issues.json
+++ b/slack-bot/issues.json
@@ -1,18 +1,83 @@
 [
   {
-    "id": "AwAAAZd_diaRbftBTAAAABhBWmRfZGlhUkFBQVlUZWw2RFJBSk1BQUEAAAAkMDE5NzdmNzktZWFjNS00MTdhLTljNWEtMTBmZmRiYWE2NzJlAABCyQ",
+    "id": "AwAAAZeJaWMgnQUT0AAAABhBWmVKYVdNZ0FBQmN5dDJ0U3FXZUNRQUEAAAAkMDE5Nzg5NmMtN2FkYi00YjY4LWE3OWQtN2UyMjI2ODRjYWIzAAAg4g",
     "type": "log",
-    "environment": "dev",
-    "test": "browser",
+    "environment": "production",
+    "test": "functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "us-east",
-    "env": "dev",
+    "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"013056656539155a7bc6c4196668339c649da997a09c9ad86a0f30a425548d88\" installation_id=\"3a6a5900bbaa5555d4965662f5e86115c5a9b7cdb1015f25f07754f9def1711c\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99321819 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99321819] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      ", Library)",
+      ", last_stream_id: StreamId(0) }",
+      "sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(7)))] group_id=\"370b85bbe935300ffed3a9e07952e73d\" inbox_id=\"4f77124bc0cefeabd7324234609510205e15d140958eb45ff4294934acdb0abb\" installation_id=\"4e927dcb1b2ef26b6eb574ac4720a67cca70e80c09550da01c24b7275d7bef43\"",
+      "sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(7)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(7)))]",
+      "FAIL  suites/functional/dms.test.ts > dms > fail on purpose"
+    ]
   },
   {
-    "id": "AwAAAZd_c8xW9-TuygAAABhBWmRfYzh4V0FBQmwybUxPeGJTU2FRQUEAAAAkMDE5NzdmNzktZWFjNS00MTdhLTljNWEtMTBmZmRiYWE2NzJlAABCyg",
+    "id": "AwAAAZeJXYHslPgzcgAAABhBWmVKWFlIc0FBQ3pxZXlQUXFFem13QUEAAAAkMDE5Nzg5NjQtNTVhMS00ZWE1LWI4M2EtNjQ5OGM2YTg3NzllAAA1dA",
+    "type": "log",
+    "environment": "production",
+    "test": "agents",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d12c5858f3ce8a332c587dbc628d85341770f521306671e016ae035b0c65ccb1\" installation_id=\"28b2469ba2eae2fd12d86f322e050c3b519d312097247798f5edcf5b75a3a7a9\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
+  },
+  {
+    "id": "AwAAAZeJWMu1wdrS2AAAABhBWmVKV011MUFBQU1oUkZhZnlxVFR3QUEAAAAkMDE5Nzg5NjQtNTVhMS00ZWE1LWI4M2EtNjQ5OGM2YTg3NzllAAA1dQ",
+    "type": "log",
+    "environment": "production",
+    "test": "functional",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      ", Library)",
+      ", last_stream_id: StreamId(0) }",
+      "sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(5)))] group_id=\"f17cf19330f507cfae0f523f7f6f44d7\" inbox_id=\"cb136fd6295c334420841f47f7e568f6d20a166f41ed7ae348d6c8d2868fc67c\" installation_id=\"82c9e4b398028f11171b6ea1eb019128fc2d7d53063d53b9f142b0e74a31d59b\"",
+      "sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(5)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(5)))]",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(9)))] group_id=\"e7f322ef76cd649ae15526857d1a2823\" inbox_id=\"cb136fd6295c334420841f47f7e568f6d20a166f41ed7ae348d6c8d2868fc67c\" installation_id=\"82c9e4b398028f11171b6ea1eb019128fc2d7d53063d53b9f142b0e74a31d59b\"",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(9)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(9)))]",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [ProcessIntent(AlreadyProcessed(4513901))] group_id=\"e3c64d81d946e6a5ed5ba419a45deb42\" inbox_id=\"cb136fd6295c334420841f47f7e568f6d20a166f41ed7ae348d6c8d2868fc67c\" installation_id=\"82c9e4b398028f11171b6ea1eb019128fc2d7d53063d53b9f142b0e74a31d59b\"",
+      "process:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([ProcessIntent(AlreadyProcessed(4513901))]) error=Receive errors: [ProcessIntent(AlreadyProcessed(4513901))]",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [OpenMlsProcessMessage(ValidationError(WrongEpoch))] group_id=\"e3c64d81d946e6a5ed5ba419a45deb42\" inbox_id=\"fdc407113758ea0c1cfe31e41fe33a5fb6bb5b4e72dea35a85c84f3c17c5829d\" installation_id=\"8730fdd3ab542a18b5dd5df98b97f18342dae1bce1ccebdc30dbd4840fe81ba3\"",
+      "process:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([OpenMlsProcessMessage(ValidationError(WrongEpoch))]) error=Receive errors: [OpenMlsProcessMessage(ValidationError(WrongEpoch))]",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [OpenMlsProcessMessage(ValidationError(WrongEpoch))] group_id=\"e3c64d81d946e6a5ed5ba419a45deb42\" inbox_id=\"82da437bbd39216dac0acb1d6142b0b48fe18a3253c403a6b572c178544313f4\" installation_id=\"8f9ddf35455c8f880fe478872dbb65c262ccb571cc16fe43b474d6eec438f945\"",
+      "}",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [ProcessIntent(AlreadyProcessed(4513903))] group_id=\"f4adeb2501f3cc368517b2184e1c0608\" inbox_id=\"cb136fd6295c334420841f47f7e568f6d20a166f41ed7ae348d6c8d2868fc67c\" installation_id=\"82c9e4b398028f11171b6ea1eb019128fc2d7d53063d53b9f142b0e74a31d59b\"",
+      "process:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([ProcessIntent(AlreadyProcessed(4513903))]) error=Receive errors: [ProcessIntent(AlreadyProcessed(4513903))]"
+    ]
+  },
+  {
+    "id": "AwAAAZeJUS9D-EwGrwAAABhBWmVKVVM5REFBQjctcVpnUC1LbjZBQUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJQQ",
+    "type": "log",
+    "environment": "production",
+    "test": "agents",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"fa332049d0698da71300d1d3eb458be81e5d021e64ea13b4a77eb6d9bc9c8ac4\" installation_id=\"d8f85cb4e82f828c362080c10616dae025c48583ca88f0f0e81e2478cf7f7c3b\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
+  },
+  {
+    "id": "AwAAAZeJURX3ZfcczAAAABhBWmVKVVJYM0FBQV9qMU1CMmpoMFhRQUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJQg",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -21,70 +86,15 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ac3144079b776a67e16f98a122e4c7739450b3aa52a8805d71273bd5971b0f0a\" installation_id=\"fef27016f336479a232963d8a286f93fc05087c190b7b514b59d0d173fefdfe6\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109183827 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109183827] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"7df11b954e9b8f61d26773382daf1d825c1e39a69e515867cf27b3962ab335b8\" installation_id=\"14d95ed5b1beee6f344e957c8fd4bc8bd2651483efd83d36d493add4668cae3b\"",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110215611 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110215611] already processed",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd_cmVvx1UylAAAABhBWmRfY21WdkFBQWNFNjlTWE9GTVF3QUEAAAAkMDE5NzdmNzktZWFjNS00MTdhLTljNWEtMTBmZmRiYWE2NzJlAABCyw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"0d1b00eb5b2b496ed65eefc34fda504b10a2c251e2bf81d49247b4ed3e9f6826\" installation_id=\"6a0af531c4a4b3099bd9759e13079253aadd527a9aca39383f9053822c3b5bce\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd_chSff5xbOwAAABhBWmRfY2hTZkFBQTJnc1V5aGl2eG53QUEAAAAkMDE5NzdmNzktZWFjNS00MTdhLTljNWEtMTBmZmRiYWE2NzJlAABCzA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"290da3e66ba17f1ab1eb63f532183c20988fd133717c1ad141f16170ab816fd6\" installation_id=\"2a1b7db9494189d1f86e4ec6ae772a8d3bd6fd6a94817c590d959e5a0205c0d0\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_YdhwX4npSQAAABhBWmRfWWRod0FBQWotMUJKSWJQektnQUEAAAAkMDE5NzdmNjMtMzAxOS00N2YyLWEyNDktYjhiYjM2NzJkOGJhAABAdw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"da38e05783037a446c01c5ec29d0f14ec834794c859e0e8e9f5a3afd64776f69\" installation_id=\"63141164cd882939fcdeb5b48c606d7f93c479d5933c8cdc847f33e8d204dd49\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd_YV9ed_WERQAAABhBWmRfWVY5ZUFBQ3JyTEJWYW5EQ1dnQUEAAAAkMDE5NzdmNjMtMzAxOS00N2YyLWEyNDktYjhiYjM2NzJkOGJhAABAeA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5c119efbd3741d2bf03039a5d68bfa6942cba898e8d55f9d7543cdc0fc1594e5\" installation_id=\"d982febdf3458ac76b2f51158cb78e63cd4988dd3c1a61ad4e1d585c3bdf20cd\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_WSWbfYZlnAAAABhBWmRfV1NXYkFBRGd6YTJZaWtlUjJ3QUEAAAAkMDE5NzdmNTktNGI5ZC00NDlhLWE2ZDctZGJiNjY4NDcwOTZjAAA34g",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b8759392c99e26a7a722dd0c88cdbc867f57e73cd8701ea9280b74b2e6f091c0\" installation_id=\"3dbdbd280b0bbfbeaa28c4bab9c002bb7cc1064d38e0887b64f4ed56250ea40c\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109177942 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109177942] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd_WRhtEhcHuwAAABhBWmRfV1JodEFBRF9pTlRkX2U4U3lRQUEAAAAkMDE5NzdmNTktNGI5ZC00NDlhLWE2ZDctZGJiNjY4NDcwOTZjAAA34w",
+    "id": "AwAAAZeJUQ03Kh0UKwAAABhBWmVKVVEwM0FBQklfNGNIekFkS29nQUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJQw",
     "type": "log",
     "environment": "dev",
     "test": "browser",
@@ -93,10 +103,34 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c74157c0398ae869429d4a3d75b6916d3e8ac718f5172361caaf125dbab440f5\" installation_id=\"b412fb6f8999f7a237a6dee809d7f0be8cf3a4904a10e539e13c3c68d2b4f655\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99315857 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99315857] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"06bf88610398de389a69da60b6320c3d12d8dae392da87b8633478fd84e75917\" installation_id=\"e3c1141ddce0b2e30d74076ad39fed825672f116a13810f908f6b4eabda0c299\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99625514] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 99625514 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd_V28XSYkMsAAAABhBWmRfVjI4WEFBQzhhTmJkVklDU1hRQUEAAAAkMDE5NzdmNTktNGI5ZC00NDlhLWE2ZDctZGJiNjY4NDcwOTZjAAA35A",
+    "id": "AwAAAZeJR-in_LvnvQAAABhBWmVKUi1pbkFBQmZMV1NEb1dGWVZBQUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJRA",
+    "type": "log",
+    "environment": "production",
+    "test": "performance",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"6edcb49b7b2d5bf46281b962e5d7efb550c445c608c07243c01bc6cd50bcc858\" installation_id=\"03906f88f806c786185310692d33b411d0ff8162a6b36d6a0c98113f18836ecb\"",
+      "m_performance > [dave-210] Collector timed out. 10s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams"
+    ]
+  },
+  {
+    "id": "AwAAAZeJRSkJCzPUNwAAABhBWmVKUlNrSkFBQ1VfZWhpVGxocTJRQUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJRQ",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -105,46 +139,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"45de1e2f5b76f6a6c684803820bdbb527db490921b069a0fb91db22373d5c659\" installation_id=\"1824103fd2c49330fd5265c81fa54d3747a4647e95d5f7a82be3bccce44b2d84\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"54d2a959ed311bbc44b84bfbdf347abfa2a1fc7c82bbc6166ed06c07cc23db31\" installation_id=\"ab3f6b1c256e465f13c6e261c5d5424fd6edffe353a056c3ce196a5bb3312d65\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd_VuHGx9679wAAABhBWmRfVnVIR0FBQVFidTc5dVB1S3pBQUEAAAAkMDE5NzdmNTktNGI5ZC00NDlhLWE2ZDctZGJiNjY4NDcwOTZjAAA35Q",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"144086b3723708e5e0f7e520627f7d87d10d123616fdb261a203e0acc01ec8e2\" installation_id=\"e03bbc751d0c1ea8b6b1122226064611bdbadece1e31e0bceafcd89c4a9d6c0c\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_RhhRIoFSxgAAABhBWmRfUmhoUkFBQmF5LW96VkZ0T3V3QUEAAAAkMDE5NzdmNGUtNGZiZS00NWY5LWIyYjEtNDBlZTk5MWZlYmYzAAAjng",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d364347a3bfb6c0f88dd21b020c72db44d4197f4f420475a68323d8b3e7fa68a\" installation_id=\"1fac4860c5ff9535113d674ee1f04bbd005dfa41d8adb08264a1acdff125e61f\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd_Rb16vdoL5QAAABhBWmRfUmIxNkFBQzJBTlVvU3B6Y0ZBQUEAAAAkMDE5NzdmNGUtNGZiZS00NWY5LWIyYjEtNDBlZTk5MWZlYmYzAAAjnw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"311ed42e44206bcece4ca6164dd044682484ea23e554750de2280a869f514d72\" installation_id=\"b6f8c06b4e2ad822c7979edcb1614fad3a9da9a1f79faee1d47647c26a9725cc\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_Pc_E5A2ERQAAABhBWmRfUGNfRUFBQ0YzS0JYQnV3NHR3QUEAAAAkMDE5NzdmNDMtZWU5OS00ZTZhLWJjYjgtZTM5NDQ0OTc3OWJjAAAkAA",
+    "id": "AwAAAZeJOWvbEFT7_AAAABhBWmVKT1d2YkFBQXFkVThTMS05RmR3QUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJRg",
     "type": "log",
     "environment": "dev",
     "test": "browser",
@@ -153,10 +155,15 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b0c3dee97b914ef34e62753a19d9dccce48528ca12dce42ef1768f82083690e9\" installation_id=\"7ad600f23e0dcb6fcfa6da6091dd97eec48881b76e35043938c3c0503f367f79\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99315503] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99315503 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"679adad73aa5a94975351da89f5a252825e26872794bcd0a45982f65e6ea0dfb\" installation_id=\"29ca98a488c134d5fdd2bb08a5d6a7e97073811a3539756833540ac8c4809b01\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99618777] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 99618777 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd_PcaIbaQeoQAAABhBWmRfUGNhSUFBQmktY2RWVU5rOWJRQUEAAAAkMDE5NzdmNDMtZWU5OS00ZTZhLWJjYjgtZTM5NDQ0OTc3OWJjAAAkAQ",
+    "id": "AwAAAZeJOWq0d1axtgAAABhBWmVKT1dxMEFBRDIwUG1TalUxVjh3QUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJRw",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -165,10 +172,15 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2d55e6041c0b95a4057b742003c11cf26192431e660567106b11bd78f2891080\" installation_id=\"9a4d7e33ca1579e7444a57db7eeb627e8886bc752f1ba97ccd5d5c58be881759\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109177322 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109177322] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2dc155864bde3a063affde8cbf95164c3663eaaf74d5dbde8644ea071090b20a\" installation_id=\"cc5e67ee46e075345bc8630c38fa6430be7e00fa7e5a94b5f75ce9de2702524e\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110208300] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110208300 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd_PH7NAhWa8AAAABhBWmRfUEg3TkFBQVJ4QXJGZ1FaVmlnQUEAAAAkMDE5NzdmNDMtZWU5OS00ZTZhLWJjYjgtZTM5NDQ0OTc3OWJjAAAkAg",
+    "id": "AwAAAZeJN-nGtyonRQAAABhBWmVKTi1uR0FBQjJQZlZPeWxWMDBBQUEAAAAkMDE5Nzg5NWQtZTJmNC00ZTU3LThhMDctYmU3YTUwNjZiYjY0AAGJSA",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -177,22 +189,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4e012c636c13b62d10a9cb21fb001dbb53fa03d46e8dd06b35dcd9266a84d9c2\" installation_id=\"9a3efa30d6898bf706a87910987937314e543a55e737ccc9280df975c171098d\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"50193e71f90bc8318ac8d57b593415064dcc0886f50dfeb7dca906c0ad4f0548\" installation_id=\"35075831210e0e79f23604c860e97f11ce365cf6b7aa3fcec0e25c2c1ff920cf\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd_PAmBj6QBmQAAABhBWmRfUEFtQkFBREU1TlhOMXpZZHpnQUEAAAAkMDE5NzdmNDMtZWU5OS00ZTZhLWJjYjgtZTM5NDQ0OTc3OWJjAAAkAw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"11d3e36cfc12c80856411d0b0f16a33040509ef9a910e1340e5c83a8a8ecea39\" installation_id=\"396c2c440536ad5df767c5da958a17d3edd3fd036aeecc1c58d28a20c61f2ec8\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_MlZe0ZZE_AAAABhBWmRfTWxaZUFBQkNRUEZ0WE9LNVN3QUEAAAAkMDE5NzdmMzgtZjNmZS00NGU0LThlZTAtODliZTI0YmY5OTMzAAAktw",
+    "id": "AwAAAZeJJfcuXRX23gAAABhBWmVKSmZjdUFBQW1XX2tBSy1DMXRnQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP9g",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -201,22 +205,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c7e9e676b526afc577173552d5965f3ef5e26c4046d9e70e10b32b28b8dba756\" installation_id=\"320af8aa98527cec5166e38369ca97e97ba08acb74a597e263161379c9165f33\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"9247e0461fb4cd860b757a78cb88d0e49eaa35aac753f74faa02e4601eded165\" installation_id=\"52bdfe3b070e98331c032f4a77385d15d46e91f7b67283ebe9b4c2f2f155c667\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd_Md_nLdnzTwAAABhBWmRfTWRfbkFBQll3NzZtRWY3cDBnQUEAAAAkMDE5NzdmMzgtZjNmZS00NGU0LThlZTAtODliZTI0YmY5OTMzAAAkuA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"0f13d24ca6e8a6d85d4f839af509610086bb2a38cb7ea5c0b186f0d912781368\" installation_id=\"820276c4c38bc8d2d5bbcf9097fccaabe27545cc03cd8808ce8ba8da0ccdacb0\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_JTynTm-C3gAAABhBWmRfSlR5bkFBQVlFYUgyWF9jd2Z3QUEAAAAkMDE5NzdmNzAtOWM5Yy00YTM1LWEzZWMtMDdjY2QxYjMzMGE3AAFXcQ",
+    "id": "AwAAAZeJHBwRyT2Z7QAAABhBWmVKSEJ3UkFBRGJXcjJsSkdKM0dBQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP9w",
     "type": "log",
     "environment": "dev",
     "test": "browser",
@@ -225,10 +221,15 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"eb055d3df9208397e65a0ff938742b6c051f96fc5b70bb628010a872aaf9e88e\" installation_id=\"7bdb0600f81386ea17d67faa4c2648abdf0d64727cbafef9839dae12088c490d\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99309921] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99309921 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e9b5ff477450a78be49b421fe042b1d23b38f00adfc9769698c225b524d768e6\" installation_id=\"d490b3d30d1b5c8418b6e68c3e7fa7b4d3e31a56b4b68c1cae68bd942ac53505\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99618379] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 99618379 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd_JTpNmrB0wgAAABhBWmRfSlRwTkFBQVBUY3FPME1ldURnQUEAAAAkMDE5NzdmNzAtOWM5Yy00YTM1LWEzZWMtMDdjY2QxYjMzMGE3AAFXcg",
+    "id": "AwAAAZeJHBQ8TJjgZQAAABhBWmVKSEJROEFBQXNKeERwcjFGZjBnQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP-A",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -237,10 +238,15 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"31031566e4faeca20a24c8d1b3af80efd080e39b58f3175096e8ad29745418dc\" installation_id=\"2e89210f1ba2d6d08cb02f266d28cc9c056ccb711627ab9f8a6d9da7f4ca6c7d\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109171479 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109171479] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"3ed67eabc4897b2ad42fa2aba66f80314b0907b18edf2dc4fb6b64f85b88c647\" installation_id=\"a947106a6ca66487e940c39e4dde00d7e51c3769047b8b0f637e46faca97f1f4\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110207839] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110207839 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd_IkFChdO3kgAAABhBWmRfSWtGQ0FBRFRjeGJ6WEt0RVFBQUEAAAAkMDE5NzdmNzAtOWM5Yy00YTM1LWEzZWMtMDdjY2QxYjMzMGE3AAFXcw",
+    "id": "AwAAAZeJG-qT0z3EFQAAABhBWmVKRy1xVEFBQV83ZmsyeUw5ZzdnQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP-Q",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -249,46 +255,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f9b508935858f9c7d3e6efd586aba8bc206e776bbe3c49a1244cbd33b20ee76a\" installation_id=\"a85f1dab1b2544e67df528fc8f3c49960863253a4daf15954cfaf889edc183cb\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from elsa agent (0xe15aa1ba585aea8a4639331ce5f9aec86f8c4541) when sending \"hi\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b6e8de15fe0701578f54700c336f5ef1a2ef2f48bf30c2f608bdaeba26e71fb3\" installation_id=\"792c473a19cb9208d6cedfa3608d0f0391327e584642af13dbbfd0424cce71dc\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd_IcHWPwi28QAAABhBWmRfSWNIV0FBQ28xRFhwb0xNM19RQUEAAAAkMDE5NzdmNzAtOWM5Yy00YTM1LWEzZWMtMDdjY2QxYjMzMGE3AAFXdA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"6f6a7497c0d35875b6d568326f35913cdd448b643ef5872568f4aec05a383b6f\" installation_id=\"7a4f52c10329d3a8f785bcdc0dcfdbb5c293007fd4c3e4f02eb3ba0dd7924fd4\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_GPLBOklvZgAAABhBWmRfR1BMQkFBRHUxN2g0SnN6QkJRQUEAAAAkMDE5NzdmNzAtOWM5Yy00YTM1LWEzZWMtMDdjY2QxYjMzMGE3AAFXdQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "suites/agents/agents.test.ts",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "agents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_FQSgZ72gWAAAABhBWmRfRlFTZ0FBQzllX2s4Z1UwQl9nQUEAAAAkMDE5NzdmMjMtNTA3OC00YmJkLThjNTktNzg4YTY5ZTBhOTViAAHpAg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "agents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_ECSJW5ABmQAAABhBWmRfRUNTSkFBREU1TlhOMTlucHVnQUEAAAAkMDE5NzdmMjMtNTA3OC00YmJkLThjNTktNzg4YTY5ZTBhOTViAAHpAw",
+    "id": "AwAAAZeJGwt_mF6ApQAAABhBWmVKR3d0X0FBQkExOVhLZGkxV3BRQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP-g",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -297,82 +271,106 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c1a6009f1b85547fc17812abda7e53488e4674f08e62d0aa8ad944d5dc2d25b8\" installation_id=\"5d3f58d4cc6e31381754a77b1fb27ef9da3e3b0c2a7ecf2f9e945311d4dce7ea\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2d0710e059defba98207450147c1240a11f035503f6ef61d379e4eed7c782bd5\" installation_id=\"5caf93e74e4d3722965af5c713e6c3169bf4504c0713bfbd2c160b47a2635623\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd_D61rqqUaWgAAABhBWmRfRDYxckFBQndaZk1iZHN1S2pnQUEAAAAkMDE5NzdmMjMtNTA3OC00YmJkLThjNTktNzg4YTY5ZTBhOTViAAHpBA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"6dc304983fd33c128acac1e8c2f214a331a3bbfad74ab14223b793b59c16789e\" installation_id=\"abd2e85496d32940d3acd57e85d486f3ae13278400c7f2faabaf980e2b1341a2\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd_A9vp1xe0tAAAABhBWmRfQTl2cEFBQlJZc1NnZzFQb3ZBQUEAAAAkMDE5NzdmMjMtNTA3OC00YmJkLThjNTktNzg4YTY5ZTBhOTViAAHpBQ",
+    "id": "AwAAAZeJGvsXlkRWSAAAABhBWmVKR3ZzWEFBQ3FxWFNmVkp4NFZRQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP-w",
     "type": "log",
     "environment": "production",
-    "test": "browser",
+    "test": "functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a38f2e476aab385d43e9c9ff841a8a7b85cc9c543e5d554c5d5a310cfed0edff\" installation_id=\"5e8401dab14123a5cf614bd4812d2117dbe90150f08a9feb3134bfca05abb2c4\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109171111] already processed"
+    "message": [
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [ProcessIntent(AlreadyProcessed(4512628))] group_id=\"f8a6e057e0b4b890a5fa506f6e2b45c3\" inbox_id=\"0c21d705a95f9d7763bd3d935439649157d881886e590fde47961f2ccdaeee57\" installation_id=\"f37305802dcc9e0d1f9df767a7b1cf866244971feed9493d3c1adcc7abe1407e\"",
+      "process:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([ProcessIntent(AlreadyProcessed(4512628))]) error=Receive errors: [ProcessIntent(AlreadyProcessed(4512628))]",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(21)))] group_id=\"f8a6e057e0b4b890a5fa506f6e2b45c3\" inbox_id=\"0c21d705a95f9d7763bd3d935439649157d881886e590fde47961f2ccdaeee57\" installation_id=\"f37305802dcc9e0d1f9df767a7b1cf866244971feed9493d3c1adcc7abe1407e\"",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(21)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(21)))]",
+      "CORE sqlcipher_page_cipher: hmac check failed for pgno=97",
+      "CORE sqlite3Codec: error decrypting page 97 data: 1",
+      "CORE sqlcipher_codec_ctx_set_error 1",
+      "FAIL  suites/functional/consent.test.ts [ suites/functional/consent.test.ts ]",
+      "FAIL  suites/functional/order.test.ts [ suites/functional/order.test.ts ]",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream",
+      "FAIL  suites/functional/dms.test.ts > dms > fail on purpose"
+    ]
   },
   {
-    "id": "AwAAAZd_A9NsMb0J6gAAABhBWmRfQTlOc0FBQmhZTGJ6UUFabFVRQUEAAAAkMDE5NzdmMjMtNTA3OC00YmJkLThjNTktNzg4YTY5ZTBhOTViAAHpBg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"07d3c4d0c10ec4974adc092d293311f2e1da6d1a6222712c2257abd87d1976b6\" installation_id=\"764036b89dbc987ea299a9f469c638b84aab7aee05f0a3b794030e60b670433d\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99309703] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99309703 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd_Aao6GdEFcgAAABhBWmRfQWFvNkFBQTBjaE9XZ2lZZFpRQUEAAAAkMDE5NzdmMDMtYzJiZS00NGIyLTkxY2YtMmQ4YmYwYjZhZWNiAAAo-w",
+    "id": "AwAAAZeJGc93nRHl9QAAABhBWmVKR2M5M0FBQWFKbmVqRndnTUpnQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP_A",
     "type": "log",
     "environment": "production",
-    "test": "delivery",
+    "test": "functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"dcca795d7a3fbdec7b64c59598816e783e330e2ad24e8cf43a4ad51cc7893ad9\" installation_id=\"ad334900c1961f280ad59dbff76b5ddd097aca3f5734d074c1577d23f85a5c8d\"\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s."
+    "message": [
+      ", Library)",
+      ", last_stream_id: StreamId(0) }",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream",
+      "FAIL  suites/functional/dms.test.ts > dms > fail on purpose"
+    ]
   },
   {
-    "id": "AwAAAZd_AalJ0yCKswAAABhBWmRfQWFsSkFBQm9SLXZXOVl4bTVnQUEAAAAkMDE5NzdmMDMtYzJiZS00NGIyLTkxY2YtMmQ4YmYwYjZhZWNiAAAo_A",
+    "id": "AwAAAZeJGcQ8ZegvLgAAABhBWmVKR2NROEFBQk9UNHR6c3RSRkVRQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP_Q",
     "type": "log",
     "environment": "production",
-    "test": "agents",
+    "test": "functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5c4abd3d8006cf5cc60ce2e4788beeac3158635bec0346883f5169e31c9cf12d\" installation_id=\"22093e386b63bff3e46b087ab70b711623fa0336a1957e033c5270633d918a56\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: client: Association error: Missing identity update",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: storage error: UNIQUE constraint failed: consent_records.entity_type, consent_records.entity",
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(26)))] group_id=\"5eb9d8237fa04ffe9d4d610134c8a989\" inbox_id=\"0556ca0bcfe82b464d7b5a081d00de628e5057b45f5df50323074707c5c3b5dc\" installation_id=\"811dcaa39a9efd1ac77275a5d0ed02bfa83789e8e7199dbfc72dc39cc1b89ba6\"",
+      "sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(26)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(26)))]",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream",
+      "FAIL  suites/functional/dms.test.ts > dms > fail on purpose",
+      "FAIL  suites/functional/playwright.test.ts > playwright > should stream real-time group updates when members are added using async iterator pattern"
+    ]
   },
   {
-    "id": "AwAAAZd_AagIOAWFZwAAABhBWmRfQWFnSUFBQmV0Z1NfRllza25nQUEAAAAkMDE5NzdmMDMtYzJiZS00NGIyLTkxY2YtMmQ4YmYwYjZhZWNiAAAo_Q",
+    "id": "AwAAAZeJGWurtr_EFQAAABhBWmVKR1d1ckFBQV83ZmsyeUxwRWNBQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGP_w",
     "type": "log",
-    "environment": "dev",
-    "test": "delivery",
+    "environment": "production",
+    "test": "functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "us-east",
-    "env": "dev",
+    "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e7027f9d36dfb2030696374b87ea593b672dc06f7a8184f1c230790099e4faaa\" installation_id=\"48637213c5ded047e1c8c30c691a1efa0d613c60e70c92bd817333115a5c5035\"\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s."
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b83aa5f49c163ba9f073b0ed06b32ec76a4183e57888166a226b3253e6838af7\" installation_id=\"b269a7e08b65e18db6c9ef58589e011134fbb682ee28ddaf92863927e682d568\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110205726] already processed",
+      "streams > [alice-210] conversation stream error: Error: group with welcome id 110205728 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "DEVICE SYNC: xmtp_mls::groups::device_sync::worker: Sync worker error: storage error: UNIQUE constraint failed: processed_device_sync_messages.message_id inbox_id=\"801ca92b9d6c4aaf42f3638284c9df3075d868b130a6ade8a7de13190e44d273\" installation_id=\"c51195d7ed68f0661c1d4667ead1115ac6694d197d92fab7ca533d98a2e3463d\"",
+      "DEVICE SYNC: xmtp_mls::groups::device_sync::worker: Sync worker error: storage error: UNIQUE constraint failed: processed_device_sync_messages.message_id inbox_id=\"f9288d36ff8bbcde807add797fdb708a26861014a74f616f5916a4e3a645ec04\" installation_id=\"6b9a65d341cd77892dc3ee990c60795a38440fce6a7fdb7fa507f190c5eb3aca\"",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream",
+      "FAIL  suites/functional/downgrade.test.ts > downgrade > should maintain database integrity and functionality when downgrading across SDK versions",
+      "FAIL  suites/functional/playwright.test.ts > playwright > should stream real-time group updates when members are added using async iterator pattern"
+    ]
   },
   {
-    "id": "AwAAAZd-_uScZVLMkwAAABhBWmQtX3VTY0FBQU1SMWVyMG1Oa2h3QUEAAAAkMDE5NzdmMDMtYzJiZS00NGIyLTkxY2YtMmQ4YmYwYjZhZWNiAAAo_g",
+    "id": "AwAAAZeJFoxY0-1KkwAAABhBWmVKRm94WUFBQm1mT1FCdmh4a1pBQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGQAA",
     "type": "log",
     "environment": "local",
     "test": "dms",
@@ -381,34 +379,133 @@
     "region": "south-america",
     "env": "local",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5404a736336f789c7898c76b4ad2bb06d2ba49cdb290a1c340621f3c866cf02e\" installation_id=\"cdc2cf4024331dfb1cd32f119acb69eb166ce5decf2f32888d5237e941e2a06f\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"249dfd8a09e486a24c66e57642b9809dda10827e3bbd7b04878090efc64ef930\" installation_id=\"adc636095b8c9a27c77d7b7c7746392752d7960bed44c00428aa5f3c20f26c6b\"",
+      "FAIL  suites/functional/dms.test.ts > dms > fail on purpose"
+    ]
   },
   {
-    "id": "AwAAAZd-_pJ6oBBHPgAAABhBWmQtX3BKNkFBQmZFN0tKbmxEUmNBQUEAAAAkMDE5NzdmMjMtNTA3OC00YmJkLThjNTktNzg4YTY5ZTBhOTViAAHpBw",
+    "id": "AwAAAZeJELGvp-UM3AAAABhBWmVKRUxHdkFBQjYzM05DTk92aEFRQUEAAAAkMDE5Nzg5MTMtODA1Ny00ZTc5LTg5MTMtZDkwNjMyNDgzYmUwAAA2XA",
+    "type": "log",
+    "environment": "production",
+    "test": "agents",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"bd30c64e4cd721c5f2b87d55df01eee538d758c5b71e671bf2870c940cb97bfa\" installation_id=\"8efb0059fc696dfb9438e1f24a2c51a7efc1b606cfd96d4d6e314e9a177c0629\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
+  },
+  {
+    "id": "AwAAAZeJEHgsZqaxhgAAABhBWmVKRUhnc0FBQ2plQnlLWkwwMWpBQUEAAAAkMDE5Nzg5MTMtODA1Ny00ZTc5LTg5MTMtZDkwNjMyNDgzYmUwAAA2XQ",
+    "type": "log",
+    "environment": "production",
+    "test": "functional",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: storage error: UNIQUE constraint failed: consent_records.entity_type, consent_records.entity",
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(5)))] group_id=\"a56deb968db0e2364e8109c7bdf3e35c\" inbox_id=\"7318c564755f5fc923ca9a00ea334b86e8a517d924d3672adaf9b14a3dca4e47\" installation_id=\"1ab3e228a7ed37e58a7fd8c0223cce7040b2197a066cbfb32b871f1e9ca7f9bc\"",
+      "sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(5)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(5)))]",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream"
+    ]
+  },
+  {
+    "id": "AwAAAZeJDz1IChBEbgAAABhBWmVKRHoxSUFBRFdNZktRblIxOEdBQUEAAAAkMDE5Nzg5MTMtODA1Ny00ZTc5LTg5MTMtZDkwNjMyNDgzYmUwAAA2Xg",
+    "type": "log",
+    "environment": "production",
+    "test": "functional",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(4)))] group_id=\"44f99fcb57a65a282cae840f7d35c762\" inbox_id=\"57522102ac08fbb61084463d9b72672ba31cecee4ecf778753317626e13cf35a\" installation_id=\"03cbd098313548247c1ec65bbea03a9b2f9dca1f8c89ac3545b6c6490ae04445\"",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(4)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(4)))]",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(7)))] group_id=\"17e0e183965d6cb3f15ebe1ee8f4b56e\" inbox_id=\"eedfa9d0334bff016afe554c1a1d48040c17f3e114f54078b7057e3531b1b6d7\" installation_id=\"b8c7abdb29e714bde0503a62a16c228df5fc34f0f20cc873a2caad5586912dd5\"",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(7)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(7)))]",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [ProcessIntent(AlreadyProcessed(4510530))] group_id=\"b4f9a4f3d20616a3aab1d43f07d0a099\" inbox_id=\"155f300f32cc807504e033b541eb934b30387620269115fbfe17397923e820ab\" installation_id=\"1949def63d8c1531a0340ac10dff86c03b112c7ab8f640b82fce06afa3d2b4fe\"",
+      "process:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([ProcessIntent(AlreadyProcessed(4510530))]) error=Receive errors: [ProcessIntent(AlreadyProcessed(4510530))]",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [OpenMlsProcessMessage(ValidationError(WrongEpoch))] group_id=\"b4f9a4f3d20616a3aab1d43f07d0a099\" inbox_id=\"eedfa9d0334bff016afe554c1a1d48040c17f3e114f54078b7057e3531b1b6d7\" installation_id=\"b8c7abdb29e714bde0503a62a16c228df5fc34f0f20cc873a2caad5586912dd5\"",
+      "process:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([OpenMlsProcessMessage(ValidationError(WrongEpoch))]) error=Receive errors: [OpenMlsProcessMessage(ValidationError(WrongEpoch))]",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [OpenMlsProcessMessage(ValidationError(WrongEpoch))] group_id=\"b4f9a4f3d20616a3aab1d43f07d0a099\" inbox_id=\"57522102ac08fbb61084463d9b72672ba31cecee4ecf778753317626e13cf35a\" installation_id=\"03cbd098313548247c1ec65bbea03a9b2f9dca1f8c89ac3545b6c6490ae04445\"",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [OpenMlsProcessMessage(ValidationError(WrongEpoch))] group_id=\"b4f9a4f3d20616a3aab1d43f07d0a099\" inbox_id=\"94c7076ce83ddb3e4b4a9898bf42f23bf39927284db27651721f3200489735e0\" installation_id=\"00e311c9485aeae9aa98c6fbaa0aa0fd5aa45b455bd0ed6fa0c08bf3ed2aa5cb\"",
+      "process:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [ProcessIntent(AlreadyProcessed(4510534))] group_id=\"10867cdac9a30ab1cabeace6a04a1189\" inbox_id=\"155f300f32cc807504e033b541eb934b30387620269115fbfe17397923e820ab\" installation_id=\"1949def63d8c1531a0340ac10dff86c03b112c7ab8f640b82fce06afa3d2b4fe\"",
+      "process:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([ProcessIntent(AlreadyProcessed(4510534))]) error=Receive errors: [ProcessIntent(AlreadyProcessed(4510534))]"
+    ]
+  },
+  {
+    "id": "AwAAAZeJDuuEq7Um9gAAABhBWmVKRHV1RUFBQ0ZYMjRBUUpBTHN3QUEAAAAkMDE5Nzg5MTMtODA1Ny00ZTc5LTg5MTMtZDkwNjMyNDgzYmUwAAA2Xw",
+    "type": "log",
+    "environment": "production",
+    "test": "functional",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: storage error: UNIQUE constraint failed: consent_records.entity_type, consent_records.entity",
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream"
+    ]
+  },
+  {
+    "id": "AwAAAZeJDusC_vuVXwAAABhBWmVKRHVzQ0FBQnAyazI5S05aZURnQUEAAAAkMDE5Nzg5MTMtODA1Ny00ZTc5LTg5MTMtZDkwNjMyNDgzYmUwAAA2YA",
+    "type": "log",
+    "environment": "production",
+    "test": "functional",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "FAIL  suites/functional/consent.test.ts [ suites/functional/consent.test.ts ]",
+      "FAIL  suites/functional/order.test.ts [ suites/functional/order.test.ts ]"
+    ]
+  },
+  {
+    "id": "AwAAAZeJDhAe7idXAAAAABhBWmVKRGhBZUFBQ2hpeUp1N1VpMnhBQUEAAAAkMDE5Nzg5MTMtODA1Ny00ZTc5LTg5MTMtZDkwNjMyNDgzYmUwAAA2YQ",
     "type": "log",
     "environment": "local",
-    "test": "dms",
+    "test": "suites/functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "south-america",
     "env": "local",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"82046665499c647dbe7334a0889c8aa37f4f4572a65d3d4578b9a8a64ec4e43c\" installation_id=\"9c1dd0cd53348d511ff8aa150b2db6ef90326b3e4fdf58a864b014dfa2f09c1b\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
+    "message": [
+      ", Library)",
+      ", last_stream_id: StreamId(0) }",
+      "}",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(69))), Storage(NotFound(IntentForCommitted(107))), Storage(NotFound(IntentForCommitted(141)))] group_id=\"38252f89c1bb89763a43e64c1feae771\" inbox_id=\"e7f0149ce65570a6c321c02a76eb58206c1dc7d46c4f2e6ab28dba7a6d1c3150\" installation_id=\"eb129ccae5c9caa68866cb8ca90ae34f81f612fb009a83244c91853727dd3d83\"",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(69))), Storage(NotFound(IntentForCommitted(107))), Storage(NotFound(IntentForCommitted(141)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(69))), Storage(NotFound(IntentForCommitted(107))), Storage(NotFound(IntentForCommitted(141)))]",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream"
+    ]
   },
   {
-    "id": "AwAAAZd-9pqLOIfAYAAAABhBWmQtOXBxTEFBQlBIUkhWZV9RSnF3QUEAAAAkMDE5NzdlZjctOWU3Mi00YWEwLWIzMTAtNzE5YzE3NDZjYjllAAA2jg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4e8ae07ca596676ceb99eab85221047f7ef7faf4c6439fdfa34fd98b12a87853\" installation_id=\"2364e3f78939f3e6e104f7983caf98b643e29ae3475c5fdd7ae8e90eb16a26b9\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-7MmvQ9_ysQAAABhBWmQtN01tdkFBQ3NtTFBEQ2JJU0hnQUEAAAAkMDE5NzdlZWQtMTU4Zi00NDllLTgxMGMtNDRkOTNiNzE2MmI1AAAxnQ",
+    "id": "AwAAAZeJA-SqqTcBRQAAABhBWmVKQS1TcUFBQUZyT1RBNXpMQXZRQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGQAQ",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -417,10 +514,15 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ad14c72980b35268dd60dcc7f2f46e6f760a84ac8f311c5e5b04ce186d0b560a\" installation_id=\"d68f40ada2b90671ee15ae0ffbb877e1f5ce29d1c6adedfbb43445c0f803d0e8\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109165303 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109165303] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"9071fb711353e5f712335c13cdd05409094a99677e4f083686b24596b008b453\" installation_id=\"2dd20144c615f54a088819876eaa6f1141cf2c8dd6203d0278f087b4d1c0fee0\"",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110197487 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110197487] already processed",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd-7MHcslyPzwAAABhBWmQtN01IY0FBRE5vYnFjRXMweFFBQUEAAAAkMDE5NzdlZWQtMTU4Zi00NDllLTgxMGMtNDRkOTNiNzE2MmI1AAAxng",
+    "id": "AwAAAZeJA9Q5aPDl9QAAABhBWmVKQTlRNUFBQWFKbmVqRjlyWUJRQUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGQAg",
     "type": "log",
     "environment": "dev",
     "test": "browser",
@@ -429,10 +531,15 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b1d339a1ee6cab0bf7cc299df6338b0f680163b31a13f904311c77fd910d9f77\" installation_id=\"bb1b8cdeafc1a79da43e21ec3a63276e2a2b12a432b50ae1be1f666da259af3c\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99303992] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99303992 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"74ff633397860cb564954d8cf2546759ae7a73437be191fdb9cc9f864bc828e3\" installation_id=\"32166a09e230b2e0d104c134311a42af9dc5cec160e12a9a5e242d11f2aa261b\"",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 99611494 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99611494] already processed",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd-6Zx8oftr-gAAABhBWmQtNlp4OEFBRG03b2RtNkFjMHJBQUEAAAAkMDE5NzdlZWQtMTU4Zi00NDllLTgxMGMtNDRkOTNiNzE2MmI1AAAxnw",
+    "id": "AwAAAZeJAxydgm-D0gAAABhBWmVKQXh5ZEFBQXh1WlJIblJZLWF3QUEAAAAkMDE5Nzg5MzYtN2M2ZS00ZjdjLTg0MjItZTZhOWI5MGM2ODM3AAGQAw",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -441,226 +548,34 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"318f6b7145ac6f93454bb13f922c2a91009a1d269e995385a0246d04d572e0dc\" installation_id=\"dd4b679f58ecf424b7243118f8ecc206dcdd96b1ee217188e7369ae9b97018fa\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2785e183bbce1c8c20ac0c72af43427ac31b76abb00a283fbebe32fe1759de5f\" installation_id=\"af8d9be967c576313333e627f163adc22866bedc0559287d66ad0a1fed67edf3\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: gang : 0x6461bf53ddb33b525c84bf60d6bb31fa10828474",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd-6SeSrSo-XgAAABhBWmQtNlNlU0FBRDV6Qm1yWHFveklRQUEAAAAkMDE5NzdmMjMtNTA3OC00YmJkLThjNTktNzg4YTY5ZTBhOTViAAHpCA",
-    "type": "log",
-    "environment": "dev",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"51ce0529fd6d2b5cb2e8123aaefe8b79242196a7e0570e091f7943fe1d625c4f\" installation_id=\"cd47e1f93eb18ccf1806a90925be1b4ef47225cbc81fb1ceebdd2c8b9ff15806\"\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd-2R5V9G-KygAAABhBWmQtMlI1VkFBQWJ4UnBWb19mZXF3QUEAAAAkMDE5NzdlZTItMGJkOS00OTQ3LWI3YjQtZWRjNjE1OTE3MzAwAAAxhw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5cca3ba08d806666703f4b886cb8698327f93260feb1a68b148e8d50549431b8\" installation_id=\"7cc44296ec70879b150aeaebf8ddadb1b0689b6b3b4dc146c931592378b0a1e5\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-0JOhEy_vrQAAABhBWmQtMEpPaEFBQTRYRnNQalBIUm5RQUEAAAAkMDE5NzdlZDctZDM0YS00NGJkLWEzNGQtMjMyOTdlYjA4YzBjAAAvnA",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"fb2357aa574c0b8eb9eef3f118f69f19f3fa5f0fa81d004af73a32e15a8fd38f\" installation_id=\"838e010aad683bb8f7d28bf6430589493dadd9b2c5014a7b3dace536c3b9e6c0\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109164910] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109164910 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-0G-X15bHaQAAABhBWmQtMEctWEFBREZqbDdXNzFIVVBRQUEAAAAkMDE5NzdlZDUtNmIxZi00NDQ0LTk4OTItMWRlMGQ5NjYxMWQwAAHzXA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"08f6efc0b48673deaae940f462afa6bdfa1838f519191785e0edd32fb334245b\" installation_id=\"23f3ec59297fb94f8ad725841355bc03a9f696cd9cb2aa3842fa45922d6d7e05\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99303721] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99303721 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-zvuDjOOa8AAAABhBWmQtenZ1REFBQVJ4QXJGZ1JfZ1dBQUEAAAAkMDE5NzdlZDctZDM0YS00NGJkLWEzNGQtMjMyOTdlYjA4YzBjAAAvnQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"04d7bb578a8e2523d14e9d6389a8308661c55f219c116e83c8d31f29ccabbf7d\" installation_id=\"3d20c26ab0d6786a662c03f6d886c664934f282226487987d2d1f7c78529f713\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-zk2U6sd_SAAAABhBWmQtemsyVUFBQ0V1R1lGWGRGTHhBQUEAAAAkMDE5NzdlZDctZDM0YS00NGJkLWEzNGQtMjMyOTdlYjA4YzBjAAAvng",
-    "type": "log",
-    "environment": "production",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b9e4d48945f0545d0b4f65a79e95ddbe86a0fa3882c1182f8c856456a500d2b8\" installation_id=\"eb9c904a1ce649ff83f1bb9e41951835eb64c489fdad4a026d206b6f9d00627e\"\nm_delivery > [elon-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s.\nm_delivery > [fabri-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd-xo6-KBjoWAAAABhBWmQteG82LUFBQUN6UDZqN255Y0ZBQUEAAAAkMDE5NzdlZDUtNmIxZi00NDQ0LTk4OTItMWRlMGQ5NjYxMWQwAAHzXQ",
-    "type": "log",
-    "environment": "production",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ee243870600684e94b3b8fb14a0e6c640b1546adaa4b2ce7ffaa9c08f4a62aa6\" installation_id=\"5cbf52b224a8510b8e95bdf01dfe8733356316412ef1d135e9f8b4c44485d09f\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: Hpke error: Key not found\nm_performance > [grace-210] Stream collection timed out. 10s.\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd-w37nzRu0tAAAABhBWmQtdzM3bkFBQlJZc1NnZzh2ZXdBQUEAAAAkMDE5NzdlY2MtMWE5Ni00ZTFiLTlkMjQtMDAzNTRiYTA0ZGI2AAA0eg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f19ee9c536dcd156c6f8ccd340cec38d844c4f0c04ff1a3ccedd8b76c504f3a3\" installation_id=\"af66a1909e2adee879a1c6c6ce15be52d64031fde156cf53ebb82dc4d81bea3d\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-t14064K0tAAAABhBWmQtdDE0MEFBQlJZc1NnZzdIOUp3QUEAAAAkMDE5NzdlYzAtNTFlNS00MjRiLThhNGUtMWFhZTFiMmQ4ZTA1AAA1Qg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e92031c7ed2ef774198e1fd7be6e823e7f4f82b09fa2430111983aefc7f9e124\" installation_id=\"ba8df9d1a987a31ff989a5ab81783cf70c7f5c512fb7f4e36dfb9d6ecc57aada\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99298148] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99298148 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-t1nJNz6qNgAAABhBWmQtdDFuSkFBQ3Z0OHQ1NzhmLTBBQUEAAAAkMDE5NzdlYzAtNTFlNS00MjRiLThhNGUtMWFhZTFiMmQ4ZTA1AAA1Qw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"3f8ac639e61484f51d49083e2230a47851ecf87c69aaf36fcfa858c83464a060\" installation_id=\"74021a34d2c3bf91abcc076252700f01a774a8b00f5c22ba514f98229a9b2bb5\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109159216 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109159216] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-s9-H93uKswAAABhBWmQtczktSEFBQm9SLXZXOWVlTFFRQUEAAAAkMDE5NzdlYjUtZWRmZC00MTQwLThlMTItZTdjMzUzMTUzODBlAAA39g",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"404018cadc7d6ad73bba1704b9ac2956b74d8a26c77e085a4f8be0d43bf35865\" installation_id=\"c5937a162edd18e91e431ea5c1c34b6ae87b678da24762eb16e305f04d5d3340\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-s0KVDRHTHAAAABhBWmQtczBLVkFBQ3ZUcVJxM196Vjd3QUEAAAAkMDE5NzdlYjUtZWRmZC00MTQwLThlMTItZTdjMzUzMTUzODBlAAA39w",
-    "type": "log",
-    "environment": "dev",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e31c593e22f6aa248174fe8ee473e143104a14591bb875615ac12fe92b4875d0\" installation_id=\"5464738b6695797f34ee943bc7af7d7c8c36517b740a3095380191c8552edb21\"\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd-oaV3nbxROQAAABhBWmQtb2FWM0FBQ1RCRklaVDhGU3lBQUEAAAAkMDE5NzdlZDUtNmIxZi00NDQ0LTk4OTItMWRlMGQ5NjYxMWQwAAHzXg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5794b781b5a8c62511c33d0bc0e7fc00498a84e72a97d204aeeba765145aefe5\" installation_id=\"212f6ba1f4b6c4d06bcacb3b642b9a7064e8da4663e964a233b45507d432db02\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-oUxw7z3MkwAAABhBWmQtb1V4d0FBQU1SMWVyMHB2dWNnQUEAAAAkMDE5NzdlZDUtNmIxZi00NDQ0LTk4OTItMWRlMGQ5NjYxMWQwAAHzXw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b0362bbddc285b53e346f584c97614c55b4373a43cb39cd968bafdb7d9fa41c2\" installation_id=\"2319cd482cf93182a5ba3b320ab9f62e6349834d9b18fdfb439d753c678b997c\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-ltAKb1ycDgAAABhBWmQtbHRBS0FBQ1RqaVlLMkFvdkdBQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrWA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"59e5bc9fdb66b5e583d98e18aff910b83655aaea02f35b1cc5e9df6daec1497b\" installation_id=\"010e2b36f026eb3dca3d56492589f355ad4aab44519985b74e879b7b6d706f27\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99297802] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99297802 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-lsQ3RkzAYAAAABhBWmQtbHNRM0FBQlBIUkhWZXljWGNBQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrWQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"343ba86bcc7cf692cda3c9a568638f27bd0bb825f3ab86cc5100c94f1bb87524\" installation_id=\"a7d3f9ccb403b37df5dbb0a9533bc92e9cc92897a6e9c8f58298286c4fe1e51a\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109137191 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109137191] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-lOAg4hD2IQAAABhBWmQtbE9BZ0FBQks1TDh2RzdfRzhnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrWg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f12b0d428efb31e90555ee919215e49aa4e7d1165605e4a2148fd1f9a54e3f98\" installation_id=\"453aec86253ce52fdb530dd1886ae591d0e3b6e1956622a707b3ab3432efe07b\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-imsXzcN_SAAAABhBWmQtaW1zWEFBQ0V1R1lGWFQ4dXdBQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrWw",
+    "id": "AwAAAZeI8PTL1UTc_gAAABhBWmVJOFBUTEFBRDBubVNVNy1yWVFRQUEAAAAkMDE5Nzg5MDItNGMyMi00NzAzLWJjY2MtZTE5MDRkMDdlZDkxAAFY0w",
     "type": "log",
     "environment": "local",
-    "test": "dms",
+    "test": "suites/functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "south-america",
     "env": "local",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e7aafdebfb1d180ba581da035c70bcfca9b6f7e91ab2d2d669e1671826f9b9d6\" installation_id=\"39dbf2996746a0f52105d4064f35cca50b1008d3ba65df91ff5c0b3556eb0851\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
+    "message": [
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn:receive: xmtp_mls::groups::mls_sync: Message processing errors: [Storage(NotFound(IntentForCommitted(69))), Storage(NotFound(IntentForCommitted(107)))] group_id=\"38252f89c1bb89763a43e64c1feae771\" inbox_id=\"e7f0149ce65570a6c321c02a76eb58206c1dc7d46c4f2e6ab28dba7a6d1c3150\" installation_id=\"eb129ccae5c9caa68866cb8ca90ae34f81f612fb009a83244c91853727dd3d83\"",
+      "send_message:sync_until_last_intent_resolved:sync_until_intent_resolved:sync_with_conn: xmtp_mls::groups::mls_sync: receive error ReceiveErrors([Storage(NotFound(IntentForCommitted(69))), Storage(NotFound(IntentForCommitted(107)))]) error=Receive errors: [Storage(NotFound(IntentForCommitted(69))), Storage(NotFound(IntentForCommitted(107)))]",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive messages using async iterator pattern with streamAllMessages",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream"
+    ]
   },
   {
-    "id": "AwAAAZd-idLqT1Y9rAAAABhBWmQtaWRMcUFBRFdaR0RsOVNxXzRRQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrXA",
+    "id": "AwAAAZeI74qG_FjXIgAAABhBWmVJNzRxR0FBQ3JLUkZHVTN3QjBnQUEAAAAkMDE5Nzg5MDItNGMyMi00NzAzLWJjY2MtZTE5MDRkMDdlZDkxAAFY1A",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -669,70 +584,58 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c5c866415994925ae62d904191e7a162aa8174e11ad18d84afec4be74795d147\" installation_id=\"edcd6bfd865fd6a1bfc4927473184d119bb03857de4965b9e204cad1ab399043\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a6274e2e03b754c27a954e68e3f767c4132e4102be4b50b42e63aa2995b1b106\" installation_id=\"fd59e0f90dd7760fe168a8f6e377bf04cd046a60538d13a70d19eccc470b7f0e\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd-ic4Lq9tn7gAAABhBWmQtaWM0TEFBQThnOHJoOXg1eXhnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrXQ",
+    "id": "AwAAAZeI5fu2TkpHwAAAABhBWmVJNWZ1MkFBRHRjWjVBVFdWU213QUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7rg",
+    "type": "log",
+    "environment": "production",
+    "test": "functional",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8e45601a9e643a92a1dfe586133a2d36b21f2f2229572f1bcc6ff799bed8fa58\" installation_id=\"ea09ef7795403fbbf7569f1fa6678c79b81ccddd95b18edcab954d7f02b40d78\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: group with welcome id 110157178 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110157195] already processed"
+    ]
+  },
+  {
+    "id": "AwAAAZeI5LsFEkU37wAAABhBWmVJNUxzRkFBQ01QcXhKM0gydm93QUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7rw",
     "type": "log",
     "environment": "local",
-    "test": "dms",
+    "test": "suites/functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "south-america",
     "env": "local",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"86fa3dfb0f3d6f86a66092e9060bd669a8e75c0a538eb0f92cdd94c416e28b06\" installation_id=\"744bcfac04087e571fc9fe52367156fa38ba2056b4c9290d019c828f21ea1001\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2c4a2a54256f356c8ac5895cbb0c74b6bb5adce1850c12a40c7d54ac0a576963\" installation_id=\"529fd4e6271ce08dbf0dc8be7dd7d70ca5ad46ea904031d66be9c4bd3e5d0cb6\"",
+      "playwright > [bob-210] conversation stream error: Error: group with welcome id 402188 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [402188] already processed",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "DEVICE SYNC: xmtp_mls::groups::device_sync::worker: Sync worker error: storage error: UNIQUE constraint failed: processed_device_sync_messages.message_id inbox_id=\"00d7204146e14a7d563d42cd10fb0b4702b8e1e622f1ece1a4e9a1a58d542092\" installation_id=\"61a347b1b84a291831e5711739c3e15b79f749f64c4df99b1fae44698376111f\"",
+      "DEVICE SYNC: xmtp_mls::groups::device_sync::worker: Message processing: Archive(Reqwest(reqwest::Error { kind: Request, url: \"http://localhost:5558/upload\", source: hyper_util::client::legacy::Error(Connect, ConnectError(\"tcp connect error\", Os { code: 61, kind: ConnectionRefused, message: \"Connection refused\" })) }))",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: storage error: UNIQUE constraint failed: consent_records.entity_type, consent_records.entity",
+      "DEVICE SYNC: xmtp_mls::groups::device_sync::worker: Message processing: Storage(Connection(Database(DatabaseError(Unknown, \"database is locked\"))))",
+      "DEVICE SYNC: xmtp_mls::groups::device_sync::worker: Sync worker error: storage error: database is locked inbox_id=\"ada2bd0b226979338ed530fd3637ea6cafd1e34acb9cba05a2aa0fb48730eb25\" installation_id=\"527c187eece43a24ffcac92b8d5d82f9b79001970408472c5538e3e27d48fed1\"",
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream",
+      "FAIL  suites/functional/playwright.test.ts > playwright > should stream real-time group updates when members are added using async iterator pattern"
+    ]
   },
   {
-    "id": "AwAAAZd-iX3JMMaVQAAAABhBWmQtaVgzSkFBQkhpTUdBT1llWmFBQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrXg",
-    "type": "log",
-    "environment": "local",
-    "test": "dms",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "local",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"75429fd1af503f8294eee6671b2c0095e8cfaedf63659c9363d94259667bc8e7\" installation_id=\"be0cb1505563f7d54a2e090eae5d139e74eb4c3e54c63daa085c038d0e0a7b9e\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
-  },
-  {
-    "id": "AwAAAZd-iTce_l8KswAAABhBWmQtaVRjZUFBRHJqajNDeG9kWGxRQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrXw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"bc3ddf1898e0f5aae1c5b148726be239d2808493d31c0ba09c4103c873d01d76\" installation_id=\"6852f1ed9ad769b93fd1d97244e35a7969377c2c9c8fb9c9742b4e8605832897\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-iNqU5S4CxgAAABhBWmQtaU5xVUFBQ044YkI5VFh1NE5BQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrYA",
-    "type": "log",
-    "environment": "local",
-    "test": "dms",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "local",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"179961f10bbca9174872eb603bd8b77bf6e7fe2fe3b3d78fbb07af0c65597181\" installation_id=\"f74f84fdf5ecd2d8aaedaf3c04b6654c4d6dae887caec57062962aa9136bc5ec\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
-  },
-  {
-    "id": "AwAAAZd-h-nGsuuVQAAAABhBWmQtaC1uR0FBQkhpTUdBT1lRYmpRQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrYQ",
-    "type": "log",
-    "environment": "local",
-    "test": "dms",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "local",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e88be57047bfe2b77160f047c0de225144534348c1ef07c3d84f5354d5982fe7\" installation_id=\"bb7b0564ed0140eb949d8a52e7ef56c9764ef9643d7af7ccb36b782502888775\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
-  },
-  {
-    "id": "AwAAAZd-f-pXyOVWTQAAABhBWmQtZi1wWEFBQllpc210TkIxTUt3QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrYg",
+    "id": "AwAAAZeI4rCjxveBcwAAABhBWmVJNHJDakFBQURKSE1laHlNblVRQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7sA",
     "type": "log",
     "environment": "dev",
     "test": "browser",
@@ -741,10 +644,15 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"fce3c89391e7d785bf2d925c2cb7d78ee5791e53659a2b7641a4872b4c5fc46b\" installation_id=\"d3ce4a7546310aab55585385821428bfdd17c3d636b113a0c702f48f7fc432e6\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99292223 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99292223] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4880709d96fdaa2c3962e0343674afba3e3f3f0cb52e08ecbeadc2e6aa524d0c\" installation_id=\"2a28059f496f79b03222f92512b6be0ed66fd88a745baada141f0beded28da0e\"",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 99611264 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99611264] already processed",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd-f-QiIZQznQAAABhBWmQtZi1RaUFBRGlfMkZxdWJuanlnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrYw",
+    "id": "AwAAAZeI4rAlsgbIBgAAABhBWmVJNHJBbEFBQy0wMmM1N3RIcGZRQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7sQ",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -753,10 +661,41 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e337d3ed5a1cda4160399f3b9c6edceb82b5adb2590915b1ec35da65c90e39a6\" installation_id=\"e614c2ca22d63863858c1d11758fffaf8fddefcec7f1d34036a82b067162b74f\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109131501] already processed"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"0f7aa508cd6bfe1929d0a52de8745a6856459aaa7ffeb3e42f72e32ed5559b8c\" installation_id=\"9ff2550db0892cddde98d049bf45295963d3d8daa92c82edbcc65e7c5aebef35\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110157121] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110157121 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd-fPZ83YzHaQAAABhBWmQtZlBaOEFBREZqbDdXNzUzYU13QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrZA",
+    "id": "AwAAAZeI4gZf7QJHwAAAABhBWmVJNGdaZkFBRHRjWjVBVFZ6eFV3QUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7sg",
+    "type": "log",
+    "environment": "production",
+    "test": "functional",
+    "level": "error",
+    "service": "xmtp-qa-tools",
+    "region": "us-east",
+    "env": "production",
+    "libxmtp": "latest",
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2a6c6160aacd7b0542eb23e053d3437e5c90b623602bd11f8dd0d1333aff8da5\" installation_id=\"c5aec1d86422bd87a4de3efa0c1497827a1633306b409259769e8ab374635a41\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110156576] already processed",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "streams > [elon-210] conversation stream error: Error: group with welcome id 110156577 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: storage error: UNIQUE constraint failed: consent_records.entity_type, consent_records.entity",
+      ", last_stream_id: StreamId(0) }",
+      ", Library)",
+      "CORE sqlcipher_page_cipher: hmac check failed for pgno=149",
+      "CORE sqlite3Codec: error decrypting page 149 data: 1",
+      "CORE sqlcipher_codec_ctx_set_error 1",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream",
+      "FAIL  suites/functional/playwright.test.ts > playwright > should stream real-time group updates when members are added using async iterator pattern"
+    ]
+  },
+  {
+    "id": "AwAAAZeI4dhVTN2HHwAAABhBWmVJNGRoVkFBQ0ZXNjBqenpzWEhnQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7sw",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -765,1078 +704,55 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"68f419d18124b1cd5f4035533baabcc208e55b123229e62bb1307ee008c8e72d\" installation_id=\"7611b8e3fe2cbccdec3b16e3df27cbb18c9d0dd35214d46b30f6107dced145cd\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e1e52005e5634100ede924eba0b08c229fbd849de561484481252f367b99eeea\" installation_id=\"2b61b2b0eef1890deb49c1fae087c8c262c40e132ee8d249feeed5048a824293\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd-fFzce8JdUQAAABhBWmQtZkZ6Y0FBRG42djl3SWpLV1FnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrZQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"39a22716d5c4c0b073728bb267d1509dd800766b8f3ffbced270baf0e2491436\" installation_id=\"a054e257ba1c767c86cb2b3bc6d8c44a4407e39eee1d06c09217b0c03d263325\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-e_sZRQUYmwAAABhBWmQtZV9zWkFBQUFkX0lFVXBPY2xnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrZg",
+    "id": "AwAAAZeI3l0DcgSZZQAAABhBWmVJM2wwREFBQVd1T2xvT2ZSY1lBQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7tQ",
     "type": "log",
     "environment": "production",
-    "test": "delivery",
+    "test": "functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b12d9f3dc4bed01ccb1fdd1b029db18356f52700526809e1e3f3e8d2fb61b3af\" installation_id=\"a8b745b4104f1099194831fbc9a3af30cf50b8ae69fa813f1c4be98050cb5537\"\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s."
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"057da8ed144b9672710212ca86c4c312a94ca582d37f3612c3693593f3a308ca\" installation_id=\"1bb9f57f15c704cfc97a8842b8b4ef001802dd1e4c9a130d877f0ff36e8e1995\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110155919] already processed",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: group with welcome id 110155938 not found",
+      "DEVICE SYNC: xmtp_mls::groups::device_sync::worker: Sync worker error: storage error: UNIQUE constraint failed: processed_device_sync_messages.message_id inbox_id=\"7ca65dbe043578c81579704532b5ab5f35c15c969d3ca7b1587e7fe2cd39c8bf\" installation_id=\"1ba8f9d71b9f9a482f3495fe0296a70b332cf207198e0b77686af869cac5110f\""
+    ]
   },
   {
-    "id": "AwAAAZd-asBxR1Tc_QAAABhBWmQtYXNCeEFBQk5BeWJGSzVJVFh3QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrZw",
+    "id": "AwAAAZeI22gAY-gvzwAAABhBWmVJMjJnQUFBQXF3Q013MjU2RXh3QUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7tg",
     "type": "log",
     "environment": "production",
-    "test": "agents",
+    "test": "functional",
     "level": "error",
     "service": "xmtp-qa-tools",
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4284a74a040446dc16de6444663438057e70746aaa44e13e8241891eb521b536\" installation_id=\"96fbea2101c0ade58f9525d2503231bc972df267667877cdb0786ff21ec58591\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-alsGdfqDOgAAABhBWmQtYWxzR0FBQ2pyWmZHR3p3aXJ3QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMraA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c442b7dfdcef8112da6672f4d0d65107b888d128b90667400048e0d36733f68f\" installation_id=\"29bc9d6eeffed1241451bab114cb4efc3e076f21ccecf7851e74fde1d5f4d7bc\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-YMl6hR7XFgAAABhBWmQtWU1sNkFBREI2ODVXZTZJQk13QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMraQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"0304a3c1b5b7a417f5b6333660bbb97f65ee86aa8e36b6d4b74ce2456b2d7320\" installation_id=\"4c76f708eba708991eb5c8eda02f04bdcd7f9d22fcb150575d8e371496c368c2\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109131095] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109131095 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-YK_ggck0HQAAABhBWmQtWUtfZ0FBQjZQMjk3SlZmdlFnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrag",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"df59d17d9d84930d067b76b1d97b0e2ad2843af13d74667463daa10b15c9a347\" installation_id=\"a6ada6dec7e35bc2e301b9fb668951c965ff436e79f913f5e339020325e261e9\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99292004 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99292004] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-XyULEDIznQAAABhBWmQtWHlVTEFBRGlfMkZxdVhIU2FBQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMraw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a553e00595c1bdfbc32fb0493dae40bf3d46bdb454a77532c00510ddd16e5d0f\" installation_id=\"4a9bc24239b9683fbe0f461e1c60730adf9f130c76d5b097ca2b407b58dc2b21\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-XtpVSwLMkwAAABhBWmQtWHRwVkFBQU1SMWVyMGdwS053QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrbA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a768db278272a4a4c24249d17872bf37d0ec2dfed5a3e13229f10cc3b26c3c9f\" installation_id=\"3de9321ad8d057c6457fd1ed0e1bf6909fa597e6737b29b8430e9de211c80cc6\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-XnERNFwgGQAAABhBWmQtWG5FUkFBQkNHX2JzeENWZ1RRQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrbQ",
-    "type": "log",
-    "environment": "production",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"23aba4873017a62b6764afa9814444ce1a28ef11d900978f345a7ec5cb4ebda4\" installation_id=\"009c0ce41d08aae99dbeb826895a406594540bd55379118d16de66572b9bf994\"\nm_delivery > [bob-210] Stream collection timed out. 10s.\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [alice-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd-U8ngsBBROQAAABhBWmQtVThuZ0FBQ1RCRklaVHhabEhBQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrbg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8117ceaab3e4f2f17242f1962cf05e9ca3f6618618a406af88e36aa4a4d9025c\" installation_id=\"e352388cd6d12ddba39b8307e79b96dcadc32e29577d21ffb20bbd96a8404b53\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-U2LAr-VO8wAAABhBWmQtVTJMQUFBQVlRNjE3N3liS1h3QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrbw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"93525e998e15412419e4171886fd0f46a2f2c58113759e75ea591f33f9873543\" installation_id=\"0dadd3a57b69090cb226e82415e50b177d69b7b98306c5dea0cbdd1de8fea30f\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-SHfpmDauMAAAABhBWmQtU0hmcEFBQUJBQzMwdnJmVjhRQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlrw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d4d8e16486988df284714cc6161c83e74b049b436419992337a6e07a70fc9bd8\" installation_id=\"a9e159e2bd22d401ae1e833c54aa4abe2a1c8abbd6873ec4bc07434b618c7115\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109125218] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109125218 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-SG73CWCgWAAAABhBWmQtU0c3M0FBQzllX2s4Z1pTam9RQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlsA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"423b81ff48bd07c245ffeb5c5ff49808fd0c632c007dfb6e12b1d717a61482d2\" installation_id=\"1913b38315e10f513d40dcbf22a59ac79e479e4d723f5c2cb8f346539a1f2259\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99286489] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99286489 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-Ra-S3e97oAAAABhBWmQtUmEtU0FBQXFGckRXSy1sdnVBQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlsQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"697b2619867f638544009f64f5aab01bafce0222cac7453032d17c4323afb202\" installation_id=\"0e1a148883512be16ccd4a9b7126aab8c44aa3bd60ee9d119f27c8db50fa2a7e\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from bankr.base.eth agent (0x7f1c0d2955f873fc91f1728c19b2ed7be7a9684d) when sending \"hey there how are you?\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-RRgksG1dUQAAABhBWmQtUlJna0FBRG42djl3SXJqSzdRQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlsg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"43f38eac06a13d20706dfc91474b237bb284925f6bd7bcfdb01052b49c17474f\" installation_id=\"5a71b61bc3362b658e8c371c1b85dc3eff8791a64540220288f58b6b72ae181d\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-M8e5f4ZGDAAAABhBWmQtTThlNUFBRHAteExDcTMwVVFRQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlsw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"feca34cce0af997310c15068b1ff3ef3c91bbe9cb1c80362e06313274554cab9\" installation_id=\"b0b6b39d4bc9df36f532c89eeb634bbbebef4e92ed3fa954539f133f631254f4\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-M2UALw6mfgAAABhBWmQtTTJVQUFBQjdrSUN4Qzd0ZzlRQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrcA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ed7ad4a694463cb61afe10e6773a5beac64f414062c387f1e3cf58afa26b8257\" installation_id=\"fbda43dc6a29a3e693028b1a108e8b8bad823ff65ce1336f8eb59fa9a294723d\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-KjLLEZOryAAAABhBWmQtS2pMTEFBQV9EUGR4RFRrbERnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrcQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"eccbd8ced540671c8f89fa4ee71e47116fa8b0b9199a7b4332e78bef0baa85f6\" installation_id=\"748455e64d5197a7d48fad17d3d753fb259cd523bbb1422bb622c3a876dde526\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109103722] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109103722 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-Kiwi9Ms_4QAAABhBWmQtS2l3aUFBQUEtLUJ1R3o2ZkxRQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrcg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"1c6cb9edab2b004ae05ec80eba024fc4be3fc39bf764972901da9b6bd9e5f0bb\" installation_id=\"2e6e9acc6b399861efa11bb7957e306c2c4d33c6c928c7d1f1314f52b5b2f045\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99286273] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99286273 not found"
-  },
-  {
-    "id": "AwAAAZd-KWO27cagWAAAABhBWmQtS1dPMkFBQzllX2s4Z1UtSUJ3QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrcw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"84e9723fdd63de09b9e985a77a6ab9b985f4a0178c081787674973e950515924\" installation_id=\"c4ebc7b9865b35cf80c67c0a555f19f7634426faf00a1d022c74880d1811fa1d\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-KOvSx-H6uwAAABhBWmQtS092U0FBQ2lSY1MwLVhLd0lnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrdA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"18b83066cc165cb2ef9df275ee84729eb312684647408218b795abb54f7f331d\" installation_id=\"1b40c60a8a048756f1addbcbf404364e65f4e0ffe3a21d62621cc823083c55f9\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-H_sZ3aemfgAAABhBWmQtSF9zWkFBQjdrSUN4QzVBUGpnQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASltA",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e39f8633e2d378fa2a92bf3064b71b698ea287bee340f974f7188eaec745184c\" installation_id=\"4901ca2cf51171cdfcbc23540104eede2672d2ab1fe5ee30c9ee05522c4fed85\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from bankr.base.eth agent (0x7f1c0d2955f873fc91f1728c19b2ed7be7a9684d) when sending \"hey there how are you?\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-H1_q4g2utAAAABhBWmQtSDFfcUFBQzk1ZWxtVjhLdWxnQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASltQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2042c7f4b97dd07e14a04b47dab2f709232fd2dec02d9c8bdf9efaddb7029c1d\" installation_id=\"5e38e14c0808864542f970e93738ab2e27cf2d8f64d9f1e417d41113fc0338c1\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd-E-6kK6FwGQAAABhBWmQtRS02a0FBRDVjbUpHNzdZZkd3QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrdQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f3fbd359a2fd7fe42edb23d76eead81e1a94dc52e717c211b4b2dcf417ab769c\" installation_id=\"30aa665b694b78b369f42bd1d634e1c44672d6ebcf8a2f76388ca00ed5415e09\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99280730 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99280730] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-E9dMUyRJTgAAABhBWmQtRTlkTUFBQ19Ua3VqVG84Y0FnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrdg",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"022780ecda4a40351edcd877fb2163dc1bc15db6834701ef9c9f74e1f96e8cfa\" installation_id=\"d93fdde32cb20ad8fb32aa8ff362737d5af03c82fe4548acf6e7627be3e9c995\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109098045] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109098045 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd-EYYTY2xBwgAAABhBWmQtRVlZVEFBQmt5SHFta1plblZnQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMrdw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"12a1c5d93a095e51d636340091b60d670147d0e4eac6b1cea2b980aa97fa792f\" installation_id=\"c682a3867203271101ca7eb0c8e7198d587a7e9f218356e4140b3dccf92682dc\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd-EOLJDTln7gAAABhBWmQtRU9MSkFBQThnOHJoOXhMVUpBQUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMreA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8a3024b121b0c759add3688fd1e6a54a75ff2decaff86876fdb56f13a30220eb\" installation_id=\"005d0ea0cec19acd133e27478ac28a58bcb922bb18c8f156ade5bb3f4ff951ba\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9_aXVQJSKswAAABhBWmQ5X2FYVkFBQm9SLXZXOVZYVVdnQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASltg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"dbfd902d18c990605d28331a8254ba8ca03c28256a2ca92048cc2a8755c7646e\" installation_id=\"19d302cf38a76966ccee67818a6af0fb36e29a93bb871abcd7f59ca026f26a29\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9_SmlEobfAAAAABhBWmQ5X1NtbEFBQmo1LTFjRGFiMUFnQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASltw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"cc03b5109ad79f18231b823d21ddb0d8239317e91a6891569c746160f9761418\" installation_id=\"9b22dbddcee4624b6dcaeafe41486d8f3ef0713919b81dd2f3ad5791d62f611e\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9_J4glA-uMAAAABhBWmQ5X0o0Z0FBQUJBQzMwdmc3UnlnQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASluA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8d3f5b7d432a929f5f0e57170b707dc7ee4da6fce23d3a9843dafd69f44a5796\" installation_id=\"0a0f304b76b23b9c83ebc50031b87bf7217e8cdc034685376febfe4732603d6e\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99280521] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99280521 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9_JKAf_0dYQAAABhBWmQ5X0pLQUFBQi16MDFHblNjTnp3QUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASluQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a45a1a1ef939b0b20f0713e8710359a32dc10b7de399d662102b281193488742\" installation_id=\"eb4d752b1cb68c3d1e4c63b3e679284dd4b36ad0e2e805222e4a8a1a1137c9e7\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109097557] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109097557 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd97F8nZ0SuMAAAABhBWmQ5N0Y4bkFBQUJBQzMwdnVxa193QUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlug",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"9aab25c148a4d1ea326f307872a03a4ad12d408af10ac864c74df83be89cc192\" installation_id=\"72b3111f89ffe20e20971e353912b755ad977353c899cccf7951e498dc1e4bf9\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd969yX8WOs9wAAABhBWmQ5Njl5WEFBQUpyOVQyWkVzQnNBQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASluw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4a242dc01c66fa9f3932e1205c7d9563badcf752122eed92e529f216535f31b6\" installation_id=\"63d0b8fdf12380d733c05e6ac559c27bdf180f088e4f76f928851b8f04d8a841\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd93PdaEmsiiwAAABhBWmQ5M1BkYUFBQ0FESEZjaFI5MXBBQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlvA",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d1c6454c817168d6cd3e9a194451e32c75ab2a6edb4126bce30f0ba20284680c\" installation_id=\"b2ec663de63c157486a34c3034797e3a533e0229746e54d6e8782362655e076b\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109091880] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109091880 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd93LwDcRKVQAAAABhBWmQ5M0x3REFBQkhpTUdBT1FqWnRBQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlvQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"388795f78538ff682eca93d2f1b49e41cf44d035469e1008fba396da344800e7\" installation_id=\"e18d6d75fba5c8b79f5a8be68bb1ed1b6f5f9508cd7ddcdabbd664d3f595f9c7\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99275090 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99275090] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd92YI0X8CVQAAAABhBWmQ5MllJMEFBQkhpTUdBT1FISVlnQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlvg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"bc1dcf9575b354b6e375725dd71022c2e53fb6ded5e171eabee8a460baa5902b\" installation_id=\"d1226a944b71c72de25832fb56e8010855cd04f24e4ce005147a2a3d305be423\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd92SHoSq8L5QAAABhBWmQ5MlNIb0FBQzJBTlVvU29kbzZRQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlvw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"15220627e0340348be02676fda5d1f720d4b5b5d183624384888d62a08f88f78\" installation_id=\"bce51d51935b8e295ce67ecf5c0c564ba8921c2498342e5e2dd022e9ee564d36\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9xqjGA0_kXwAAABhBWmQ5eHFqR0FBQnpPVzIxcVJnSGl3QUEAAAAkMDE5NzdlOWUtNjdmOS00ODkyLWEwYmYtZmQ2NGY3ZGVlMzA2AAMreQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"afd59af6b92bf4214e3449550ec9a78d4684b202de4642794ae86183c8b8d166\" installation_id=\"5f2abfa869eeb07cffceb7a54c53355ed4c8cf0427d66f1ac258a2b5969b3a82\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9xibnv2mdHwAAABhBWmQ5eGlibkFBQVVqdF9PMlA5LXdBQUEAAAAkMDE5NzdlNTUtYTJjNC00MWY5LWFhMDUtOTExZjNlMjU2YWU4AASlwA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"698eaa1c000ae6157f8a4a42fd7fd9e8b1bdfdfec11b9db8de25234b1bcba91e\" installation_id=\"f070d12724fccf464c5fb8c93cbd15d86d51a6e00a35e19d5149b90f554d1103\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9ucNVTmBp3wAAABhBWmQ5dWNOVkFBRFV5eUktLWRlZVF3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrtA",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8d05e6dcd07c832d492fa4f06af9932e10fe8954f67039e86797c0324b2779d1\" installation_id=\"a63d946a617fa0c0cb367ac8ebbe1b2f368fbd3211e48715b492b8968d41211c\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109070533 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109070533] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9ubTksS-dHwAAABhBWmQ5dWJUa0FBQVVqdF9PMk9Sd2hnQUEAAAAkMDE5NzdkYzItYWRhZC00OGRlLWI0YjgtYTg5OGNkMDM0NjE5AAIMEQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"38d69a98a025b6020d5e6e8c2d07559b346306897aff00ed759640e240cdefe5\" installation_id=\"363af151f95de1fe68f7620ff0cd694fc2ce7a23d0566c1738a0a907e56092e9\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99274872] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99274872 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9t7POdf0yBwAAABhBWmQ5dDdQT0FBQ2lfVU1vU193bzBRQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrtQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"3fbcdf47006fada3373fc8f498185af0e2aca3c88ae1c68e166441dbfb204696\" installation_id=\"e01527a8f2d21ad8962bf511cfefe26897c1cfc90cee48e8950874e675b851a4\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9tzyN5wAbswAAABhBWmQ5dHp5TkFBQ29RSlNLdGJBS3R3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrtg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"23bbfc32d48cc7910c30d2d3c9a612306edada390938e585837e975b470d8759\" installation_id=\"eabbb8f00c07424b71c4db87fc61c084ce3ff3d05aa867e17865fdd4441984d8\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9tp_CX4Q6ZwAAABhBWmQ5dHBfQ0FBQlJfbnNlRjVpMXJBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrtw",
-    "type": "log",
-    "environment": "dev",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"3e4b0370eb7f8543308d5674025188970768204b94b19b8ccbbcdd5c45e7106b\" installation_id=\"d9e36c0cdabb51e91b57a5752cd51176594be5b792fa6d9e6664abc2d7454638\"\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd9rjK7IyPyawAAABhBWmQ5cmpLN0FBRDRXOHJaTHI4NWh3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWruA",
-    "type": "log",
-    "environment": "production",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"1d5596d23d4730961bbcff373bd87a472d544d710c567f4ea4320b0e00b58f82\" installation_id=\"e30548d712d4346b00162c1ddf4f77085d7048fee8963fa5fecee04eda815b2b\"\nm_performance > [fabri-210] Stream collection timed out. 10s.\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd9q0GL0axYGQAAABhBWmQ5cTBHTEFBQ3F0Q3pwVWZvd2h3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWruQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8876449fe9c10bf4067ed83c708afb9335d4b9418bf111e374290fff7a30cfa7\" installation_id=\"55cfcbe628f2ea0494b39f1e6a0c7693ce6e613b4f8e74f03b60462d6632271a\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from bankr.base.eth agent (0x7f1c0d2955f873fc91f1728c19b2ed7be7a9684d) when sending \"hey there how are you?\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9qp8Hd-mUMAAAABhBWmQ5cXA4SEFBQlRzMy05QVhyYU5nQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrug",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f11964a2f267c6235f5c5bb01050d9a99102c897fdf756feb68dde5f424afbc1\" installation_id=\"4e4121180ea610f69c599a2ff361b4a1dd3da26befad41058b0794876aa89863\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9orjh1J_msgAAABhBWmQ5b3JqaEFBQ0doRXlEQURkRHJBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWruw",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"49e7a04a966a50f66734328046d8e8322a0e21547fa21d5a6a668fb3c1806ce2\" installation_id=\"236b0d875bb31f00005e8baf62a52bbb8e676ab2abbc2d5e17a1fe376a30e01e\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99269391] already processed"
-  },
-  {
-    "id": "AwAAAZd9orPaYcSMCwAAABhBWmQ5b3JQYUFBQmdPcG95TVYwSll3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrvA",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f628f9fab8be3247c3c2292a516f7b787808ca83599c837bd2581e421aca9c63\" installation_id=\"c3fa1a08a6932de30b91494bbf22dc0927d89e1c7ac48b22d3899efcf186b9a1\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109064936] already processed"
-  },
-  {
-    "id": "AwAAAZd9oA6NgxkbswAAABhBWmQ5b0E2TkFBQ29RSlNLdFgtbTBBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrvQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"9ea6f53d9eae639bc5c5142c062153c1a6f397d3347eb7ea1a5998b0f751a301\" installation_id=\"e582b21e9e77bf0bf3f402f56051ce43b648a61ef26b3cedff2baccde24cc1e2\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9n5ZDXfgWqwAAABhBWmQ5bjVaREFBQTZ6WGM3b3RXN0h3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrvg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a78c3d7a74bd6c747faa3163d2cf4a6644ef197a7917ecacf602888ddc5271de\" installation_id=\"ab78ecd1f4163284885bd875233dd593c418b50ea3b45bbcead5dfc8491c6157\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9jsSjTHRwGQAAABhBWmQ5anNTakFBRDVjbUpHNzVZXzdnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrvw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"85729c3aa26fe327455461e7c1291173e6f976d5276f20928bf534859e46931f\" installation_id=\"a2115ad943cd39e4b89bb60a73c40a3ef83b822f5c1ae59fe79b848187dab177\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9jkqRLw0FcgAAABhBWmQ5amtxUkFBQTBjaE9XZ2dBeW9RQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrwA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"efbf6c7d8d18b3721df74bcae13df7f7b75397b49dde2546a029922aa149d93f\" installation_id=\"046496b31a162295d165503200598b6ee7e556efec028e26c26a7de4f77d59dd\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9hObxBx8wpgAAABhBWmQ5aE9ieEFBQkMwbndrQ2RXNmV3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrwQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"58d9c21a6d5e9e2b77cb6f6dcfe88b4db619592997c74fbaaa998fd11caf26a6\" installation_id=\"8ad61e83ddc119b329925e7085b59e83a31d66aeed6dc8535e6235529cda3a3b\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109064567] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109064567 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9hN65jSW0tAAAABhBWmQ5aE42NUFBQlJZc1NnZ3hlZXlnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrwg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"78025740dce9f6d0a0ae0e16c85119fba90f34437e366605e32e90df950d6c97\" installation_id=\"25226fee08485389166bf1dad344db7c1916b4b19060f3846efa0ec9980937c2\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99269179] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99269179 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9gzrAWXmC3gAAABhBWmQ5Z3pyQUFBQVlFYUgyWDNFN2lRQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrww",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4c3382fce7d1ce4e81709084c02850f4f7cc0eec26d733be46dd29b82f9cfe23\" installation_id=\"e06e5c282dc6f8e3f10fe22b39b5043d34dc07c84b4635c55bb2da4ed610919c\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9gwDw1duJVwAAABhBWmQ5Z3dEd0FBQXoyekthd1dhdHJRQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrxA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"720dadd34b6e2080d51bd2ddd0f2536e1a0b98221790dcc7657aeca44b4453ea\" installation_id=\"cf8bc1a46473675d727a0ba95fdad6ad6a2b1e859b46124787fef3ee1d428cf1\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9e8eSBbQ4vwAAABhBWmQ5ZThlU0FBRG9QcURzUDI2SFlBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrxQ",
-    "type": "log",
-    "environment": "production",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"aeae7a8a35f69997b8335af62875ed74637afccb27d42b9e49bd683372c4adaa\" installation_id=\"21b2d947a1fcdbd935a4b3b43de3ca1343f17418cac0af38c05f0ce0cbe36b93\"\nm_performance > [charlie-210] Stream collection timed out. 10s.\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd9eDxE6tYukwAAABhBWmQ5ZUR4RUFBQ2tRdG02SnhLZVl3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrxg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"71918cc6e2cfa0a1ac56d3a79945e238d58f40e0476086e962b2f6dab2f39a6b\" installation_id=\"e76bc72213fd6b4cbf5aff88b2d333802de2c00815fe9166f07bc9b282864d72\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9bRsWUi_UlwAAABhBWmQ5YlJzV0FBQ2QzN1BIT1publd3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrxw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c2a3285b6e3736d266ee9f7d3cb377ad3764a590c89e2e3faea72d5b48081704\" installation_id=\"8d4b579f3ea193a3977a54c066dbe8037240b4f68f9a31bb55df6852b200ab7f\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109059002] already processed"
-  },
-  {
-    "id": "AwAAAZd9bPmm77G1EQAAABhBWmQ5YlBtbUFBRGpJSjhmTnhKd0xnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWryA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c63f89123db3a1287db8bbae1dd02a9fad7bae7808cedc773102c44a0451b63f\" installation_id=\"e32313f4021461e5292ccc94c4549851cd07c29ee5d3b894d6de9ff16ddf099b\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99263713] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99263713 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9agGGBju-tQAAABhBWmQ5YWdHR0FBQ0pWTEVRWmhuMmdnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWryQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e188957159e1b17d909d1bc4de5eeb6ea2257224cb3779036c42331fcf85cf19\" installation_id=\"89d4710b9629e1aa95b19a468a176797a89e224c8525190ce8895649b9fc19b5\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9aZxdHliT3wAAABhBWmQ5YVp4ZEFBRDN3bkpZaWVNTk53QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWryg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8f3981224ddf039eb7dc8df57ca1c7dd8409641af55bca1ae0c971c1ce26047c\" installation_id=\"6ef5399753a5255acac09d6df07cfcbe7c01949e98fd735c578ce3e135cfb3be\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9aYB0lU8_4QAAABhBWmQ5YVlCMEFBQUEtLUJ1RzZVX3NRQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWryw",
-    "type": "log",
-    "environment": "production",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"3fd926b1e6d822cbb7eb60ee56f7a1926cc4a160d8ba66aa3290ab1d00e0a46f\" installation_id=\"447b5a713f74a73972169c3a22d51aae31f37ce5a3d764679d17ea22b0d8cb89\"\nm_delivery > [bob-210] Stream collection timed out. 10s.\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd9aXmrTnJAbgAAABhBWmQ5YVhtckFBRDNKdUFGSFZzRkJnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrzA",
-    "type": "log",
-    "environment": "dev",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"daf4d2211304a1733de2057ca8a512af834d7b15f3b702e78b52ab3073678490\" installation_id=\"a4770fc0212737d834c9af1eece796c5932f20a9da5299bf24664ce0ad1d60cf\"\nm_delivery > [bob-210] Stream collection timed out. 10s.\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [alice-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd9WFsrEH1_SAAAABhBWmQ5V0ZzckFBQ0V1R1lGWGJCeGVnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrzQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ad26fd1547bc48a6069fc651343b10494bfa63f9982090815aec521bafce11a2\" installation_id=\"8fcc0b5c74581324332121928775a3ba36c1ac3a65b7379024451411d88580e4\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9TWcMkois9wAAABhBWmQ5VFdjTUFBQUpyOVQyWkFlaTFRQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrzg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2129ca6a4920172e917d87c6ef53c10675177455e9ba24e12803380eb68bcc57\" installation_id=\"5475bf1ca3870cb3998035107bf3fa903f2dba98e0816df32629f3fb8103b728\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99263497] already processed"
-  },
-  {
-    "id": "AwAAAZd9TU4LPmCE8AAAABhBWmQ5VFU0TEFBRHB5OWNUa2U4eUN3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWrzw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f3ff8c5c7866a19bfe43ca934cb1759b04abee16839a33bc1b4c0cc1f9ef8043\" installation_id=\"3071dad04f565a69ca6ba3517e579f8f4ef1e9ab7869adf0675d8dd3591f35f7\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109037046] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109037046 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9S2ht6VDj8gAAABhBWmQ5UzJodEFBQnItVzdlUzByQlR3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr0A",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"09311ca04e62aedf876a045fdf855daa52edfad50442c9c03eb2094913162888\" installation_id=\"55a2a74896eaafe31bb2298c74aa86cc39e3e37e722b0299cd9f9d368ae79bea\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9SwPW5UNJTgAAABhBWmQ5U3dQV0FBQ19Ua3VqVHU2dUlRQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr0Q",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"034572e848008a31f9f369ce540234fa6d4c42df04aa680b0711af25ae492392\" installation_id=\"b89afe16c1d719506988aad4fb9f8a5769dbbb597ec9126630761b2a57710ee8\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9P6h0leg_7wAAABhBWmQ5UDZoMEFBQUZJQzd4NFZDb0tRQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr0g",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"fd40e083a3b3b5d6a9a45c9ff9476a09117462a04ce602959d315bac10520ee3\" installation_id=\"fc8811578ea4cfb6b1c04bfbbcb147afd9f275fd89738bf4ebe0f684ad19d2d1\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9Njd2HcORAAAAABhBWmQ5TmpkMkFBQ21OSjNZZGNZMXpBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr0w",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4db07f357b0e867f2c7e41f360c3cf19c94acd1d0ef91d1945745b83ebeb8a1e\" installation_id=\"4b49c80aa2b7383187ddd60b54df296883f3de7341c5798f2e02b9714d9c5b6f\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99258055] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99258055 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9Nh0WxI0yBwAAABhBWmQ5TmgwV0FBQ1F0YmVOMUQzRkJBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr1A",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"66d3aa1dff3bda293e5955fcabc28cefe121079e58cf78ebab484f3e21038933\" installation_id=\"c6a5be9f7f95e32628d2fdb192f6b9413253226b899e33e69916f918f32a961d\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109025885] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109025885 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9M1bt7BrfAAAAABhBWmQ5TTFidEFBQmo1LTFjRFEzT2xnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr1Q",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5137861edee836d91c997ff263bc915752631f3a557fede18ad4e8a926733c5e\" installation_id=\"15faa07c30b7d8193110cc0ccee780b7968f087bb71cc7d9d781d43736b151ff\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9IcJ-4upWTQAAABhBWmQ5SWNKLUFBQllpc210TkVKbU1BQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr1g",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"65ca46fc66d5863ea1102db45e572eab914fc978a44c2ddae0f08011ec418013\" installation_id=\"7f9e437781534db23e5e2da7deaa3ecf4d456e36c9d175ec9aa90f73e8f5653f\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9IW3UTAiE8AAAABhBWmQ5SVczVUFBRHB5OWNUa1o4X3N3QUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr1w",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"54b1fe4c80e17666123075abd007bb71a31bd1d35162ff1e400c4dd586fee5cd\" installation_id=\"f608a3a8df8fb488440c6773a6ea4ecd35352d40574c78ad997bb4c885949f7b\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd9GTSqEETbwQAAABhBWmQ5R1RTcUFBQ3BlRmxjS1Z0RUhnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr2A",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"3c8e69665813df1dfc893d3bbf70392077399fdf346474c65a0f0ebf7173ee98\" installation_id=\"b31d43d935f62b6d30887ed28b1ba8a43803266cfadf684ff27a94b0d5a8e5f9\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109025494] already processed"
-  },
-  {
-    "id": "AwAAAZd9GSQ1UCg76gAAABhBWmQ5R1NRMUFBRFRLbHkta2dMV2xBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr2Q",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ad3c70efc204a89fac534aa58e453be84668c8c471f465b064a14e131346d672\" installation_id=\"181baf29ae5beb6b660fd4a495e0c5187391c0127c0deb92036bcadb5bc492e5\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99257831 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99257831] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd9FxTjJY1YGQAAABhBWmQ5RnhUakFBQ3F0Q3pwVWQtRWFBQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr2g",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ca3be07de8fe4ed7624d6b426ea9b8fd6df6cad7a40b434bb61b31039b3e6a81\" installation_id=\"40ca687f64d627244cb63017e804cf0b820c399caae995f33fa31ffdf4aeb088\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9C76hoLjlwQAAABhBWmQ5Qzc2aEFBRF96QzdtNkxPYTRnQUEAAAAkMDE5NzdkYmQtYTAzZC00YmI2LWFkOGQtZjJiMjhmYTg1OWRlAAWr2w",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"296a361bc6dda3d403569081a68c4c0fc5024e0741ad888f8c07010e31cf695f\" installation_id=\"087714840f400337c969b8ee9139e00a486307f8413636520bed543c0a412320\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd9AAJLxVyKygAAABhBWmQ5QUFKTEFBQWJ4UnBWb3g2dm1BQUEAAAAkMDE5NzdkYzItYWRhZC00OGRlLWI0YjgtYTg5OGNkMDM0NjE5AAIMEg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"0f68fdd0e44a994faa815f9e7d7cfe2b98ca99a64f6e845cf09eb0e26ff12dee\" installation_id=\"c05c044cce91073fe522b1f94defb44c1ea851708fb1e22f2cbd7d6d6111846d\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99252396 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99252396] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8_-DE5O7NNgAAABhBWmQ4Xy1ERUFBQ0gxWVdmLWtXZ0t3QUEAAAAkMDE5NzdkYzItYWRhZC00OGRlLWI0YjgtYTg5OGNkMDM0NjE5AAIMEw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"08560247e11c70207537ec72f4b6b7919defc0f23578680a5aeac2b457e40555\" installation_id=\"338e0da5289343646dd05cbb149a2ef1e3986806bf8f38496c1501710a9f8294\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 109019653 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [109019653] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8_KeQf-MJpAAAABhBWmQ4X0tlUUFBRGotVlRBeUNWZ1lRQUEAAAAkMDE5NzdkYzItYWRhZC00OGRlLWI0YjgtYTg5OGNkMDM0NjE5AAIMFA",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f801f2cb0138e80b18b3f58fd3c48660774ce67a9837855697c6e94aa35e4797\" installation_id=\"f6ffe8efdbb0c2c290e23be61442005acb5fe7fb1a6b3f8d36b6203a8b478155\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd86owd_j4y-wAAABhBWmQ4Nm93ZEFBQXF6UW0yV1JqUU1RQUEAAAAkMDE5NzdkYzItYWRhZC00OGRlLWI0YjgtYTg5OGNkMDM0NjE5AAIMFQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a0159d750b2d861cfb0f57ac22486433b0923380c27f0e6c70f6176a2780ae29\" installation_id=\"bcb9f1876e4e03b41fbb47e0124acd6e6d6c2d051e6a4cc4634acabece0a6431\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd86lNO-ncdYQAAABhBWmQ4NmxOT0FBQi16MDFHblFxSVNRQUEAAAAkMDE5NzdkYzItYWRhZC00OGRlLWI0YjgtYTg5OGNkMDM0NjE5AAIMFg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8fc142267a2dfef812ad6f094471f101c04f3f0934039c1400a98294bb61993d\" installation_id=\"6183aef04b34d86511c309e40c3b2141a98396cd6fb9308daf90d504479d1d47\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd83ruR9GA_LQAAABhBWmQ4M3J1UkFBRGs3M2NCSkFwX0V3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcAQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4523a2913137012dc8986b34d86c90b6ee2213df8b40ab3178e8e31a19fa77b8\" installation_id=\"696e00294767ce04ea267d49725b4bbc654b5bd0ecf33c014737a866f93f6da4\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108998455] already processed"
-  },
-  {
-    "id": "AwAAAZd83qi-gX-cDgAAABhBWmQ4M3FpLUFBQ1RqaVlLMklOQk93QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcAg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d12eb5a0408f086981b4701f1d32babe26513d1342c5792b601f15e65eba387d\" installation_id=\"13aeda318bc19d1e2c287185e97708d2b4e97e94a6243e37d3092c78170e5896\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99251709] already processed"
-  },
-  {
-    "id": "AwAAAZd83JjGCJAiiwAAABhBWmQ4M0pqR0FBQ0FESEZjaFRCcnlRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcAw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"431d05c5880ba591d3c7e19639da8df43eaaadd59e4dd5f39ba48f8df387f764\" installation_id=\"c41aa91a416868bdaf7cbe233e1b9d2c0144d45faede5ca02ab08ac0e3ec4543\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd82-ey6hXyAAAAABhBWmQ4Mi1leUFBQTBxMVA4V2x0OGxRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcBA",
-    "type": "log",
-    "environment": "production",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5f23ac0669feb4cf5eb4caf1d811dfeb2a837e80cdc97ef078dcce4c80864041\" installation_id=\"62891b76ec80176905f054c1ac9612047cfdb63d34558da9f2598ab3cd096adf\"\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd81WtXUkQ76gAAABhBWmQ4MVd0WEFBRFRLbHkta29qWXNBQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-nQ",
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"7cfd374dd570763e4fed5df1f295cb3f69324ae85fc5ba94b6faaa3e25a3cc8e\" installation_id=\"28e6eab25e69dffade293beb9d93fdbd7d95278fba05f8f2d1835381a8439667\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110155264] already processed",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: group with welcome id 110155280 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome error: Error writing to storage: connection database is locked",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: storage error: UNIQUE constraint failed: consent_records.entity_type, consent_records.entity",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using async iterator pattern with conversation stream",
+      "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation events using callback pattern with conversation stream",
+      "FAIL  suites/functional/playwright.test.ts > playwright > should stream real-time group updates when members are added using async iterator pattern",
+      "FAIL  suites/functional/regresstion.test.ts > regression > downgrade 204,203,202",
+      "FAIL  suites/functional/regresstion.test.ts > regression > upgrade 204,203,202"
+    ]
+  },
+  {
+    "id": "AwAAAZeI2m4GANJHqwAAABhBWmVJMm00R0FBQkdIdXc1Q000Rm5nQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7uA",
     "type": "log",
     "environment": "dev",
     "test": "performance",
@@ -1845,10 +761,17 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"3da4d8c5c01d0712379c33a0fddbe19fd4aba5d7f733c5a5341cfdeb7f0b871d\" installation_id=\"7e2b591f5855bbdae888642e6017ba4aed4aeb54218e48d670164e64490c4d41\"\nm_performance > [grace-210] Stream collection timed out. 10s.\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"a9112d87d27b2cc26cf297f804196523c3c5fd535c526a5f27ca31f8770b05a9\" installation_id=\"7287293e53f77ce0e6c84519a28f0a40de28cf1b8f75222d2be6bfe9fe601577\"",
+      "m_performance > [elon-210] Collector timed out. 10s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams",
+      "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams"
+    ]
   },
   {
-    "id": "AwAAAZd80LvUKsnlcAAAABhBWmQ4MEx2VUFBQzJYRWo1NVRHSVpnQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-ng",
+    "id": "AwAAAZeI1vhEuwaD0gAAABhBWmVJMXZoRUFBQXh1WlJIbmJoM0FnQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7uQ",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -1857,22 +780,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8a10ad7d62dd9f855e585b5c5609699c710a5cedad490d7061283000d81e0f14\" installation_id=\"e24fdf98fa22539d72bdd4f6ca72a13885594f7e2f204b154410e3f8adea09fc\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"6c5672c8303a509e21ac108279ac63394b715c83712dc4674dc424c7cf8ce662\" installation_id=\"78c9fe356d0dfc87609521f1350b8c5de417c9d4aff723eda71c6018c4af8c62\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd80E8Ppbz4UwAAABhBWmQ4MEU4UEFBRDlkV0hvcjR2LTBRQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-nw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"812c8f6edb7bb88fc398ab790ec16f155f4e8daecca7674d48bcb83ba0b2dba0\" installation_id=\"26b15f7253e6074718a801c8aa925e2d04102c9ece34de049ee1181268c736d4\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd8x-paUb1FKwAAABhBWmQ4eC1wYUFBQ2pnME5aVGRIMzZBQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-oA",
+    "id": "AwAAAZeIzBDFi_lflwAAABhBWmVJekJERkFBREo2MmFqazZFcWN3QUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7ug",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -1881,10 +796,15 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"6d798b0eda4ca5f4a2211cd17321ac011dba00149fdb2add2513544aac0868b4\" installation_id=\"853472ffe4386c7217f4e916c12310176251b4b28902b8dbe7fc67cb4780d825\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108992738] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 108992738 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"818b2a2b2d556a7296d14db67a125cbd27c8886f63c7c4873585268a02efca6e\" installation_id=\"9276caa8f5090c16bc83175e2d70e044406bf5f4afa57131d87c19b085e1d6d9\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110148194] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110148194 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd8x9jkhx0WqwAAABhBWmQ4eDlqa0FBQ1VyV3V4WXZhQW93QUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-oQ",
+    "id": "AwAAAZeIzAgd_VWrowAAABhBWmVJekFnZEFBQk1NLTlmbVFtNzRRQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7uw",
     "type": "log",
     "environment": "dev",
     "test": "browser",
@@ -1893,10 +813,15 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"cb3937b666a6f9fc6f38923b3c2e6e725022268784473dcad1bcf37e92f5924c\" installation_id=\"9cadbaaa7dd6f30049ca611e97698cd623a85fa1b446d93faac61371d4e911b8\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99245855 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99245855] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4b5e44a6e0a62e42de8bc130565e5ebf40dea686281d3b72e0f66de56deff8de\" installation_id=\"552e72f3a9dffcbc8cf1c7b5b119a909cc811810ea9755c7d45c8fea1c9170fb\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99604557] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 99604557 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd8xPzkKuloqgAAABhBWmQ4eFB6a0FBRE54ZS1aRVRNbUR3QUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-og",
+    "id": "AwAAAZeIykmvfF_4CwAAABhBWmVJeWttdkFBQkJFaUNOQWx2WHRnQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7vA",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -1905,22 +830,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8cc54d8e06ed5238e3f4aab3ca41ed807b43a50202e9447aa144d04b7a6e01b4\" installation_id=\"4a88595e6093b4201d21cd21153b46508610769b10a6b71896f1088848421e1f\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"fbd0d851076baf00824c64d9499e2efdf40e01e5eafa39ca345effc4a647a7ac\" installation_id=\"c06ea7ea383636bead0c1ace65899033822e4a59d23140622920c69588828647\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd8xJQokSl5PAAAABhBWmQ4eEpRb0FBQWxvMmN2MGlJX3BBQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-ow",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d82df7cfbae2a36c358d1224267579f36f8abddec7853f3b1927507c0723d046\" installation_id=\"005eb803bf2cdd8bd41b361bc7174c88c9c18f2c8d50c811f24a93944a4dd307\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd8syhFOeHaRQAAABhBWmQ4c3loRkFBQWFzWmpEYTQ4Z1RBQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-pA",
+    "id": "AwAAAZeIuCDk7udtiAAAABhBWmVJdUNEa0FBQXhJUFhIUXZfNGVBQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7vQ",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -1929,10 +846,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5e2c41414525be6cd14020e07d17b17e75f90b1ba15d18e410f15c1c086672ca\" installation_id=\"d78dd82cbe1ac5096208401785bda82df18cb90ca10753b11927195278015359\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4cb04ae184a66e3e633a4a35ac40aa7b22de5c7a24927d52e1b21767b4dbe43c\" installation_id=\"a1c7556fff0718b66fc5249d4c2ae4b56a8d15dbeb0298590500296dbf82abe1\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd8qz6IP01dUQAAABhBWmQ4cXo2SUFBRG42djl3SW9wWnpRQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-pQ",
+    "id": "AwAAAZeIrJMge-4HOwAAABhBWmVJckpNZ0FBQlN0Rl9nTl8ydzFBQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7vg",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -1941,22 +862,15 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"39070ff6b75e3bd06744912c5fe0cc9fb8fe3df1b3c77b35b2f699d1edef33a9\" installation_id=\"e73f920c080f3f44889934977750d4b8b9ebeef24cb6ed91b5a7e8ce961e4e35\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 108991662 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108991662] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"182a9b1dee7c43fa657cd6048d59ae840037cd794b13805469487a6a2294cbea\" installation_id=\"4fac05a9fcdcc1f3542018a6ae2d0951745e48aaad678725076d12525c76acda\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110147845] already processed",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110147845 not found",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd8qzEGPvH7GQAAABhBWmQ4cXpFR0FBQU40YmY2VzRfUy1nQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-pg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"39e913f71f576abda6f08d7106fc726dad269898cdaae4a4f180f9d11f6a1fab\" installation_id=\"b33d1c02f80299dd632b3042de7175ae2909ef320d6891b215642609719383c8\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99245543 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99245543] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8qi90ue876gAAABhBWmQ4cWk5MEFBRFRLbHkta2p0QVd3QUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-pw",
+    "id": "AwAAAZeIq_mLNVm3ugAAABhBWmVJcV9tTEFBRFFiR09ySUh5bURBQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7vw",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -1965,22 +879,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"0afb7961e6422dfe2cbcf13438ae23adb9244ce7b70163fc3bc42c23bb920327\" installation_id=\"3aab866b98a9e20342c27fb120c796be295d1fc9e70f127f36ec3f1ba37a239b\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"98739caeb8265e6f6d1cfd06e9435830026fa4057cbe408212240858cbe3deab\" installation_id=\"21535a5ea857cc51a6d88eaaf49ef6ab55dc6e52b096aa724134ed2b889d6498\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd8qcIrFWqH3gAAABhBWmQ4cWNJckFBQmRpRzNvYTdsaXlBQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-qA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d4055b307752b07c96d8403acc90fbed25d98082cc811336989e54954480df75\" installation_id=\"41c07d06d918a21915d87e9e2c12dd56f9547465da93ace1aee4e282fe6c5147\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd8n5K7wtXyawAAABhBWmQ4bjVLN0FBRDRXOHJaTHNmWk9RQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-qQ",
+    "id": "AwAAAZeIoGix-wLkYQAAABhBWmVJb0dpeEFBQ1hlbURQT0pIM1BnQUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7wA",
     "type": "log",
     "environment": "production",
     "test": "agents",
@@ -1989,10 +895,14 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"19e0a0313e291769dd887e096bc587c77f26f7c6fb42d3c32dcd67db0fe1ae00\" installation_id=\"b06a4075304004491889ab6ead0361c55dedfc452a0cac0e6853744cd7713c01\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"9bfeb470ad7726a9af68d0af4a26ad7e77b1c2929a65a5cd40899d686281ebfd\" installation_id=\"97d5627c55a89cda31eafd11774e0d3c936c3fe3b3d4a261b497d6dbe0522ef3\"",
+      "agents > [bot-210] Collector timed out. 30s. Expected 1 events of type message, collected 0 events.",
+      "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+    ]
   },
   {
-    "id": "AwAAAZd8kkrOwon7vAAAABhBWmQ4a2tyT0FBQVBDLUowNW40cUpRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcBQ",
+    "id": "AwAAAZeIlS6H9FuDOwAAABhBWmVJbFM2SEFBQzJWSnRxdC0tem93QUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7wQ",
     "type": "log",
     "environment": "production",
     "test": "browser",
@@ -2001,10 +911,15 @@
     "region": "us-east",
     "env": "production",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8800a3324311f5ccb5daa1f439611f3ab4b33c50c9baa9aefe9d1e1bbee07f8b\" installation_id=\"4dbfa4e160638a407e4b3960fd0e0ca7372aaed8b869b877ad6aea9e20ba5827\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 108986181 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108986181] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b02b9f58c84fecea3a3f0881b80dc55300a6ccfac2b5e9aedebfa59c54c6cc5a\" installation_id=\"c9cc65fdf7a7d22cd100d0aef07dc3b42e6fe5af6612e2e62003c5ac4c767f12\"",
+      "browser > [bob-210] conversation stream error: Error: group with welcome id 110140795 not found",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [110140795] already processed",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   },
   {
-    "id": "AwAAAZd8kihYdi1WTQAAABhBWmQ4a2loWUFBQllpc210TkVENWN3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcBg",
+    "id": "AwAAAZeIlSl8_R2BcwAAABhBWmVJbFNsOEFBQURKSE1laDMxZGR3QUEAAABdMDE5Nzg4ZWItMWZiMy00OTM3LTliNTYtYzYzNTQ2ZGY1NDRiLXN5bnRoZXRpYy10aW1lLTE3NTAzNDE2MDAwMDAwMDAwMDBjLTE3NTAzNDg3OTk5MjMwMDAwMDFvAAh7wg",
     "type": "log",
     "environment": "dev",
     "test": "browser",
@@ -2013,810 +928,10 @@
     "region": "us-east",
     "env": "dev",
     "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2863c0f7f20a2b4cb1796ec03e61504356ee31cb10b8a4226c9240c411bb1356\" installation_id=\"73a8ad7709e126b39cf67f332aa63563f2ba5e6845f80a7f848cf282b7c71473\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99240102] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99240102 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8juuGzL3AYAAAABhBWmQ4anV1R0FBQlBIUkhWZXhLZDRRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcBw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d2540da00090c863e6e6aa91ca2e91b3969b4d4d53392deffc81760d9b34d2ab\" installation_id=\"1a2d49421930a14bdd17b33d25c39e57b675449e041eaa37719356335cd5941e\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8jnPJv6CurgAAABhBWmQ4am5QSkFBRHREU2FIdGNxVzhRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcCA",
-    "type": "log",
-    "environment": "production",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4f24d01cbbfab0a5edf929e32321ffdafefe71d8fb9d1403eaf0343ac88997a6\" installation_id=\"3790a47fdfd3fef0060b03546fa289c5f6fd46bea4c6edc30e73c342534bf538\"\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd8fNC9vwwL5QAAABhBWmQ4Zk5DOUFBQzJBTlVvU3ZiZFJnQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcCQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"bcfd1d9bb1a69742f5ed988d886d813a8c12771e42002e61fa22f14c767c16ac\" installation_id=\"5adb1e008b3f8dcee0fe7b5f0e4915a674dc78d0cd1e980293164b8b8a63e5c3\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8fDq1YJV5PAAAABhBWmQ4ZkRxMUFBQWxvMmN2MHFJUEVBQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcCg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ae7cf2be47e3d31b5bf7359a467868648570239d76e8b51ca1e86ffd4d5560a3\" installation_id=\"58cd1d6c0d26b72f13fb9e7f54e304620b86e5167399ea00c95340eacb69e7a1\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd8cYBl98OGyAAAABhBWmQ4Y1lCbEFBQnhvVDdMSXo5ZmZBQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-qg",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"767dddaada7d4a0e1f2bceec7bdc01d9eef94f1dc8134d8861c36f6b3c181e4e\" installation_id=\"cee6cec3a01852014b37a88b79e39239ae184aa07999d73180b3dcb82e212e87\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108965325] already processed"
-  },
-  {
-    "id": "AwAAAZd8cXvdQvsvwwAAABhBWmQ4Y1h2ZEFBQy1palVuYzc5WlpBQUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-qw",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d6215767cf5c0c44ab682b271e12ff88c6ee24e4c9048742f6edff4009bfeb67\" installation_id=\"2531a681905ac4f878bcccbcf784be89f09ea1dc9f9536dda2a641b25e8b417b\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99239891] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99239891 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8b3YAWMhGDAAAABhBWmQ4YjNZQUFBRHAteExDcXd2dGd3QUEAAAAkMDE5NzdjZTYtZjNlZS00OTZiLTk5OTUtYTkyNWExY2FmMjBmAAH-rA",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"08f7362aaa846bc4ec90a057aae6f1c0552e1416433c00d2cb5bda19d28354e0\" installation_id=\"5a52dd6e74ee3d719da1c9529366c60a79080a2e7be285ecb957e3a2885986b5\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8Z3hzV1kyBwAAABhBWmQ4WjNoekFBQ2lfVU1vUzQ4S0xRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcCw",
-    "type": "log",
-    "environment": "production",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"33eec817c71ddfeb537d1e0fff945102a17af95cd7f21b0881242649dd8d3645\" installation_id=\"3b8ea9296f5edb71a80df71142d27889546d73f22640ac60b659ef3d11e0ffe5\"\nm_performance > [alice-210] Stream collection timed out. 10s.\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd8ZDHAZBMbswAAABhBWmQ4WkRIQUFBQ29RSlNLdFQ2SHlnQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcDA",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"37a5506acaa589f24fe28f04dadb2f548dad27a63530d9217b6715a62c68f03e\" installation_id=\"4f0e09b0ea5c355fb582924de3de06892ba209ea5c05d098095d145c023bb841\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8Wf7fb7M6ZwAAABhBWmQ4V2Y3ZkFBQlJfbnNlRnhiRjJ3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcDQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4d903f2287f703f7e4142836edeaebfd362049a4433cda3410753ea9ccea8c90\" installation_id=\"1a0bf0b6737a98caf4b0b92f1c9755aecc1de884e0bd956b9d131f151926019d\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 108959877 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108959877] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8We18BSkfRAAAABhBWmQ4V2UxOEFBRGNhMVVSQkRBUmV3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcDg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"86cf7ef84169c7c9f5a053be3a0458248265d1e092786c0e812d5b9c0a5b305c\" installation_id=\"635438550881f6eb1341da607d05e64fbd9cbabe176ef33a4ebb35df65fa716a\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99234533] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99234533 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8Vt8ZW2a6bgAAABhBWmQ4VnQ4WkFBQ1d2X2hVSlI5OGtnQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcDw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"12d5e688259c45e916adb7e52da917675ca8df4f2ea4838487040d26a08944bd\" installation_id=\"9cfcdcc9626971d3e4b3070b51abf2bcea452eaf2de47cf6a8d58cd4e37ad06d\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8VkMxX2Tj8gAAABhBWmQ4VmtNeEFBQnItVzdlUzVVM1l3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcEA",
-    "type": "log",
-    "environment": "dev",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"148a8a97d97017169dc41aca9fedf8bc6689e3547158a396ca466ea4bb4824b9\" installation_id=\"06a76519d712a3ffe953d76823e23ef9057458113e44a55723a8fd121ecc95be\"\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s.\nm_delivery > [alice-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd8VjtlJpt3CgAAABhBWmQ4Vmp0bEFBQUtnSHA3bkNiUkh3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcEQ",
-    "type": "log",
-    "environment": "production",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2058e4583f597b7866da07fc6003ecec4933b9e955d2f41594253c70ce0ca5f1\" installation_id=\"b3337a6aabdc9f631265a1495afd6845294c38aa559431c3df23509b0d364442\"\nm_delivery > [alice-210] Stream collection timed out. 10s.\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd8RX85Codr-gAAABhBWmQ4Ulg4NUFBRG03b2RtNk1DZE9BQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcEg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"837e91454b84d6c950302484d904c00779f772a7fdf41348f7752c33ad7fff49\" installation_id=\"5080c47b65486b01c64505503ebbfea97c129ed91a76961718ac7344ef3c4a45\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8PBVac8WUXQAAABhBWmQ4UEJWYUFBQ0tiTkxqUlQ5VThRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcEw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"9e4e8ddaa9620c4817726db5f5726047b912d74d52203281ddb9cf745afd8820\" installation_id=\"ffa8db7e9ad239f8de89df35a8c7db95b7d9ed0bd40a274a86d2ed5a15765bcc\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108959534] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 108959534 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8PBC6rN7fAAAAABhBWmQ4UEJDNkFBQmo1LTFjRFZXUFdnQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcFA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"718e72cf6195198bb13964ae254fe97604a6b0943a67e93d151d88e5d76b4f0a\" installation_id=\"bacaa0f6b16908d8ea0848f14eb5d2121a65da14dcc936a93dc2ce701cebf8d3\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99234319] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99234319 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8Ou86zgPkXwAAABhBWmQ4T3U4NkFBQnpPVzIxcVR2U1B3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcFQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e34f784a376074a2a80e1692e32c3ca26f2578a2727b6112f730938d46b1027b\" installation_id=\"e11e3fd2e95b639c7d5f6fd71c4c192733e4a95b326e45d0c50a8b733ace0414\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8OnbGlaLHaQAAABhBWmQ4T25iR0FBREZqbDdXN3k2U1NRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcFg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2616b7170b2e629cfb1420ab8d672fc7919382a184187f99f376c505e6cde857\" installation_id=\"16aa29849b0ed1324a83cee163d05cfb2938abcfa80df322ed0f6a737f2fc91c\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd8OimUmEbc3QAAABhBWmQ4T2ltVUFBQnlmeVR4d05mU3hBQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcFw",
-    "type": "log",
-    "environment": "dev",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"2b3128025080d7b70bd0f934678874207b05e60b0be232ab1c1e21962a622ce5\" installation_id=\"f928d9bccc75b5e0d5e8e1236344ad43583068eb8d89fdba19165682337ebb9f\"\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [bob-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd8Oihb8npzAwAAABhBWmQ4T2loYkFBRG1FNnluenBCVTh3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcGA",
-    "type": "log",
-    "environment": "production",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"29676aa29f3457f0796c4e79d7e3ac20a5da3898dc86e539b5570edc6aceefbe\" installation_id=\"fbc119030fee934a097a78b975a2869c664ad0e40db41b0cfde33b11f7921bb6\"\nm_delivery > [fabri-210] Stream collection timed out. 10s.\nm_delivery > [elon-210] Stream collection timed out. 10s.\nm_delivery > [alice-210] Stream collection timed out. 10s."
-  },
-  {
-    "id": "AwAAAZd8M8YEU5t3sQAAABhBWmQ4TThZRUFBQUI0SGFaVEh3MFdBQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcGQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"d890ba6a154ed8bf9626cee60cbc145ee2af3f7dc276747e9a6e5008cd663270\" installation_id=\"dd5f5918932ba8af394b67915ecbae1665b41bc599ca22b5de8a59b5df5315e5\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: Hpke error: Key not found\nm_performance > [charlie-210] Stream collection timed out. 10s.\nm_performance > [elon-210] Stream collection timed out. 10s.\nFAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd8MFu_-G1ROQAAABhBWmQ4TUZ1X0FBQ1RCRklaVC02dGVRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcGg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4bbd4c8c8a7bfbbb2bac237200ac1aa8300c35623f87963982a242595010f29b\" installation_id=\"e697cdcc91b0676251ab73f6e715864d00e1f6afa4750db6587709e9e1b6506f\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8L-32mq1QpgAAABhBWmQ4TC0zMkFBRDJSdkJFZjNyazV3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcGw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"42a468c0f22338fdba80f35eb014c5598cc480cd6a83dca98107a566a4058ca3\" installation_id=\"c6357957797e0e034d308ae8b18ed80d1f3960e818f734a82a1698a99590d803\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\"\nFAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd8JEHiKvo_LQAAABhBWmQ4SkVIaUFBRGs3M2NCSk1HMXJRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcHA",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"8db2f381810071d529407e85fadf32c4b403b0f5ba6e148b4a7730fcfb248360\" installation_id=\"b837e3b7e1483c35ae174de64a4a1aaa6b85c4366186cef7e9911e85577a0952\"\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 108954105 not found\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108954105] already processed\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8JDdSer07xAAAABhBWmQ4SkRkU0FBQ3BickxkQV9BU3RnQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcHQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ac1ea6bbd7005780c460526380040d4f8ec717e4cd342a4a8333c41906cb9d32\" installation_id=\"832a44acf25490920622673a9b856f753f7d1f72177250b4e0285af3a7ca1414\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99229356] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99229356 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8IzyCzi9a6wAAABhBWmQ4SXp5Q0FBRDZjMFNnREZFSWdRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcHg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"e0976a0793ba643637401bd68411926af20742a0646e562b64301943d7417726\" installation_id=\"438fc34f6dd6dcb331dd72e2741a75a5ee4902693df824dfd7d9a15b7420ff62\"\nagents > [bot-210] Stream collection timed out. 10s.\nFAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8GAUOJfpn7gAAABhBWmQ4R0FVT0FBQThnOHJoOTFUczVRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcHw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"0d339e5ab22ed322c241fd5e136f3c5ef4318faab332ad5e288ccc9a4784e7a9\" installation_id=\"3a2682e63f0971d1e32e4f2071376fce2c3d7b093bd079e75a0b9ff3b90d8224\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108953897] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 108953897 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8F_fyahJROQAAABhBWmQ4Rl9meUFBQ1RCRklaVDhNZkhnQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcIA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f5217fd6a424629cec9fc20c6f8bbde781b530057f218d38909f083efe014871\" installation_id=\"dc2aa8daf133e6a5db3ef7f51566bcc6c5999c9fd1148b844b0856f9f01f9cd6\"\nprocess:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99229206] already processed\nbrowser > [bob-210] conversation stream error: Error: group with welcome id 99229206 not found\nFAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8Fy7fCcTWwwAAABhBWmQ4Rnk3ZkFBQ04tYlQxRTh6UzZBQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcIQ",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8Fy4G3LzHaQAAABhBWmQ4Rnk0R0FBREZqbDdXNy1fWll3QUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcIw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"5c03869735940a58d7f309bab68ab66cf1d7b0d69ab2507d38695c9e425f8785\" installation_id=\"607edc1c5a62f1ffd100e9f92c32fb963a15e420722fb5e4bd672b919f3ccd31\""
-  },
-  {
-    "id": "AwAAAZd8FlB6DY6kawAAABhBWmQ4RmxCNkFBQUFhc29QdDVkME5nQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcJA",
-    "type": "log",
-    "environment": "local",
-    "test": "dms",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "local",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"7abc053e45f4868b1585bfc5a585880574921298088d437544521b966b412813\" installation_id=\"dcff3d879976b1502c7f70befab18e8a2bcb4ba0293f7f2cb71e1a7aa5ed1d7e\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
-  },
-  {
-    "id": "AwAAAZd8FBNn0_Iy-wAAABhBWmQ4RkJObkFBQXF6UW0yV1oybDVRQUEAAAAkMDE5NzdjZTQtODA0Mi00YzFjLTliOTItMTJhNzIyYTc2NjhhAAQcJQ",
-    "type": "log",
-    "environment": "local",
-    "test": "dms",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "local",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"85be3cd6ea36579d29c543bf840204dd106deb892d3b549e4e1c2b15bb79b96b\" installation_id=\"d318a55cc007eb6d593d093ebdc8c2aa010a2d73dcbb720170dbc8ecaa3f5a12\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
-  },
-  {
-    "id": "AwAAAZd8CzKWxqVKkwAAABhBWmQ4Q3pLV0FBQ21XQ2xBUDRwWE5RQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Lg",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8CzJndld3sQAAABhBWmQ4Q3pKbkFBQUI0SGFaVEROWEZBQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Lw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "browser > [bob-210] conversation stream error: Error: group with welcome id 108933375 not found"
-  },
-  {
-    "id": "AwAAAZd8CzIewOo0HQAAABhBWmQ4Q3pJZUFBQjZQMjk3SmRFdVpBQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9MA",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108933375] already processed"
-  },
-  {
-    "id": "AwAAAZd8CzG-wADbGQAAABhBWmQ4Q3pHLUFBRExRdHJuZU9jNE5RQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9MQ",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"b0145bd1c9795c1bb39c1bfa22a9035d46e66eb5b34055393e91dfc9776a09e2\" installation_id=\"fa3019b3ceb0a3cef53cfd49674a87d8c6c438b9bfa6ac4c25af6c925c8ea03c\""
-  },
-  {
-    "id": "AwAAAZd8CyzzQXi-wAAAABhBWmQ4Q3l6ekFBQ09ZX2E1THZGR09nQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Mg",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/browser/browser.test.ts > browser > should detect real-time group updates when members are added asynchronously"
-  },
-  {
-    "id": "AwAAAZd8CyzbE0Z8dQAAABhBWmQ4Q3l6YkFBQnlPeW5mVmJzTFN3QUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Mw",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99229067] already processed"
-  },
-  {
-    "id": "AwAAAZd8CyyzbAfyAAAAABhBWmQ4Q3l5ekFBQTBxMVA4V3VuLWh3QUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9NA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "browser > [bob-210] conversation stream error: Error: group with welcome id 99229067 not found"
-  },
-  {
-    "id": "AwAAAZd8Cyxx7h6UXQAAABhBWmQ4Q3l4eEFBQ0tiTkxqUmVmUFNnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9NQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c972ee22f034a17d5e8a02e395f5810a293f93150fcfa55a66a0a23aa9a197e1\" installation_id=\"bec2391410e9344d6976b93222aa7d6c862416b2159b3912fbad6c763ce6a789\""
-  },
-  {
-    "id": "AwAAAZd8Cdm9fy5KkwAAABhBWmQ4Q2RtOUFBQ21XQ2xBUDRnUHZnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Ng",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd8CdklODdflwAAABhBWmQ4Q2RrbEFBQ2g3bmlFRHBOTVlnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9OA",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f4d457036aec77e1914316180052f5459b9737929bf2651f0df4f8b663aca27c\" installation_id=\"9ec26eeae3f3efef0ef33020173be39fa5954ea941684a0db17bd74f77922f72\""
-  },
-  {
-    "id": "AwAAAZd8CaXtIyg5FgAAABhBWmQ4Q2FYdEFBQm9ELThWM0lPNGFRQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9PA",
-    "type": "log",
-    "environment": "dev",
-    "test": "delivery",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ce4918c3e22c14322caf77bdee505deee68f0a226be4e42846c5adc6ad286154\" installation_id=\"592053d9efe887e4d1b7a00fe0e8089168b05e05f2c4e0973c0c957036a506bc\""
-  },
-  {
-    "id": "AwAAAZd7_lxFSf7gLgAAABhBWmQ3X2x4RkFBQmFnQkE2MjI2Qnp3QUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9PQ",
-    "type": "log",
-    "environment": "local",
-    "test": "dms",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "south-america",
-    "env": "local",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f17cb6a853492a8c9775af1cd91162d8bd42967df37be731884dd12737a15bfc\" installation_id=\"55f4419907f0f8d7e380b13bd465554b8f1931d4f8a21f37efce30d953905902\"\nFAIL  suites/functional/dms.test.ts > dms > should  fail on purpose"
-  },
-  {
-    "id": "AwAAAZd795mMqR20tAAAABhBWmQ3OTVtTUFBQlJZc1NnZzAyNndnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Pg",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [108928091] already processed"
-  },
-  {
-    "id": "AwAAAZd795kaba_gLgAAABhBWmQ3OTVrYUFBQmFnQkE2MjJLbGdBQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Pw",
-    "type": "log",
-    "environment": "production",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"c9bce52d76198ae0826cd4d780b2f2534158a07670a0bffa727b20fe351a27d3\" installation_id=\"d602f9f952827a913f068a80a9a57b548d6f16c042b4fcf070411f7528d851e7\""
-  },
-  {
-    "id": "AwAAAZd7945nMgZOkQAAABhBWmQ3OTQ1bkFBQktVTkExS3hRa3RnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9QA",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99223832] already processed"
-  },
-  {
-    "id": "AwAAAZd79432A92oyAAAABhBWmQ3OTQzMkFBQXBhTS0wbzBxSGZ3QUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9QQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "browser",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"f0d3edfc5344b89919404a6587dafd5591e215df671b6e946700f47e1e81cb50\" installation_id=\"b3c63f8d290fe81a9becca195958318e4a13b8f6700a9d097042bc46d5ca0bee\""
-  },
-  {
-    "id": "AwAAAZd79qBK7hxwGQAAABhBWmQ3OXFCS0FBRDVjbUpHNzdYaGxnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Qg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd79qAFB6RuTgAAABhBWmQ3OXFBRkFBQWJZMk45ZWtudXJBQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Qw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd79p_wz-u30gAAABhBWmQ3OXBfd0FBRHExNGxOQnh0R0NnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9RA",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd79p-T9AlJPQAAABhBWmQ3OXAtVEFBQllEZjQ5dnJtS01nQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Rg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"4788a2996ba06ffb1df1020401c5edbd73c8d00a2a0e07cecdcb34f2c84c7fb5\" installation_id=\"198fba89790697e58b7c9317ccd77dfccdcf177f81ba9d4c3505f3acfd23c5ec\""
-  },
-  {
-    "id": "AwAAAZd79jjdavXMkwAAABhBWmQ3OWpqZEFBQU1SMWVyMG1OcUtnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Rw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd79jifmx2MCwAAABhBWmQ3OWppZkFBQmdPcG95TVZOQ3ZBQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9SA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd79jg0kM0FcgAAABhBWmQ3OWpnMEFBQTBjaE9XZ2lDVVlRQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Sg",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"433f27c42560347360b2cde12bfdcb105bba13b8218bcbfd7edbb67b5df79ad4\" installation_id=\"6b8aafe892d9a12485bdf339b6df4e59d6d435c210cea6bcf14b8bd9a4bd413c\""
-  },
-  {
-    "id": "AwAAAZd7379NfMp6GQAAABhBWmQ3Mzc5TkFBQktEQXhCTmg0LVh3QUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Sw",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from clankerchat.base.eth agent (0x9E73e4126bb22f79f89b6281352d01dd3d203466) when sending \"hi\""
-  },
-  {
-    "id": "AwAAAZd7378k_BBQyAAAABhBWmQ3Mzc4a0FBRDRuM1BycmY2MW1nQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9TA",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd7376uhm0gUQAAABhBWmQ3Mzc2dUFBQ1RXUW9jZDBOX0ZnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Tg",
-    "type": "log",
-    "environment": "production",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "production",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"861559da46edf8be2dd93f2c3a58c31836f68804a130c40a51f6da99416f7e25\" installation_id=\"1b49caff45f5a94ea19ab064ef637acbf8d16a22a41badfef689600594f1a830\""
-  },
-  {
-    "id": "AwAAAZd731D7doDI9AAAABhBWmQ3MzFEN0FBQU5lQVVZR2pkV2NnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Tw",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from gang agent (0x6461bf53ddb33b525c84bf60d6bb31fa10828474) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd731DdPQtp3wAAABhBWmQ3MzFEZEFBRFV5eUktLVhTTTdnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9UA",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/agents/agents.test.ts > agents > should receive response from csx agent (0x74563b2e03f8539ea0ee99a2d6c6b4791e652901) when sending \"hola\""
-  },
-  {
-    "id": "AwAAAZd731BzYfMYmwAAABhBWmQ3MzFCekFBQUFkX0lFVW9PNWhBQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Ug",
-    "type": "log",
-    "environment": "dev",
-    "test": "agents",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"869681374575a1d6d5525a443a369b60b0edcfeca10a51a9952ab772486a2c9f\" installation_id=\"9e66c744c59243dd4cbd45769963b3e22fb16197cf8e77826ff31f81abdb2fda\""
-  },
-  {
-    "id": "AwAAAZd72tl5riZHPgAAABhBWmQ3MnRsNUFBQmZFN0tKbmlEZmhnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Uw",
-    "type": "log",
-    "environment": "dev",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-200: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd72tk2FWRBwgAAABhBWmQ3MnRrMkFBQmt5SHFta1d0WlRnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9VA",
-    "type": "log",
-    "environment": "dev",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-150: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd72tj7yxmurgAAABhBWmQ3MnRqN0FBRHREU2FIdFkyaWFnQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9VQ",
-    "type": "log",
-    "environment": "dev",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-100: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd72tjbvG66bgAAABhBWmQ3MnRqYkFBQ1d2X2hVSlVMZG1nQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9Vg",
-    "type": "log",
-    "environment": "dev",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "FAIL  suites/metrics/performance.test.ts > m_performance > receiveGroupMessage-50: should create a group and measure all streams"
-  },
-  {
-    "id": "AwAAAZd72thGk9GC3gAAABhBWmQ3MnRoR0FBQVlFYUgyWDNWMTRRQUEAAABdMDE5NzdjMGItMzlkOC00ODQwLThkNDItN2NlZmZlNjdkMzQxLXN5bnRoZXRpYy10aW1lLTE3NTAxMjkyMDAwMDAwMDAwMDBjLTE3NTAxMzI3OTk5NjAwMDAwMDFvAAV9WA",
-    "type": "log",
-    "environment": "dev",
-    "test": "performance",
-    "level": "error",
-    "service": "xmtp-qa-tools",
-    "region": "us-east",
-    "env": "dev",
-    "libxmtp": "latest",
-    "message": "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"ebf09492c129d89978ab958a03dda99b4dcf2096cd042fbf98a4e35add720a45\" installation_id=\"c2db3f3be915d0711aa57b224130ca8cd6f8eec10a310ee90bedb9b1693f230c\""
+    "message": [
+      "xmtp_mls::groups::key_package_cleaner_worker: sync worker error storage error: Record not found inbox_id=\"741cee8ab6cb58b5894b2287f890005e46c09abacd3406df3590059c8b4cc63e\" installation_id=\"6344aaaf8fcc6f198d00989813b28a8816c21de1d7f261e576d0e4ea8a205fcc\"",
+      "process:sync_welcomes: xmtp_mls::groups::welcome_sync: failed to create group from welcome: welcome with cursor [99597545] already processed",
+      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition"
+    ]
   }
 ]

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -96,7 +96,7 @@ describe(testName, async () => {
     }
   });
 
-  it("fail on purpose", () => {
-    expect(false).toBe(true);
-  });
+  // it("fail on purpose", () => {
+  //   expect(false).toBe(true);
+  // });
 });


### PR DESCRIPTION
### Add performance test failures to known issues list in helpers/logger.ts
Adds a new 'Performance' category to the `KNOWN_ISSUES` array in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/547/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) containing four error lines for failing performance tests that measure group message reception with 50, 100, 150, and 200 messages.

#### 📍Where to Start
Start with the `KNOWN_ISSUES` array in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/547/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) to see the new performance test entries.

----

_[Macroscope](https://app.macroscope.com) summarized 6241336._