### PR TITLE
Add support for XMTP SDK version 3.0.0 features

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -150,7 +150,7 @@ export const sdkVersions = {
     sdkPackage: "node-sdk-300",
     bindingsPackage: "node-bindings-124",
     sdkVersion: "3.0.0",
-    libXmtpVersion: "7b9b4d0",
+    libXmtpVersion: "df2f166",
   },
 };
 

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -50,6 +50,12 @@ import {
   Group as Group220,
 } from "@xmtp/node-sdk-220";
 import {
+  Client as Client300,
+  Conversation as Conversation300,
+  Dm as Dm300,
+  Group as Group300,
+} from "@xmtp/node-sdk-300";
+import {
   Client as ClientMls,
   Conversation as ConversationMls,
 } from "@xmtp/node-sdk-mls";
@@ -63,6 +69,90 @@ import {
 import { sepolia } from "viem/chains";
 import { initDataDog } from "./datadog";
 import { addFileLogging, setupPrettyLogs } from "./logger";
+
+// SDK version mappings
+export const sdkVersions = {
+  30: {
+    Client: ClientMls,
+    Conversation: ConversationMls,
+    Dm: ConversationMls,
+    Group: ConversationMls,
+    sdkPackage: "node-sdk-mls",
+    bindingsPackage: "node-bindings-mls",
+    sdkVersion: "0.0.13",
+    libXmtpVersion: "0.0.9",
+  },
+  47: {
+    Client: Client47,
+    Conversation: Conversation47,
+    Dm: Dm47,
+    Group: Group47,
+    sdkPackage: "node-sdk-47",
+    bindingsPackage: "node-bindings-41",
+    sdkVersion: "0.0.47",
+    libXmtpVersion: "6bd613d",
+  },
+  100: {
+    Client: Client100,
+    Conversation: Conversation100,
+    Dm: Dm100,
+    Group: Group100,
+    sdkPackage: "node-sdk-100",
+    bindingsPackage: "node-bindings-100",
+    sdkVersion: "1.0.0",
+    libXmtpVersion: "c205eec",
+  },
+  105: {
+    Client: Client105,
+    Conversation: Conversation105,
+    Dm: Dm105,
+    Group: Group105,
+    sdkPackage: "node-sdk-105",
+    bindingsPackage: "node-bindings-113",
+    sdkVersion: "1.0.5",
+    libXmtpVersion: "6eb1ce4",
+  },
+  209: {
+    Client: Client209,
+    Conversation: Conversation209,
+    Dm: Dm209,
+    Group: Group209,
+    sdkPackage: "node-sdk-209",
+    bindingsPackage: "node-bindings-118",
+    sdkVersion: "2.0.9",
+    libXmtpVersion: "bfadb76",
+  },
+  210: {
+    Client: Client210,
+    Conversation: Conversation210,
+    Dm: Dm210,
+    Group: Group210,
+    sdkPackage: "node-sdk-210",
+    bindingsPackage: "node-bindings-120",
+    sdkVersion: "2.1.0",
+    libXmtpVersion: "7b9b4d0",
+  },
+  220: {
+    Client: Client220,
+    Conversation: Conversation220,
+    Dm: Dm220,
+    Group: Group220,
+    sdkPackage: "node-sdk-220",
+    bindingsPackage: "node-bindings-122",
+    sdkVersion: "2.2.0",
+    libXmtpVersion: "d0f0b67",
+  },
+  300: {
+    Client: Client300,
+    Conversation: Conversation300,
+    Dm: Dm300,
+    Group: Group300,
+    sdkPackage: "node-sdk-300",
+    bindingsPackage: "node-bindings-124",
+    sdkVersion: "3.0.0",
+    libXmtpVersion: "7b9b4d0",
+  },
+};
 
 export type GroupMetadataContent = {
   metadataFieldChanges: Array<{
@@ -426,80 +516,6 @@ export interface LogInfo {
   message: string;
   [key: symbol]: string | undefined;
 }
-
-// SDK version mappings
-export const sdkVersions = {
-  30: {
-    Client: ClientMls,
-    Conversation: ConversationMls,
-    Dm: ConversationMls,
-    Group: ConversationMls,
-    sdkPackage: "node-sdk-mls",
-    bindingsPackage: "node-bindings-mls",
-    sdkVersion: "0.0.13",
-    libXmtpVersion: "0.0.9",
-  },
-  47: {
-    Client: Client47,
-    Conversation: Conversation47,
-    Dm: Dm47,
-    Group: Group47,
-    sdkPackage: "node-sdk-47",
-    bindingsPackage: "node-bindings-41",
-    sdkVersion: "0.0.47",
-    libXmtpVersion: "6bd613d",
-  },
-  100: {
-    Client: Client100,
-    Conversation: Conversation100,
-    Dm: Dm100,
-    Group: Group100,
-    sdkPackage: "node-sdk-100",
-    bindingsPackage: "node-bindings-100",
-    sdkVersion: "1.0.0",
-    libXmtpVersion: "c205eec",
-  },
-  105: {
-    Client: Client105,
-    Conversation: Conversation105,
-    Dm: Dm105,
-    Group: Group105,
-    sdkPackage: "node-sdk-105",
-    bindingsPackage: "node-bindings-113",
-    sdkVersion: "1.0.5",
-    libXmtpVersion: "6eb1ce4",
-  },
-  209: {
-    Client: Client209,
-    Conversation: Conversation209,
-    Dm: Dm209,
-    Group: Group209,
-    sdkPackage: "node-sdk-209",
-    bindingsPackage: "node-bindings-118",
-    sdkVersion: "2.0.9",
-    libXmtpVersion: "bfadb76",
-  },
-  210: {
-    Client: Client210,
-    Conversation: Conversation210,
-    Dm: Dm210,
-    Group: Group210,
-    sdkPackage: "node-sdk-210",
-    bindingsPackage: "node-bindings-120",
-    sdkVersion: "2.1.0",
-    libXmtpVersion: "7b9b4d0",
-  },
-  220: {
-    Client: Client220,
-    Conversation: Conversation220,
-    Dm: Dm220,
-    Group: Group220,
-    sdkPackage: "node-sdk-220",
-    bindingsPackage: "node-bindings-122",
-    sdkVersion: "2.2.0",
-    libXmtpVersion: "d0f0b67",
-  },
-};
 
 export const sdkVersionOptions = Object.keys(sdkVersions)
   .filter((key) => parseInt(key) >= 200)

--- a/package.json
+++ b/package.json
@@ -40,20 +40,22 @@
     "@slack/bolt": "^4.4.0",
     "@xmtp/content-type-reaction": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",
-    "@xmtp/node-bindings": "1.2.2",
+    "@xmtp/node-bindings": "1.2.4",
     "@xmtp/node-bindings-100": "npm:@xmtp/node-bindings@1.0.0",
     "@xmtp/node-bindings-113": "npm:@xmtp/node-bindings@1.1.3",
     "@xmtp/node-bindings-118": "npm:@xmtp/node-bindings@1.1.8",
     "@xmtp/node-bindings-120": "npm:@xmtp/node-bindings@1.2.0",
     "@xmtp/node-bindings-122": "npm:@xmtp/node-bindings@1.2.2",
+    "@xmtp/node-bindings-124": "npm:@xmtp/node-bindings@1.2.4",
     "@xmtp/node-bindings-41": "npm:@xmtp/node-bindings@0.0.41",
     "@xmtp/node-bindings-mls": "npm:@xmtp/mls-client-bindings-node@0.0.9",
-    "@xmtp/node-sdk": "2.2.1",
+    "@xmtp/node-sdk": "3.0.0",
     "@xmtp/node-sdk-100": "npm:@xmtp/node-sdk@1.0.0",
     "@xmtp/node-sdk-105": "npm:@xmtp/node-sdk@1.0.5",
     "@xmtp/node-sdk-209": "npm:@xmtp/node-sdk@2.0.9",
     "@xmtp/node-sdk-210": "npm:@xmtp/node-sdk@2.1.0",
     "@xmtp/node-sdk-220": "npm:@xmtp/node-sdk@2.2.1",
+    "@xmtp/node-sdk-300": "npm:@xmtp/node-sdk@3.0.0",
     "@xmtp/node-sdk-47": "npm:@xmtp/node-sdk@0.0.47",
     "@xmtp/node-sdk-mls": "npm:@xmtp/mls-client@0.0.13",
     "axios": "^1.8.2",
@@ -124,6 +126,11 @@
     "@xmtp/node-sdk@2.2.0": {
       "dependencies": {
         "@xmtp/node-bindings": "1.2.2"
+      }
+    },
+    "@xmtp/node-sdk@3.0.0": {
+      "dependencies": {
+        "@xmtp/node-bindings": "1.2.4"
       }
     }
   }

--- a/suites/other/nodetest.test.ts
+++ b/suites/other/nodetest.test.ts
@@ -286,7 +286,7 @@ describe("E2E: Installation syncing", () => {
           console.log(
             `installation ${installation.installationId} groups: ${groups.length}, members: ${members.flat().length}, messages: ${messages.flat().length}`,
           );
-          console.log(installation.apiStatistics());
+          console.log(installation.debugInformation.apiStatistics());
         }),
       );
       console.log("=================================================");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/node-bindings-124@npm:@xmtp/node-bindings@1.2.4, @xmtp/node-bindings@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@xmtp/node-bindings@npm:1.2.4"
+  checksum: 10/a2a06f5c8a520a63935395481a88f2d205ea3a5054b6a2fa3345c292287f3fe6129086c0e719783d3ef0ed98e7695eb9ef773bd21fb4e471076dd207313edc89
+  languageName: node
+  linkType: hard
+
 "@xmtp/node-bindings-41@npm:@xmtp/node-bindings@0.0.41, @xmtp/node-bindings@npm:^0.0.41":
   version: 0.0.41
   resolution: "@xmtp/node-bindings@npm:0.0.41"
@@ -1659,7 +1666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-220@npm:@xmtp/node-sdk@2.2.1, @xmtp/node-sdk@npm:2.2.1":
+"@xmtp/node-sdk-220@npm:@xmtp/node-sdk@2.2.1":
   version: 2.2.1
   resolution: "@xmtp/node-sdk@npm:2.2.1"
   dependencies:
@@ -1668,6 +1675,18 @@ __metadata:
     "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/node-bindings": "npm:1.2.2"
   checksum: 10/fe5a08fb679f7adbd1c31d3d14611f24231b4c50490f1ed5fe6c3b40fcd3654545deae58b5c29cb3e66b9b87787534131110903b3208b998c10f0251cfdb6cc2
+  languageName: node
+  linkType: hard
+
+"@xmtp/node-sdk-300@npm:@xmtp/node-sdk@3.0.0, @xmtp/node-sdk@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@xmtp/node-sdk@npm:3.0.0"
+  dependencies:
+    "@xmtp/content-type-group-updated": "npm:^2.0.2"
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+    "@xmtp/content-type-text": "npm:^2.0.2"
+    "@xmtp/node-bindings": "npm:1.2.4"
+  checksum: 10/4b579ec63bd785a3fc19d238517361d2df201d4bb7abe827b4c05895c754d0ec21c684859bce8ef6d66bc9a88cdcc20e520d516f81651e2cda964eaea9940e9c
   languageName: node
   linkType: hard
 
@@ -5425,20 +5444,22 @@ __metadata:
     "@vitest/ui": "npm:^3.2.4"
     "@xmtp/content-type-reaction": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.2"
+    "@xmtp/node-bindings": "npm:1.2.4"
     "@xmtp/node-bindings-100": "npm:@xmtp/node-bindings@1.0.0"
     "@xmtp/node-bindings-113": "npm:@xmtp/node-bindings@1.1.3"
     "@xmtp/node-bindings-118": "npm:@xmtp/node-bindings@1.1.8"
     "@xmtp/node-bindings-120": "npm:@xmtp/node-bindings@1.2.0"
     "@xmtp/node-bindings-122": "npm:@xmtp/node-bindings@1.2.2"
+    "@xmtp/node-bindings-124": "npm:@xmtp/node-bindings@1.2.4"
     "@xmtp/node-bindings-41": "npm:@xmtp/node-bindings@0.0.41"
     "@xmtp/node-bindings-mls": "npm:@xmtp/mls-client-bindings-node@0.0.9"
-    "@xmtp/node-sdk": "npm:2.2.1"
+    "@xmtp/node-sdk": "npm:3.0.0"
     "@xmtp/node-sdk-100": "npm:@xmtp/node-sdk@1.0.0"
     "@xmtp/node-sdk-105": "npm:@xmtp/node-sdk@1.0.5"
     "@xmtp/node-sdk-209": "npm:@xmtp/node-sdk@2.0.9"
     "@xmtp/node-sdk-210": "npm:@xmtp/node-sdk@2.1.0"
     "@xmtp/node-sdk-220": "npm:@xmtp/node-sdk@2.2.1"
+    "@xmtp/node-sdk-300": "npm:@xmtp/node-sdk@3.0.0"
     "@xmtp/node-sdk-47": "npm:@xmtp/node-sdk@0.0.47"
     "@xmtp/node-sdk-mls": "npm:@xmtp/mls-client@0.0.13"
     axios: "npm:^1.8.2"


### PR DESCRIPTION
### Add support for XMTP SDK version 3.0.0 by importing new classes and updating dependencies in helpers/client.ts and package.json
- Updates XMTP SDK dependencies from version 2.2.1 to 3.0.0 and node-bindings from 1.2.2 to 1.2.4 in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/638/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
- Imports `Client300`, `Conversation300`, `Dm300`, and `Group300` classes from `@xmtp/node-sdk-300` and adds version 300 configuration to `sdkVersions` object in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/638/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1)
- Modifies API statistics access pattern from `installation.apiStatistics()` to `installation.debugInformation.apiStatistics()` in [suites/other/nodetest.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/638/files#diff-0f42b27c8ffc0dc61b6b338c39a958c32b5fd06db9b5acf81d41116e38dfd798)

#### 📍Where to Start
Start with the `sdkVersions` object in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/638/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to understand the new SDK version 300 configuration and imported classes.

----

_[Macroscope](https://app.macroscope.com) summarized d42e5d5._