### PR TITLE
Disable built-in cache for external repository usage

### DIFF
--- a/.github/workflows/AgentExamplesRepo.yml
+++ b/.github/workflows/AgentExamplesRepo.yml
@@ -22,8 +22,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: "xmtp-agent-examples/yarn.lock"
+          # Disable built-in cache since we're working with external repo
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -2,9 +2,6 @@ name: Agents
 description: "should verify performance of the library in the production network"
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "*/15 * * * *" # Runs every 15 minutes
   workflow_dispatch:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -2,9 +2,6 @@ name: Regression
 description: "should verify last 3 versions of the library"
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 0,12 * * *" # Runs at midnight and noon UTC every day
   workflow_dispatch:

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".node-version"
-          cache: "yarn"
+          # Disable built-in cache to use shared cache below
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v4;g
         with:
           path: |
             node_modules

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -16,7 +16,7 @@ jobs:
           node-version-file: ".node-version"
           # Disable built-in cache to use shared cache below
       - name: Cache dependencies
-        uses: actions/cache@v4;g
+        uses: actions/cache@v4
         with:
           path: |
             node_modules


### PR DESCRIPTION
### Disable built-in cache for external repository usage in GitHub Actions workflows
- Removes built-in yarn cache configuration from Node.js setup actions in [.github/workflows/AgentExamplesRepo.yml](https://github.com/xmtp/xmtp-qa-tools/pull/552/files#diff-d959c01804b01732c2a157b427cde461debc516b6f7b20265e03c7343e1bf525) and [.github/workflows/validate-code-quality.yml](https://github.com/xmtp/xmtp-qa-tools/pull/552/files#diff-cb2e4ffa22b3e39d0a7d4a6f0af4e074bb380818c4cb8cc13268ba5ddf381fe9) when working with external repositories
- Removes pull request triggers from [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/552/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) and [.github/workflows/Regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/552/files#diff-0ac4162fca393e5c27231d40a734df1b3adbe81f0db5d0841144208762aabfa9), leaving only scheduled and manual dispatch triggers

#### 📍Where to Start
Start with the Node.js setup action configuration in [.github/workflows/AgentExamplesRepo.yml](https://github.com/xmtp/xmtp-qa-tools/pull/552/files#diff-d959c01804b01732c2a157b427cde461debc516b6f7b20265e03c7343e1bf525) to see the cache removal changes.

----

_[Macroscope](https://app.macroscope.com) summarized e61e624._