### PR TITLE
Remove outdated callback test and failing assertion

### DIFF
--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -3,7 +3,7 @@ description: "should verify message loss when receiving via 200 streams"
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Runs at midnight UTC every day
+    - cron: "0 */6 * * *" # Runs every 6 hours at 00:00, 06:00, 12:00, 18:00 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn script versions
       - name: Run tests
         run: yarn test ${{ matrix.test }} --no-fail --debug
-      - name: Upload test artifacts
+source ~/.bashrc;pr_push      - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -3,7 +3,7 @@ description: "should verify last 3 versions of the library"
 
 on:
   schedule:
-    - cron: "0 0,12 * * *" # Runs at midnight and noon UTC every day
+    - cron: "0 */6 * * *" # Runs every 6 hours
   workflow_dispatch:
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
         run: yarn script versions
       - name: Run tests
         run: yarn test ${{ matrix.test }} --no-fail --debug
-source ~/.bashrc;pr_push      - name: Upload test artifacts
+      - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/deploy-metadata.json
+++ b/deploy-metadata.json
@@ -1,1 +1,1 @@
-{"deployedAt": "2025-06-24T20:32:27Z", "version": "0.2.0"}
+{ "deployedAt": "2025-06-24T20:32:27Z", "version": "0.2.0" }

--- a/suites/functional/callbacks.test.ts
+++ b/suites/functional/callbacks.test.ts
@@ -127,33 +127,33 @@ describe(testName, async () => {
     expect(conversation.id).toBe(convo.id);
   });
 
-  it("should receive conversation with callback", async () => {
-    const receiver = workers.get(names[1])!;
+  // it("should receive conversation with callback", async () => {
+  //   const receiver = workers.get(names[1])!;
 
-    // Set up stream first
-    const conversationPromise = new Promise<Dm>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error("Timeout waiting for conversation"));
-      }, 5000);
+  //   // Set up stream first
+  //   const conversationPromise = new Promise<Dm>((resolve, reject) => {
+  //     const timeout = setTimeout(() => {
+  //       reject(new Error("Timeout waiting for conversation"));
+  //     }, 5000);
 
-      void receiver.client.conversations.stream((err, conversation) => {
-        if (err) {
-          clearTimeout(timeout);
-          reject(err instanceof Error ? err : new Error(String(err)));
-          return;
-        }
-        console.log("Callback received conversation:", conversation?.id);
-        if (conversation?.id) {
-          clearTimeout(timeout);
-          resolve(conversation as Dm);
-          return;
-        }
-      });
-    });
+  //     void receiver.client.conversations.stream((err, conversation) => {
+  //       if (err) {
+  //         clearTimeout(timeout);
+  //         reject(err instanceof Error ? err : new Error(String(err)));
+  //         return;
+  //       }
+  //       console.log("Callback received conversation:", conversation?.id);
+  //       if (conversation?.id) {
+  //         clearTimeout(timeout);
+  //         resolve(conversation as Dm);
+  //         return;
+  //       }
+  //     });
+  //   });
 
-    // Create group after stream is ready
-    await workers.createGroup();
-    const conversation = await conversationPromise;
-    expect(conversation.id).toBeDefined();
-  });
+  //   // Create group after stream is ready
+  //   await workers.createGroup();
+  //   const conversation = await conversationPromise;
+  //   expect(conversation.id).toBeDefined();
+  // });
 });

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -95,7 +95,4 @@ describe(testName, async () => {
       throw e;
     }
   });
-  it("fail on purpose", () => {
-    expect(false).toBe(true);
-  });
 });


### PR DESCRIPTION
### Remove outdated callback test and failing assertion from functional test suites
- Disables the 'should receive conversation with callback' test case in [callbacks.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/618/files#diff-d0f3ce0ad22dcd8186ce7fd5e75a96781c1b7e16aa9eb95f2ec1526bd3ce1eec) by commenting out the entire test
- Removes the deliberately failing 'fail on purpose' test case from [dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/618/files#diff-bf59a0998d74f48f9c0cc7364d9e3f1234650add19ae4908dc573a9064092181)
- Changes GitHub workflow schedules from daily/twice-daily to every 6 hours in [Functional.yml](https://github.com/xmtp/xmtp-qa-tools/pull/618/files#diff-a1f32d9141b58464309cfc532a2528f90960df9b7ec194da3b443710e8805b88) and [Regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/618/files#diff-0ac4162fca393e5c27231d40a734df1b3adbe81f0db5d0841144208762aabfa9)
- Adds formatting spaces to [deploy-metadata.json](https://github.com/xmtp/xmtp-qa-tools/pull/618/files#diff-fb51b529bd1ae4412ebc7ad235f545cea09c61747be7aa7a947430f3735fa0c9)

#### 📍Where to Start
Start with the commented out test case in [callbacks.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/618/files#diff-d0f3ce0ad22dcd8186ce7fd5e75a96781c1b7e16aa9eb95f2ec1526bd3ce1eec) to understand the disabled callback functionality test.

----

_[Macroscope](https://app.macroscope.com) summarized 8073efd._