### PR TITLE
Refactor debug logs for clarity and relevance

### DIFF
--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -63,7 +63,6 @@ describe(testName, () => {
           );
 
           if (result?.allReceived) {
-            console.warn("result?.allReceived");
             agentResponded = true;
             break;
           }
@@ -81,7 +80,7 @@ describe(testName, () => {
 
         console.warn(
           "lastMessage",
-          messages[messages.length - 1].content,
+          JSON.stringify(messages[messages.length - 1].content, null, 2),
           "received in",
           result?.averageEventTiming,
         );

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -398,9 +398,13 @@ export class WorkerClient extends Worker {
         try {
           const stream = await this.client.conversations.streamAllMessages();
           for await (const message of stream) {
+            // console.debug(
+            //   `[${this.nameId}] Received message`,
+            //   JSON.stringify(message, null, 2),
+            // );
             console.debug(
               `[${this.nameId}] Received message`,
-              JSON.stringify(message, null, 2),
+              JSON.stringify(message?.content, null, 2),
             );
             if (!this.activeStreams) break;
 
@@ -761,9 +765,6 @@ export class WorkerClient extends Worker {
         );
 
         if (msg.type !== StreamCollectorType.Message) {
-          console.debug(
-            `[${this.nameId}] Message filtered out: wrong type ${msg.type}`,
-          );
           return false;
         }
 
@@ -773,10 +774,6 @@ export class WorkerClient extends Worker {
         const idsMatch = groupId === conversationId;
         const typeIsText =
           contentType?.typeId === "text" || contentType?.typeId === "reply";
-
-        console.debug(
-          `[${this.nameId}] Message filter check: conversationId=${conversationId}, expectedId=${groupId}, idsMatch=${idsMatch}, contentType=${contentType?.typeId}, typeIsText=${typeIsText}`,
-        );
 
         const shouldAccept = idsMatch && typeIsText;
 


### PR DESCRIPTION
### Refactor debug logs for clarity and relevance by removing verbose debug statements and improving JSON formatting in test and worker files
- Removes verbose debug log statements from [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/572/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) including message filtering details and entire message object logging
- Modifies message stream handler in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/572/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) to log only message content instead of entire message objects
- Updates console logging in [suites/agents/agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/572/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596) by removing `result?.allReceived` warning and adding JSON.stringify formatting with indentation to message content logging

#### 📍Where to Start
Start with the message stream handler in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/572/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) where the primary logging changes occur.

----

_[Macroscope](https://app.macroscope.com) summarized 4e2f930._