### PR TITLE
bump version to 0.2.0 for new feature release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.1.45",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
### Bump package version from 0.1.44 to 0.2.0 for new feature release in package.json
The version field in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/613/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) is updated from "0.1.44" to "0.2.0", representing a minor version increment according to semantic versioning.

#### 📍Where to Start
Start with the version field in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/613/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized b77d2a3._