### PR TITLE
Add workers parameter to test lifecycle setup

### DIFF
--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -46,6 +46,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     expect,
+    workers,
   });
 
   it("verifyMessageStream: should verify message delivery and order accuracy using message streams", async () => {

--- a/suites/metrics/large/conversations.test.ts
+++ b/suites/metrics/large/conversations.test.ts
@@ -38,6 +38,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     expect,
+    workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {
       customDuration = v;

--- a/suites/metrics/large/cumulative_syncs.test.ts
+++ b/suites/metrics/large/cumulative_syncs.test.ts
@@ -36,6 +36,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     expect,
+    workers,
     getCustomDuration: () => customDuration,
     setCustomDuration,
   });

--- a/suites/metrics/large/membership.test.ts
+++ b/suites/metrics/large/membership.test.ts
@@ -38,6 +38,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     expect,
+    workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {
       customDuration = v;

--- a/suites/metrics/large/messages.test.ts
+++ b/suites/metrics/large/messages.test.ts
@@ -37,6 +37,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     expect,
+    workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {
       customDuration = v;

--- a/suites/metrics/large/metadata.test.ts
+++ b/suites/metrics/large/metadata.test.ts
@@ -38,6 +38,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     expect,
+    workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {
       customDuration = v;

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -36,6 +36,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     expect,
+    workers,
     getCustomDuration: () => customDuration,
     setCustomDuration,
   });


### PR DESCRIPTION
### Add workers parameter to setupTestLifecycle function calls across metrics test suites
This change adds the `workers` parameter to `setupTestLifecycle` function calls across seven test files in the metrics test suites. The modification passes the previously defined workers object to the test lifecycle setup function in each test file:

- [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916)
- [suites/metrics/large/conversations.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-f72fc3206f89f719d01f76421266910ee1760fdbb39f84feeb134e86d8cfed16)
- [suites/metrics/large/cumulative_syncs.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-429345fdc4ac97ee978d17634e358c726a02d163e0499a086da8a10859e03ed9)
- [suites/metrics/large/membership.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-83e544a0f8e211d6a9a4c1836a054791f9a5ac667a837127851d45ef0a967864)
- [suites/metrics/large/messages.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-0306739b310388523cd78ca9335cca073dd5482327fb9aba3eacfe92b7142940)
- [suites/metrics/large/metadata.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-6ca513d58138b016a6b0fb09eba8fd88bb0fe23b26f7ee9b21d93de1a505df4a)
- [suites/metrics/large/syncs.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-82af031f05768910e2b17f121a74d9b12c5733d36988255d34fa15ccac4bfcfd)

#### 📍Where to Start
Start with any of the modified test files, such as [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/629/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916), to see how the `setupTestLifecycle` function call has been updated to include the workers parameter.

----

_[Macroscope](https://app.macroscope.com) summarized e1949bc._