### PR TITLE
Refactor test flow for clarity and efficiency

### DIFF
--- a/suites/commits/README.md
+++ b/suites/commits/README.md
@@ -1,27 +1,19 @@
 # Chaos Test: Concurrent Group Operations
 
-**Setup:**
-
-- 5 groups, 5 workers, 30 random members
-- Target: reach epoch 100 per group (epoch is a measure of how many times the group has been updated)
-- 4 concurrent operations per batch
+Stress test XMTP group consensus by hammering multiple groups with concurrent operations to verify system stability under chaos conditions.
 
 **Test Flow:**
 
 - Create 5 groups in parallel
-- Add all workers as super admins to each group
-
-- **Loop until epoch 100:**
-  - Run 4 random operations simultaneously:
+- Add 10 workers as super admins to each group
+- Loop each group until epoch 100:
+  - Choose random worker and syncAll conversations
+  - Run between 2 random operations:
     - Update group name
-    - Add/remove random member (random member is a random inbox id)
     - Send message (random message)
-    - Create new installation (random installation) (this is a new installation for the group)
-  - Sync group and check epoch progress
-  - Log stats every 20 operations
-
-**Purpose:**
-Stress test XMTP group consensus by hammering multiple groups with concurrent operations to verify system stability under chaos conditions.
+  - Sync group
+  - Log epoch progress
+- Clean logs and export forks
 
 ## Download the code
 
@@ -29,15 +21,13 @@ Stress test XMTP group consensus by hammering multiple groups with concurrent op
 # Installation For a faster download with just the latest code
 git clone --depth=1 https://github.com/xmtp/xmtp-qa-tools
 cd xmtp-qa-tools
+
+# Install dependencies
 yarn install
+
+# Start local network
 ./dev/up
-yarn local-update
+
+# Run the test
 yarn run:commits
 ```
-
-# Current Status
-
-| Runs | Forks | Percentage |
-| ---- | ----- | ---------- |
-| 100  | 25    | 25%        |
-| 100  | 22    | 25%        |

--- a/suites/commits/README.md
+++ b/suites/commits/README.md
@@ -15,7 +15,7 @@ Stress test XMTP group consensus by hammering multiple groups with concurrent op
   - Log epoch progress
 - Clean logs and export forks
 
-## Download the code
+## Test setup
 
 ```bash
 # Installation For a faster download with just the latest code

--- a/suites/commits/commits.test.ts
+++ b/suites/commits/commits.test.ts
@@ -47,22 +47,22 @@ describe("commits", () => {
         ),
       createInstallation: () =>
         getGroup().then(() => worker.worker.addNewInstallation()),
-      addMember: () =>
-        getGroup().then((g) =>
-          g.addMembers([
-            availableMembers[
-              Math.floor(Math.random() * availableMembers.length)
-            ],
-          ]),
-        ),
-      removeMember: () =>
-        getGroup().then((g) =>
-          g.removeMembers([
-            availableMembers[
-              Math.floor(Math.random() * availableMembers.length)
-            ],
-          ]),
-        ),
+      // addMember: () =>
+      //   getGroup().then((g) =>
+      //     g.addMembers([
+      //       availableMembers[
+      //         Math.floor(Math.random() * availableMembers.length)
+      //       ],
+      //     ]),
+      //   ),
+      // removeMember: () =>
+      //   getGroup().then((g) =>
+      //     g.removeMembers([
+      //       availableMembers[
+      //         Math.floor(Math.random() * availableMembers.length)
+      //       ],
+      //     ]),
+      //   ),
       sendMessage: () =>
         getGroup().then((g) =>
           g.send(`Message from ${worker.name}`).then(() => {}),


### PR DESCRIPTION
### Remove member management operations from commits test suite and update test configuration to use 10 workers with 2 concurrent operations
The commits test suite removes member management functionality by commenting out `addMember` and `removeMember` operations in the `createOperations` function within [commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/598/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca). The test configuration changes from 5 to 10 workers and reduces concurrent operations from 4 to 2. Documentation in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/598/files#diff-603b1b0d6bf32f8659531afdcb0b060e6c9cce7c28533354487499f72598443f) reflects these changes and adds steps for cleaning logs and exporting forks while removing the detailed setup section and current status table.

#### 📍Where to Start
Start with the `createOperations` function in [commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/598/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca) to see the commented out member management operations.

----

_[Macroscope](https://app.macroscope.com) summarized 1d71c4c._