### PR TITLE
Update link for agents tested in notifications

### DIFF
--- a/helpers/notifications.ts
+++ b/helpers/notifications.ts
@@ -187,7 +187,7 @@ class SlackNotifier {
 
   private generateCustomLinks(testName: string): string {
     if (testName.toLowerCase().includes("agents")) {
-      return "*Agents tested:* <https://github.com/xmtp/xmtp-qa-tools/blob/main/suites/at_agents/production.json|View file>";
+      return "*Agents tested:* <https://github.com/xmtp/xmtp-qa-tools/blob/main/inboxes/agents.json|View file>";
     }
     return "";
   }


### PR DESCRIPTION
### Update agents tested link URL in SlackNotifier.generateCustomLinks method from production.json to agents.json
The `generateCustomLinks` method in the `SlackNotifier` class updates the URL for the 'Agents tested' link from 'https://github.com/xmtp/xmtp-qa-tools/blob/main/suites/at_agents/production.json' to 'https://github.com/xmtp/xmtp-qa-tools/blob/main/inboxes/agents.json' in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/578/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc).

#### 📍Where to Start
Start with the `generateCustomLinks` method in the `SlackNotifier` class in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/578/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc).

----

_[Macroscope](https://app.macroscope.com) summarized d6bbad4._