### PR TITLE
Add new functional test error patterns for analysis

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -24,6 +24,13 @@ export const PATTERNS = {
       ],
     },
     {
+      testName: "Functional",
+      uniqueErrorLines: [
+        "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation with async",
+        "FAIL  suites/functional/playwright.test.ts > playwright > newGroup and message stream",
+      ],
+    },
+    {
       testName: "Agents",
       uniqueErrorLines: [
         "FAIL  suites/agents/agents.test.ts > agents > production: byte : 0xdfc00a0B28Df3c07b0942300E896C97d62014499",


### PR DESCRIPTION
### Add two new functional test error patterns to the KNOWN_ISSUES array in helpers/analyzer.ts for analysis tracking
This change adds a new entry to the `KNOWN_ISSUES` array within the `PATTERNS` object in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/628/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193). The new entry includes a `testName` of "Functional" and contains two `uniqueErrorLines` that track specific test failures: one for callbacks tests in `suites/functional/callbacks.test.ts` and another for playwright tests in `suites/functional/playwright.test.ts`.

#### 📍Where to Start
Start with the `PATTERNS.KNOWN_ISSUES` array in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/628/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) to see the newly added functional test error patterns.

----

_[Macroscope](https://app.macroscope.com) summarized 4da6b76._