### PR TITLE
Refactor test to simplify group operation handling

### DIFF
--- a/suites/commits/README.md
+++ b/suites/commits/README.md
@@ -10,7 +10,6 @@
 
 - Create 5 groups in parallel
 - Add all workers as super admins to each group
-
 - **Loop until epoch 100:**
   - Run 4 random operations simultaneously:
     - Update group name
@@ -18,7 +17,8 @@
     - Send message (random message)
     - Create new installation (random installation) (this is a new installation for the group)
   - Sync group and check epoch progress
-  - Log stats every 20 operations
+  - Log epoch every 20 operations
+- Save the logs in `logs/cleaned`
 
 **Purpose:**
 Stress test XMTP group consensus by hammering multiple groups with concurrent operations to verify system stability under chaos conditions.
@@ -28,11 +28,21 @@ Stress test XMTP group consensus by hammering multiple groups with concurrent op
 ```bash
 # Installation For a faster download with just the latest code
 git clone --depth=1 https://github.com/xmtp/xmtp-qa-tools
+
+# Go to the project directory
 cd xmtp-qa-tools
+
+# Install the dependencies
 yarn install
+
+# Start the local environment
 ./dev/up
-yarn local-update
+
+# Run the test
 yarn run:commits
+
+# When the test ends fork logs will be stored in
+# logs/cleaned
 ```
 
 # Current Status

--- a/suites/commits/run.sh
+++ b/suites/commits/run.sh
@@ -13,7 +13,7 @@ rm -rf .data/
 echo "Starting test cycle at $(date)"
 for ((i=1; i<=num_runs; i++)); do
     echo "Running test iteration $i of $num_runs"
-    yarn test suites/commits/commits.test.ts  --no-fail
+    yarn test suites/commits/commits.test.ts  --no-fail --debug
     exit_code=$?
     
     # Continue regardless of test pass/fail - only Ctrl+C (handled by trap) should stop


### PR DESCRIPTION
### Remove member management operations from commits test to simplify group operation handling
- Removes `addMember` and `removeMember` operations from the `createOperations` function in [commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/594/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca), eliminating member management functionality from the test
- Changes group initialization to use empty array instead of random inbox IDs, removing dependencies on `getRandomInboxIds` utility
- Updates documentation in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/594/files#diff-603b1b0d6bf32f8659531afdcb0b060e6c9cce7c28533354487499f72598443f) to reflect logging changes from stats to epoch information and adds detailed installation instructions
- Adds `--debug` flag to test execution command in [run.sh](https://github.com/xmtp/xmtp-qa-tools/pull/594/files#diff-e697561a4ead7f76457ad22ca3262a8acf49c83ab9f34bcfb78d0f5c2142569e)

#### 📍Where to Start
Start with the `createOperations` function in [commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/594/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca) to see how the member management operations have been removed.

----

_[Macroscope](https://app.macroscope.com) summarized 5f2c85b._