### PR TITLE
Limit concurrency in a single suite

### DIFF
--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -241,7 +241,7 @@ function buildTestCommand(
   // Base threading options for consecutive execution
   const threadingOptions = parallel
     ? ""
-    : "--pool=threads --poolOptions.singleThread=true --fileParallelism=false";
+    : "--pool=threads --poolOptions.singleThread=true --fileParallelism=false --maxConcurrency=1";
 
   if (testName === "functional") {
     const expandedFiles = expandGlobPattern("./suites/functional/*.test.ts");
@@ -280,7 +280,7 @@ function buildTestCommand(
 
   const defaultThreadingOptions = parallel
     ? "--pool=forks"
-    : "--pool=threads --poolOptions.singleThread=true --fileParallelism=false";
+    : "--pool=threads --poolOptions.singleThread=true --fileParallelism=false --maxConcurrency=1";
   return `npx vitest run ${testName} ${defaultThreadingOptions} ${vitestArgsString}`.trim();
 }
 


### PR DESCRIPTION
## tl;dr

- Limit the concurrency _inside_ a single test file to one when the `parallel` option is turned off.

I have a theory that concurrent writes to the same welcome topic from different batches in the same test file are causing this metric to be artificially slow. We take a lock on the installation ID of the recipient of welcomes, so there can only be one write happening at a time.