### PR TITLE
Add functional test error logging for better tracking

### DIFF
--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import winston from "winston";
+import winston, { stream } from "winston";
 import "dotenv/config";
 
 export const KNOWN_ISSUES = [
@@ -20,6 +20,12 @@ export const KNOWN_ISSUES = [
     testName: "Agents",
     uniqueErrorLines: [
       "FAIL  suites/agents/agents.test.ts > agents > production: clankerchat.base.eth : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
+    ],
+  },
+  {
+    testName: "Functional",
+    uniqueErrorLines: [
+      "FAIL  suites/functional/playwright.test.ts > playwright > should stream real-time group updates when members are added using async iterator pattern",
     ],
   },
   {

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -7,7 +7,7 @@ export const KNOWN_ISSUES = [
   {
     testName: "Browser",
     uniqueErrorLines: [
-      "FAIL  suites/browser/browser.test.ts > browser > Browser group member addition",
+      "FAIL  suites/browser/browser.test.ts > browser > conversation stream for new member",
     ],
   },
   {
@@ -25,7 +25,7 @@ export const KNOWN_ISSUES = [
   {
     testName: "Functional",
     uniqueErrorLines: [
-      "FAIL  suites/functional/playwright.test.ts > playwright > should stream real-time group updates when members are added using async iterator pattern",
+      "FAIL  suites/functional/playwright.test.ts > playwright > conversation stream for new member",
     ],
   },
   {

--- a/suites/browser/browser.test.ts
+++ b/suites/browser/browser.test.ts
@@ -43,7 +43,7 @@ describe(testName, () => {
     gmBot = gmBotWorker.get(receiver) as Worker;
   });
 
-  it("Browser new conversation stream with message", async () => {
+  it("conversation stream with message", async () => {
     try {
       const newGroup = await creator.client.conversations.newGroup(
         getRandomInboxIds(4),
@@ -63,7 +63,7 @@ describe(testName, () => {
     }
   });
 
-  it("Browser new conversation stream without message", async () => {
+  it("conversation stream without message", async () => {
     try {
       const newGroup = await creator.client.conversations.newGroup(
         getRandomInboxIds(4),
@@ -82,7 +82,7 @@ describe(testName, () => {
     }
   });
 
-  it("Browser DM creation and message stream", async () => {
+  it("newDm and message stream", async () => {
     try {
       await xmtpTester.newDmFromUI(gmBot.address);
       await xmtpTester.sendMessage(`hi ${receiver}`);
@@ -95,7 +95,7 @@ describe(testName, () => {
     }
   });
 
-  it("Browser group creation and message stream", async () => {
+  it("newGroup and message stream", async () => {
     try {
       groupId = await xmtpTester.newGroupFromUI([
         ...getInboxIds(4),
@@ -111,7 +111,7 @@ describe(testName, () => {
     }
   });
 
-  it("Browser group member addition", async () => {
+  it("conversation stream for new member", async () => {
     try {
       groupId = await xmtpTester.newGroupFromUI([
         ...getInboxIds(4),
@@ -132,7 +132,7 @@ describe(testName, () => {
     }
   });
 
-  it("Browser new installation and message stream", async () => {
+  it("new installation and message stream", async () => {
     const xmtpNewTester = new playwright({
       headless,
     });

--- a/suites/functional/playwright.test.ts
+++ b/suites/functional/playwright.test.ts
@@ -44,7 +44,7 @@ describe(testName, async () => {
   creator = convoStreamBot.get("bob") as Worker;
   gmBot = gmBotWorker.get(receiver) as Worker;
 
-  it("should detect group invitation in browser when invitation includes an initial message", async () => {
+  it("conversation stream with message", async () => {
     try {
       const newGroup = await creator.client.conversations.newGroup(
         getRandomInboxIds(4),
@@ -64,7 +64,7 @@ describe(testName, async () => {
     }
   });
 
-  it("should detect group invitation in browser when invitation has no accompanying message", async () => {
+  it("conversation stream without message", async () => {
     try {
       const newGroup = await creator.client.conversations.newGroup(
         getRandomInboxIds(4),
@@ -83,7 +83,7 @@ describe(testName, async () => {
     }
   });
 
-  it("should create DM via browser UI and receive automated GM bot response", async () => {
+  it("newDm and message stream", async () => {
     try {
       await xmtpTester.newDmFromUI(gmBot.address);
       await xmtpTester.sendMessage(`hi ${receiver}`);
@@ -96,7 +96,7 @@ describe(testName, async () => {
     }
   });
 
-  it("should create group via browser UI and validate GM bot messaging functionality", async () => {
+  it("newGroup and message stream", async () => {
     try {
       groupId = await xmtpTester.newGroupFromUI([
         ...getInboxIds(4),
@@ -112,7 +112,7 @@ describe(testName, async () => {
     }
   });
 
-  it("should stream real-time group updates when members are added using async iterator pattern", async () => {
+  it("conversation stream for new member", async () => {
     try {
       groupId = await xmtpTester.newGroupFromUI([
         ...getInboxIds(4),
@@ -133,7 +133,7 @@ describe(testName, async () => {
     }
   });
 
-  it("should stream real-time group updates when members are added using callback pattern", async () => {
+  it("conversation stream for new member with callback", async () => {
     try {
       groupId = await xmtpTester.newGroupFromUI([
         ...getInboxIds(4),
@@ -157,7 +157,7 @@ describe(testName, async () => {
     }
   });
 
-  it("should handle multiple browser instances with independent messaging sessions", async () => {
+  it("new installation and message stream", async () => {
     const xmtpNewTester = new playwright({
       headless,
     });


### PR DESCRIPTION
### Standardize test names across browser and functional test suites for better tracking
- Renames test descriptions in [browser.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/549/files#diff-a2d0c51274377213919763fa31a3bf712be257103219852afa9a9d5b05e33f6f) and [playwright.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/549/files#diff-f975bd2e8dd7e36fed92b661915e817abffae5ffbeb3cf4e460ff7160bf34dd4) to use consistent, concise naming patterns
- Updates the `KNOWN_ISSUES` array in [logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/549/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) to add a new 'Functional' test entry and modify the 'Browser' test error line to match the renamed test
- Adds unused `stream` import from winston module in [logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/549/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597)

#### 📍Where to Start
Start with the `KNOWN_ISSUES` array in [logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/549/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) to understand the error tracking changes, then review the renamed test descriptions in [browser.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/549/files#diff-a2d0c51274377213919763fa31a3bf712be257103219852afa9a9d5b05e33f6f) and [playwright.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/549/files#diff-f975bd2e8dd7e36fed92b661915e817abffae5ffbeb3cf4e460ff7160bf34dd4).

----

_[Macroscope](https://app.macroscope.com) summarized ed2392e._