### PR TITLE
Increase group count and improve worker operations logic

### DIFF
--- a/inboxes/agents.json
+++ b/inboxes/agents.json
@@ -7,6 +7,12 @@
     "disabled": false
   },
   {
+    "name": "mamo.base.eth",
+    "address": "0x99B10779557cc52c6E3a97C9A6C3446f021290cc",
+    "sendMessage": "hi",
+    "networks": ["production"]
+  },
+  {
     "name": "squabble",
     "address": "0x557463B158F70e4E269bB7BCcF6C587e3BC878F4",
     "sendMessage": "@squabble.base.eth",

--- a/suites/commits/commits.test.ts
+++ b/suites/commits/commits.test.ts
@@ -4,8 +4,7 @@ import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const groupCount = 2;
-const batchSize = 4;
+const groupCount = 5;
 const TARGET_EPOCH = 100n;
 const workerNames = [
   "random1",
@@ -13,6 +12,11 @@ const workerNames = [
   "random3",
   "random4",
   "random5",
+  "random6",
+  "random7",
+  "random8",
+  "random9",
+  "random10",
 ] as string[];
 
 describe("commits", () => {
@@ -45,28 +49,22 @@ describe("commits", () => {
         let currentEpoch = 0n;
 
         while (currentEpoch < TARGET_EPOCH) {
-          const parallelOperations = Array.from({ length: batchSize }, () =>
-            (async () => {
-              try {
-                const randomWorker =
-                  allWorkers[Math.floor(Math.random() * allWorkers.length)];
+          try {
+            const randomWorker =
+              allWorkers[Math.floor(Math.random() * allWorkers.length)];
 
-                await randomWorker.client.conversations.syncAll();
-                const groupFromWorker =
-                  (await randomWorker.client.conversations.getConversationById(
-                    group.id,
-                  )) as Group;
+            await randomWorker.client.conversations.syncAll();
+            const groupFromWorker =
+              (await randomWorker.client.conversations.getConversationById(
+                group.id,
+              )) as Group;
 
-                await groupFromWorker.updateName(
-                  `${getTime()} - ${randomWorker.name} Update`,
-                );
-              } catch (e) {
-                console.log(`Group ${groupIndex + 1} operation failed:`, e);
-              }
-            })(),
-          );
-
-          await Promise.all(parallelOperations);
+            await groupFromWorker.updateName(
+              `${getTime()} - ${randomWorker.name}`,
+            );
+          } catch (e) {
+            console.log(`Group ${groupIndex + 1} operation failed:`, e);
+          }
 
           await group.sync();
           const debugInfo = await group.debugInfo();


### PR DESCRIPTION
### Increase group count from 2 to 5 and remove parallel batch processing in commits test to improve worker operations logic
- Modifies the `groupCount` constant from 2 to 5 in [suites/commits/commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/601/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca) and removes the parallel batch processing approach by eliminating the `batchSize` constant and `Promise.all` operations, replacing them with single random worker operations per iteration
- Adds a new agent configuration for 'mamo.base.eth' with address "0x99B10779557cc52c6E3a97C9A6C3446f021290cc" and production network settings in [inboxes/agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/601/files#diff-3634e818269936c77bb56f02a82724cc70c7024526483adf799e55a90c6f1621)

#### 📍Where to Start
Start with the test logic modifications in [suites/commits/commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/601/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca) where the `groupCount` constant is changed and the parallel batch processing is removed.

----

_[Macroscope](https://app.macroscope.com) summarized 8ced8dd._