### PR TITLE
Refactor notification imports for better organization

### DIFF
--- a/helpers/notifications.ts
+++ b/helpers/notifications.ts
@@ -1,3 +1,4 @@
+import { PATTERNS } from "@helpers/analyzer";
 import fetch from "node-fetch";
 import {
   extractFailLines,
@@ -5,7 +6,6 @@ import {
   shouldFilterOutTest,
 } from "./analyzer";
 import { sendDatadogLog } from "./datadog";
-import { PATTERNS } from "./patterns";
 
 // Configuration
 const URLS = {


### PR DESCRIPTION
### Update PATTERNS import path from relative import to module alias in helpers/notifications.ts for better organization
Changes the import source for the `PATTERNS` constant in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/634/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc) from a relative path `'./patterns'` to a module alias `'@helpers/analyzer'`.

#### 📍Where to Start
Start with the import statements at the top of [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/634/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc) to see the updated import path for `PATTERNS`.

----

_[Macroscope](https://app.macroscope.com) summarized b4131d0._