### PR TITLE
Tag @fabri for multiple test failures in notifications

### DIFF
--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -460,6 +460,14 @@ function processErrorLine(line: string): {
 
   cleanLine = cleanLine.replace("expected false to be true", "failed").trim();
 
+  if (cleanLine.length < 30) {
+    return { cleanLine, shouldSkip: true };
+  }
+  // Trim long lines to 200 characters max
+  if (cleanLine.length > 150) {
+    cleanLine = cleanLine.substring(0, 147) + "...";
+  }
+
   return { cleanLine, shouldSkip: false };
 }
 

--- a/helpers/notifications.ts
+++ b/helpers/notifications.ts
@@ -226,8 +226,13 @@ class SlackNotifier {
     const errorLogsArr = Array.from(options.errorLogs || []);
     const logs = this.sanitizeLogs(errorLogsArr.join("\n"));
 
+    // Check if we need to tag @fabri for multiple failures
+    const failLines = this.extractFailLines(options.errorLogs || new Set());
+    const shouldTagFabri = failLines.length > 3;
+    const tagMessage = shouldTagFabri ? " <@fabri>" : "";
+
     const sections = [
-      "*Test Failure ❌*",
+      `*Test Failure ❌*${tagMessage}`,
       `*Test:* <${URLS.GITHUB_ACTIONS}/${this.githubContext.repository}/actions/workflows/${this.githubContext.workflowName}.yml|${upperCaseTestName}>`,
       `*Environment:* \`${this.githubContext.environment}\``,
       `*General dashboard:* <${URLS.DATADOG_DASHBOARD}|View>`,

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -95,8 +95,4 @@ describe(testName, async () => {
       throw e;
     }
   });
-
-  // it("fail on purpose", () => {
-  //   expect(false).toBe(true);
-  // });
 });


### PR DESCRIPTION
### Tag @fabri in Slack notifications when test failures exceed 3 failure lines in helpers/notifications.ts
Modifies the Slack notification system to conditionally tag a specific user (@fabri) when multiple test failures are detected. The changes add logic to extract failure lines from error logs using a new `extractFailLines` method, check if the number of failure lines exceeds 3, and append a tag message to the notification title when the threshold is met. The notification message format changes from `*Test Failure ❌*` to `*Test Failure ❌*${tagMessage}` when tagging is triggered. See [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/607/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc).

#### 📍Where to Start
Start with the modified Slack notification logic in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/607/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc) where the `extractFailLines` method is called and the conditional tagging logic is implemented.

----

_[Macroscope](https://app.macroscope.com) summarized b76de2b._