### PR TITLE
Enable specific operations for commit tests

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -55,6 +55,7 @@ export const PATTERNS = {
     "receiveGroupMessage",
     "receiveNewConversation",
     "Skipping welcome",
+    "Skipping already processed",
     "xmtp_mls::groups::key_package_cleaner_worker",
     "xmtp_mls::groups::mls_sync",
     "xmtp_mls::groups::welcome_sync",
@@ -168,7 +169,7 @@ export async function cleanAllRawLogs(): Promise<void> {
   const files = await fs.promises.readdir(logsDir);
   // Look for non-raw log files instead
   const nonRawLogFiles = files.filter(
-    (file) => !file.startsWith("raw-") && file.endsWith(".log"),
+    (file) => file.startsWith("raw-") && file.endsWith(".log"),
   );
 
   if (nonRawLogFiles.length === 0) {
@@ -195,7 +196,7 @@ export async function cleanAllRawLogs(): Promise<void> {
       }
 
       // Construct the corresponding raw filename
-      const rawFileName = `raw-${file}`;
+      const rawFileName = file;
       const rawFilePath = path.join(logsDir, rawFileName);
 
       // Check if the raw file exists

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -245,7 +245,7 @@ export const createTestLogger = (options: TestLogOptions) => {
       const cleanTestName = path
         .basename(options.testName)
         .replace(/\.test\.ts$/, "");
-      logFileName = `raw-${process.env.XMTP_ENV}-${cleanTestName}-${getTime()}.log`;
+      logFileName = `raw-${cleanTestName}-${process.env.XMTP_ENV}-${getTime()}.log`;
     }
 
     const logPath = path.join(logsDir, logFileName);

--- a/suites/commits/commits.test.ts
+++ b/suites/commits/commits.test.ts
@@ -19,6 +19,15 @@ const workerNames = [
   "random5",
 ] as string[];
 
+// Operations configuration - enable/disable specific operations
+const enabledOperations = {
+  updateName: true,
+  sendMessage: true,
+  addMember: true,
+  removeMember: true,
+  createInstallation: true,
+};
+
 //The target of epoch to stop the test, epochs are when performing commits to the group
 const TARGET_EPOCH = 100n;
 const network = process.env.XMTP_ENV;
@@ -117,11 +126,13 @@ describe("commits", () => {
 
                 const ops = await createOperations(randomWorker, group);
                 const operationList = [
-                  ops.updateName,
-                  ops.sendMessage,
-                  ops.addMember,
-                  ops.removeMember,
-                  ops.createInstallation,
+                  ...(enabledOperations.updateName ? [ops.updateName] : []),
+                  ...(enabledOperations.sendMessage ? [ops.sendMessage] : []),
+                  ...(enabledOperations.addMember ? [ops.addMember] : []),
+                  ...(enabledOperations.removeMember ? [ops.removeMember] : []),
+                  ...(enabledOperations.createInstallation
+                    ? [ops.createInstallation]
+                    : []),
                 ];
 
                 const randomOperation =

--- a/suites/commits/commits.test.ts
+++ b/suites/commits/commits.test.ts
@@ -21,11 +21,11 @@ const workerNames = [
 
 // Operations configuration - enable/disable specific operations
 const enabledOperations = {
-  updateName: true,
-  sendMessage: true,
-  addMember: true,
-  removeMember: true,
-  createInstallation: true,
+  updateName: true, // updates the name of the group
+  sendMessage: false, // sends a message to the group
+  addMember: true, // adds a random member to the group
+  removeMember: true, // removes a random member from the group
+  createInstallation: true, // creates a new installation for a random worker
 };
 
 //The target of epoch to stop the test, epochs are when performing commits to the group
@@ -98,19 +98,11 @@ describe("commits", () => {
       typeOfSyncForTest,
       network as "local" | "dev" | "production",
     );
-    const creator = workers.getCreator();
     // Create groups
     const groupOperationPromises = Array.from(
       { length: groupCount },
       async (_, groupIndex) => {
-        const group = (await creator.client.conversations.newGroup(
-          [],
-        )) as Group;
-
-        for (const worker of workers.getAllButCreator()) {
-          await group.addMembers([worker.client.inboxId]);
-          await group.addSuperAdmin(worker.client.inboxId);
-        }
+        const group = await workers.createGroup();
 
         let currentEpoch = 0n;
 


### PR DESCRIPTION
### Enable specific operations for commit tests by adding configuration-based operation control to commits.test.ts
- Adds `enabledOperations` configuration object to [commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/651/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca) allowing selective enabling/disabling of operations (`updateName`, `sendMessage`, `addMember`, `removeMember`, `createInstallation`) with `sendMessage` disabled by default
- Updates deduplication patterns in [analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/651/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) to include 'Skipping already processed' and modifies log file processing to target files starting with 'raw-' prefix
- Reorders log filename components in [logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/651/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) to place test name before environment name in the generated filename pattern

#### 📍Where to Start
Start with the `enabledOperations` configuration object and its usage in the operation list construction in [commits.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/651/files#diff-2b522ea32ec98bdea89211e97ff00b2768ef076ad37c881774df60822d9b7bca).

----

_[Macroscope](https://app.macroscope.com) summarized 42977ac._