### PR TITLE
Improve test lifecycle setup for chaos tests

### DIFF
--- a/suites/chaos/commits.test.ts
+++ b/suites/chaos/commits.test.ts
@@ -23,11 +23,12 @@ Stress test XMTP group consensus by hammering multiple groups with concurrent op
 */
 
 import { getTime } from "@helpers/logger";
+import { setupTestLifecycle } from "@helpers/vitest";
 import { getRandomInboxIds } from "@inboxes/utils";
 import { typeOfResponse, typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const groupCount = 5;
 const batchSize = 4;
@@ -51,6 +52,11 @@ const workerNames = [
 describe("commits", () => {
   let workers: WorkerManager;
   let creator: Worker;
+
+  setupTestLifecycle({
+    testName: "commits",
+    expect,
+  });
 
   const createOperations = (
     worker: Worker,

--- a/suites/chaos/run.sh
+++ b/suites/chaos/run.sh
@@ -18,22 +18,22 @@ rm -rf logs/
 rm -rf .data/
 
 echo "Starting test cycle at $(date)"
-for i in {1..20}; do
-        echo "Running test iteration $i of 100"
-        yarn test suites/chaos/commits.test.ts --debug-verbose --no-fail
-        exit_code=$?
-        
-        # # Check for forks after each test
-        # fork_count=$(detect_forks)
-        # # echo "Fork detection: Found $fork_count fork mentions in logs"
-        
-        # if [ $fork_count -gt 0 ]; then
-        #     echo "FORK DETECTED! Found $fork_count fork occurrences. Stopping test cycle."
-        #     # exit 1
-        # fi
-        
-        # Continue regardless of test pass/fail - only Ctrl+C (handled by trap) should stop
-        echo "Test iteration $i completed with exit code $exit_code"
+for i in {1..50}; do
+    echo "Running test iteration $i of 100"
+    yarn test suites/chaos/commits.test.ts --debug --no-fail
+    exit_code=$?
+    
+    # # Check for forks after each test
+    # fork_count=$(detect_forks)
+    # # echo "Fork detection: Found $fork_count fork mentions in logs"
+    
+    # if [ $fork_count -gt 0 ]; then
+    #     echo "FORK DETECTED! Found $fork_count fork occurrences. Stopping test cycle."
+    #     # exit 1
+    # fi
+    
+    # Continue regardless of test pass/fail - only Ctrl+C (handled by trap) should stop
+    echo "Test iteration $i completed with exit code $exit_code"
 done
  
  


### PR DESCRIPTION
### Improve test lifecycle setup for chaos tests by adding `setupTestLifecycle` function to commits test and increasing test iterations from 20 to 50 in run script
- Adds `setupTestLifecycle` function call with `testName: "commits"` parameter to [suites/chaos/commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/588/files#diff-6cb4c3f574fff7ce21b21c55ed6c1118bafa2a3821f321bbec20486c31b44523) and imports required dependencies from `@helpers/vitest` and `vitest`
- Modifies [suites/chaos/run.sh](https://github.com/xmtp/xmtp-qa-tools/pull/588/files#diff-d9bc8fa0cdf95936259132015d6c9c8755a177168c3d70dd632ee0741fd0704e) to increase test iterations from 20 to 50 and changes debug flag from `--debug-verbose` to `--debug`

#### 📍Where to Start
Start with the `setupTestLifecycle` function call in [suites/chaos/commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/588/files#diff-6cb4c3f574fff7ce21b21c55ed6c1118bafa2a3821f321bbec20486c31b44523) to understand the test lifecycle setup changes.

----

_[Macroscope](https://app.macroscope.com) summarized 89e32ef._