### PR TITLE
Remove default stream timeout for workflow clarity

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -2,6 +2,9 @@ name: Agents
 description: "should verify performance of the library in the production network"
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "*/15 * * * *" # Runs every 15 minutes
   workflow_dispatch:

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -18,7 +18,6 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}
       GEOLOCATION: ${{ vars.GEOLOCATION }}
-      DEFAULT_STREAM_TIMEOUT_MS: 30000
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 20
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/NetworkChaos.yml
+++ b/.github/workflows/NetworkChaos.yml
@@ -38,7 +38,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
-          cache: "yarn"
+          # Disable built-in cache to use shared cache below
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            .yarn/cache
+          key: deps-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            deps-
 
       - name: Install Dependencies
         run: yarn

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -2,8 +2,11 @@ name: Regression
 description: "should verify last 3 versions of the library"
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
-    - cron: "0 0 * * *" # Runs at midnight UTC every day
+    - cron: "0 0,12 * * *" # Runs at midnight and noon UTC every day
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -2,9 +2,6 @@ name: Regression
 description: "should verify last 3 versions of the library"
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 0 * * *" # Runs at midnight UTC every day
   workflow_dispatch:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -29,7 +29,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
-          # Disable built-in cache to use shared cache below
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -1,3 +1,4 @@
+import { getRandomNames } from "@helpers/client";
 import { sendMetric } from "@helpers/datadog";
 import { logError } from "@helpers/logger";
 import { verifyBotMessageStream } from "@helpers/streams";
@@ -15,7 +16,7 @@ describe(testName, () => {
   const env = process.env.XMTP_ENV as "dev" | "production";
   beforeAll(async () => {
     workers = await getWorkers(
-      ["bot"],
+      ["bob"],
       testName,
       typeofStream.Message,
       typeOfResponse.None,
@@ -35,7 +36,7 @@ describe(testName, () => {
   for (const agent of filteredAgents) {
     it(`${env}: ${agent.name} : ${agent.address}`, async () => {
       try {
-        let retries = 3; // Move retries inside each test for fresh count
+        let retries = 1; // Move retries inside each test for fresh count
         console.warn(`Testing ${agent.name} with address ${agent.address} `);
 
         const conversation = await workers
@@ -85,12 +86,12 @@ describe(testName, () => {
           result?.averageEventTiming,
         );
 
-        sendMetric("agents", result?.averageEventTiming ?? 0, {
+        sendMetric("response", result?.averageEventTiming ?? 0, {
+          metric_type: "agent",
+          metric_subtype: agent.name,
           agent: agent.name,
           address: agent.address,
           test: testName,
-          metric_type: "responseTime",
-          metric_subtype: agent.name,
         });
         expect(agentResponded).toBe(true);
       } catch (e) {


### PR DESCRIPTION
### Remove DEFAULT_STREAM_TIMEOUT_MS environment variable from Agents workflow and modify test configuration for workflow clarity
- Removes the `DEFAULT_STREAM_TIMEOUT_MS: 30000` environment variable from the Agents workflow in [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/551/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) and reduces test job timeout from 20 to 10 minutes
- Changes worker type from "bot" to "bob" and reduces retry attempts from 3 to 1 in the agents test suite in [suites/agents/agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/551/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596)
- Modifies metric reporting structure by changing metric name from "agents" to "response" and reorganizing tags with `metric_type: "agent"` in [suites/agents/agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/551/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596)
- Updates Regression workflow schedule to run twice daily at midnight and noon UTC in [.github/workflows/Regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/551/files#diff-0ac4162fca393e5c27231d40a734df1b3adbe81f0db5d0841144208762aabfa9)
- Replaces built-in yarn cache with custom `actions/cache@v4` configuration for `node_modules` and `.yarn/cache` directories in [.github/workflows/NetworkChaos.yml](https://github.com/xmtp/xmtp-qa-tools/pull/551/files#diff-a08e0fe551d3a4f4ffc224df9c9226ba233075b6b3b8e888d60ed5958f5ed06d)

#### 📍Where to Start
Start with the `getWorkers` function call and `sendMetric` modifications in [suites/agents/agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/551/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596) to understand the core test logic changes.

----

_[Macroscope](https://app.macroscope.com) summarized 215f39a._