### PR TITLE
Simplified datadog sdk versioning

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -16,7 +16,7 @@
               {
                 "name": "query1",
                 "data_source": "metrics",
-                "query": "avg:xmtp.sdk.delivery{$env,$region,$test,$libxmtp,$members}",
+                "query": "avg:xmtp.sdk.delivery{$env,$region,$test,$sdk,$members}",
                 "aggregator": "avg"
               }
             ],
@@ -50,7 +50,7 @@
               {
                 "name": "query1",
                 "data_source": "metrics",
-                "query": "avg:xmtp.sdk.order{$env,$region,$test,$libxmtp,$members}",
+                "query": "avg:xmtp.sdk.order{$env,$region,$test,$sdk,$members}",
                 "aggregator": "avg"
               }
             ],
@@ -84,7 +84,7 @@
               {
                 "name": "query1",
                 "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{$env,$region,$test, metric_type:agent}"
+                "query": "avg:xmtp.sdk.response{$env,$region,metric_type:agent}"
               }
             ],
             "formulas": [{ "formula": "query1" }],
@@ -110,19 +110,20 @@
     {
       "id": 4980151126779186,
       "definition": {
-        "title": "SDK Operations Performance",
+        "title": "Operations performance by network",
         "show_legend": true,
-        "legend_layout": "auto",
+        "legend_layout": "vertical",
         "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
         "type": "timeseries",
         "requests": [
           {
-            "formulas": [{ "formula": "query1" }],
+            "formulas": [{ "alias": "Operations (ms)", "formula": "query1" }],
             "queries": [
               {
                 "name": "query1",
                 "data_source": "metrics",
-                "query": "avg:xmtp.sdk.duration{metric_type:operation,$env,$region,$test,$libxmtp, metric_subtype:core, test:m_performance} by {operation,test}"
+                "query": "avg:xmtp.sdk.duration{$env,$region,$sdk,metric_subtype:core,test:m_performance} by {operation}"
               }
             ],
             "response_format": "timeseries",
@@ -147,7 +148,7 @@
     {
       "id": 5871193681027559,
       "definition": {
-        "title": "XMTP Delivery Rate & Order Correlation",
+        "title": "Delivery Rate & Order",
         "title_size": "16",
         "title_align": "left",
         "show_legend": true,
@@ -161,7 +162,7 @@
               {
                 "name": "query1",
                 "data_source": "metrics",
-                "query": "avg:xmtp.sdk.delivery{$env,$test,$libxmtp, $region}"
+                "query": "avg:xmtp.sdk.delivery{$env,$test,$sdk,$region}"
               }
             ],
             "response_format": "timeseries",
@@ -179,7 +180,7 @@
               {
                 "name": "query4",
                 "data_source": "metrics",
-                "query": "avg:xmtp.sdk.order{$env,$region,$test,$libxmtp}"
+                "query": "avg:xmtp.sdk.order{$env,$region,$test,$sdk}"
               }
             ],
             "response_format": "timeseries",
@@ -218,7 +219,6 @@
         "show_legend": true,
         "legend_layout": "auto",
         "legend_columns": ["avg", "min", "max", "value", "sum"],
-        "time": {},
         "type": "timeseries",
         "requests": [
           {
@@ -227,60 +227,10 @@
               {
                 "name": "query1",
                 "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:bankr.base.eth}"
-              },
-              {
-                "name": "query2",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:byte}"
-              },
-              {
-                "name": "query3",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:clankerchat.base.eth}"
-              },
-              {
-                "name": "query5",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:flaunchy}"
-              },
-              {
-                "name": "query6",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:squabble}"
-              },
-              {
-                "name": "query7",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:key-check}"
-              },
-              {
-                "name": "query8",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:gang}"
-              },
-              {
-                "name": "query9",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:gm}"
-              },
-              {
-                "name": "query10",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.response{agent:csx}"
+                "query": "avg:xmtp.sdk.response{$env,$region} by {agent}"
               }
             ],
-            "formulas": [
-              { "alias": "Bankr", "formula": "query1" },
-              { "alias": "Byte", "formula": "query2" },
-              { "alias": "Clanker", "formula": "query3" },
-              { "alias": "Flaunchy", "formula": "query5" },
-              { "alias": "Squabble", "formula": "query6" },
-              { "alias": "Key-check", "formula": "query7" },
-              { "alias": "Gang", "formula": "query8" },
-              { "alias": "Gm", "formula": "query9" },
-              { "alias": "Csx", "formula": "query10" }
-            ],
+            "formulas": [{ "formula": "query1" }],
             "style": {
               "palette": "dog_classic",
               "line_type": "solid",
@@ -290,41 +240,12 @@
           }
         ]
       },
-      "layout": { "x": 0, "y": 3, "width": 4, "height": 3 }
+      "layout": { "x": 0, "y": 3, "width": 6, "height": 3 }
     },
     {
-      "id": 4027963223548428,
+      "id": 8060176852557109,
       "definition": {
-        "title": "Agent Response Times by Agent",
-        "title_size": "16",
-        "title_align": "left",
-        "type": "toplist",
-        "requests": [
-          {
-            "queries": [
-              {
-                "data_source": "metrics",
-                "name": "query1",
-                "query": "avg:xmtp.sdk.response{$env,$region,$test, metric_type:agent} by {agent}",
-                "aggregator": "avg"
-              }
-            ],
-            "response_format": "scalar",
-            "formulas": [{ "formula": "query1" }],
-            "sort": {
-              "count": 500,
-              "order_by": [{ "type": "formula", "index": 0, "order": "asc" }]
-            }
-          }
-        ],
-        "style": { "display": { "type": "stacked", "legend": "automatic" } }
-      },
-      "layout": { "x": 4, "y": 3, "width": 2, "height": 3 }
-    },
-    {
-      "id": 1234567890123456,
-      "definition": {
-        "title": "Group Operations Table",
+        "title": "Operation performance",
         "type": "query_table",
         "requests": [
           {
@@ -332,12 +253,10 @@
               {
                 "data_source": "metrics",
                 "name": "query1",
-                "query": "avg:xmtp.sdk.duration{metric_type:operation,$env,$region,$test,$libxmtp,$members, metric_subtype:group} by {operation,members,test}"
+                "query": "avg:xmtp.sdk.duration{$env,$region,$test,$sdk,$members} by {operation,test,installations,members}"
               }
             ],
             "response_format": "scalar",
-            "order": "desc",
-            "limit": 100,
             "sort": {
               "count": 500,
               "order_by": [{ "type": "formula", "index": 0, "order": "desc" }]
@@ -347,7 +266,108 @@
         ],
         "has_search_bar": "auto"
       },
-      "layout": { "x": 6, "y": 3, "width": 6, "height": 7 }
+      "layout": { "x": 6, "y": 3, "width": 6, "height": 4 }
+    },
+    {
+      "id": 3075918014507898,
+      "definition": {
+        "title": "Network performance",
+        "type": "query_table",
+        "requests": [
+          {
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,env:production,$region,$test,$sdk,$members} by {network_phase,region}"
+              },
+              {
+                "data_source": "metrics",
+                "name": "query2",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,env:dev,$region,$test,$sdk,$members} by {network_phase,region}"
+              }
+            ],
+            "response_format": "scalar",
+            "sort": {
+              "order_by": [
+                { "type": "group", "name": "region", "order": "asc" }
+              ],
+              "count": 500
+            },
+            "formulas": [
+              { "alias": "Production (ms)", "formula": "query1" },
+              { "alias": "Dev (ms)", "formula": "query2" }
+            ]
+          }
+        ],
+        "has_search_bar": "auto"
+      },
+      "layout": { "x": 0, "y": 6, "width": 6, "height": 2 }
+    },
+    {
+      "id": 6297751739510491,
+      "definition": {
+        "title": "Group performance over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "name": "query2",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{metric_subtype:group,$env,$region,$members, operation:newgroup} by {members,operation}"
+              }
+            ],
+            "formulas": [{ "alias": "newGroup", "formula": "query2" }],
+            "style": {
+              "palette": "semantic",
+              "order_by": "tags",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 6, "y": 7, "width": 6, "height": 3 }
+    },
+    {
+      "id": 7792773130762525,
+      "definition": {
+        "title": "Network Performance",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,$env,$region,$test,$sdk,$members} by {network_phase}"
+              }
+            ],
+            "response_format": "timeseries",
+            "display_type": "line"
+          }
+        ],
+        "markers": [
+          {
+            "label": " Max Threshold (300ms) ",
+            "value": "y = 300",
+            "display_type": "error dashed"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 8, "width": 6, "height": 2 }
     },
     {
       "id": 202034964114978,
@@ -358,7 +378,6 @@
         "show_legend": true,
         "legend_layout": "auto",
         "legend_columns": ["avg", "min", "max", "value", "sum"],
-        "time": {},
         "type": "timeseries",
         "requests": [
           {
@@ -366,7 +385,9 @@
               {
                 "name": "query1",
                 "data_source": "logs",
-                "search": { "query": "@service:xmtp-qa-tools" },
+                "search": {
+                  "query": "@service:xmtp-qa-tools @env:production @region:us-east"
+                },
                 "indexes": ["*"],
                 "group_by": [],
                 "compute": {
@@ -378,7 +399,9 @@
               {
                 "name": "query2",
                 "data_source": "logs",
-                "search": { "query": "@service:xmtp-qa-tools" },
+                "search": {
+                  "query": "@service:xmtp-qa-tools @env:production @region:us-east "
+                },
                 "indexes": ["*"],
                 "group_by": [],
                 "compute": {
@@ -404,110 +427,12 @@
           }
         ]
       },
-      "layout": { "x": 0, "y": 6, "width": 6, "height": 4 }
-    },
-    {
-      "id": 5297767210484191,
-      "definition": {
-        "title": "Fail lines",
-        "title_size": "16",
-        "title_align": "left",
-        "time": { "type": "live", "unit": "week", "value": 1 },
-        "requests": [
-          {
-            "response_format": "event_list",
-            "query": {
-              "data_source": "logs_stream",
-              "query_string": "@service:xmtp-qa-tools",
-              "indexes": [],
-              "storage": "hot"
-            },
-            "columns": [
-              { "field": "status_line", "width": "auto" },
-              { "field": "timestamp", "width": "auto" },
-              { "field": "env", "width": "auto" },
-              { "field": "region", "width": "auto" },
-              { "field": "test", "width": "auto" },
-              { "field": "failLines", "width": "auto" }
-            ]
-          }
-        ],
-        "type": "list_stream"
-      },
-      "layout": { "x": 0, "y": 10, "width": 6, "height": 4 }
-    },
-    {
-      "id": 7792773130762525,
-      "definition": {
-        "title": "Network Performance",
-        "show_legend": true,
-        "legend_layout": "auto",
-        "legend_columns": ["avg", "min", "max", "value", "sum"],
-        "type": "timeseries",
-        "requests": [
-          {
-            "formulas": [{ "formula": "query1" }],
-            "queries": [
-              {
-                "name": "query1",
-                "data_source": "metrics",
-                "query": "avg:xmtp.sdk.duration{metric_type:network,$env,$region,$test,$libxmtp,$members} by {network_phase}"
-              }
-            ],
-            "response_format": "timeseries",
-            "display_type": "line"
-          }
-        ],
-        "markers": [
-          {
-            "label": " Max Threshold (300ms) ",
-            "value": "y = 300",
-            "display_type": "error dashed"
-          }
-        ]
-      },
-      "layout": { "x": 6, "y": 10, "width": 6, "height": 2 }
-    },
-    {
-      "id": 3075918014507898,
-      "definition": {
-        "title": "Network performance",
-        "type": "query_table",
-        "requests": [
-          {
-            "queries": [
-              {
-                "data_source": "metrics",
-                "name": "query1",
-                "query": "avg:xmtp.sdk.duration{metric_type:network,env:production,$region,$test,$libxmtp,$members} by {network_phase,region}"
-              },
-              {
-                "data_source": "metrics",
-                "name": "query2",
-                "query": "avg:xmtp.sdk.duration{metric_type:network,env:dev,$region,$test,$libxmtp,$members} by {network_phase,region}"
-              }
-            ],
-            "response_format": "scalar",
-            "sort": {
-              "order_by": [
-                { "type": "group", "name": "region", "order": "asc" }
-              ],
-              "count": 500
-            },
-            "formulas": [
-              { "alias": "Production (ms)", "formula": "query1" },
-              { "alias": "Dev (ms)", "formula": "query2" }
-            ]
-          }
-        ],
-        "has_search_bar": "auto"
-      },
-      "layout": { "x": 6, "y": 12, "width": 6, "height": 2 }
+      "layout": { "x": 0, "y": 10, "width": 4, "height": 2 }
     },
     {
       "id": 403905557672626,
       "definition": {
-        "title": "Xmtp sdk performance by country",
+        "title": "Performance by region",
         "title_size": "16",
         "title_align": "left",
         "type": "geomap",
@@ -529,7 +454,36 @@
         "style": { "palette": "green_to_orange", "palette_flip": false },
         "view": { "focus": "WORLD" }
       },
-      "layout": { "x": 0, "y": 14, "width": 6, "height": 4 }
+      "layout": { "x": 4, "y": 10, "width": 3, "height": 5 }
+    },
+    {
+      "id": 5297767210484191,
+      "definition": {
+        "title": "Fail lines",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "response_format": "event_list",
+            "query": {
+              "data_source": "logs_stream",
+              "query_string": "@service:xmtp-qa-tools",
+              "indexes": [],
+              "storage": "hot"
+            },
+            "columns": [
+              { "field": "status_line", "width": "auto" },
+              { "field": "timestamp", "width": "auto" },
+              { "field": "env", "width": "auto" },
+              { "field": "region", "width": "auto" },
+              { "field": "failLines", "width": "auto" },
+              { "field": "test", "width": "auto" }
+            ]
+          }
+        ],
+        "type": "list_stream"
+      },
+      "layout": { "x": 0, "y": 12, "width": 4, "height": 4 }
     }
   ],
   "template_variables": [
@@ -558,20 +512,8 @@
       "default": "*"
     },
     {
-      "name": "libxmtp",
-      "prefix": "libxmtp",
-      "available_values": [],
-      "default": "*"
-    },
-    {
       "name": "operation",
       "prefix": "operation",
-      "available_values": [],
-      "default": "*"
-    },
-    {
-      "name": "metric_type",
-      "prefix": "metric_type",
       "available_values": [],
       "default": "*"
     },
@@ -580,7 +522,14 @@
       "prefix": "members",
       "available_values": [],
       "default": "*"
-    }
+    },
+    {
+      "name": "libxmtp",
+      "prefix": "libxmtp",
+      "available_values": [],
+      "default": "*"
+    },
+    { "name": "sdk", "prefix": "sdk", "available_values": [], "default": "*" }
   ],
   "layout_type": "ordered",
   "notify_list": [],

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -73,7 +73,7 @@ export const sdkVersions = {
     Group: ConversationMls,
     sdkPackage: "node-sdk-mls",
     bindingsPackage: "node-bindings-mls",
-    sdkVersion: "0.0.13",
+    nodeSdkVersion: "0.0.13",
     libXmtpVersion: "0.0.9",
   },
   47: {
@@ -83,7 +83,7 @@ export const sdkVersions = {
     Group: Group47,
     sdkPackage: "node-sdk-47",
     bindingsPackage: "node-bindings-41",
-    sdkVersion: "0.0.47",
+    nodeSdkVersion: "0.0.47",
     libXmtpVersion: "6bd613d",
   },
   105: {
@@ -93,7 +93,7 @@ export const sdkVersions = {
     Group: Group105,
     sdkPackage: "node-sdk-105",
     bindingsPackage: "node-bindings-113",
-    sdkVersion: "1.0.5",
+    nodeSdkVersion: "1.0.5",
     libXmtpVersion: "6eb1ce4",
   },
   209: {
@@ -103,7 +103,7 @@ export const sdkVersions = {
     Group: Group209,
     sdkPackage: "node-sdk-209",
     bindingsPackage: "node-bindings-118",
-    sdkVersion: "2.0.9",
+    nodeSdkVersion: "2.0.9",
     libXmtpVersion: "bfadb76",
   },
   210: {
@@ -113,7 +113,7 @@ export const sdkVersions = {
     Group: Group210,
     sdkPackage: "node-sdk-210",
     bindingsPackage: "node-bindings-120",
-    sdkVersion: "2.1.0",
+    nodeSdkVersion: "2.1.0",
     libXmtpVersion: "7b9b4d0",
   },
   220: {
@@ -123,7 +123,7 @@ export const sdkVersions = {
     Group: Group220,
     sdkPackage: "node-sdk-220",
     bindingsPackage: "node-bindings-122",
-    sdkVersion: "2.2.0",
+    nodeSdkVersion: "2.2.0",
     libXmtpVersion: "d0f0b67",
   },
   300: {
@@ -133,7 +133,7 @@ export const sdkVersions = {
     Group: Group300,
     sdkPackage: "node-sdk-300",
     bindingsPackage: "node-bindings-125",
-    sdkVersion: "3.0.1",
+    nodeSdkVersion: "3.0.1",
     libXmtpVersion: "dc3e8c8",
   },
 };

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -322,7 +322,7 @@ export async function createClient(
     client,
     dbPath,
     address,
-    sdkVersion: String(sdkVersion),
+    sdkVersion: String(sdkVersion) + "@" + libXmtpVersion,
     libXmtpVersion,
   };
 }

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -23,7 +23,6 @@ interface BaseMetricTags {
   metric_subtype?: string;
   env?: string;
   region?: string;
-  libxmtp: string;
   sdk: string;
   operation?: string;
   test: string;

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -61,8 +61,7 @@ export const setupTestLifecycle = ({
       metric_subtype: operationType,
       operation: operationName,
       test: testNameExtracted,
-      libxmtp: libXmtpVersion,
-      sdk: sdkVersion,
+      sdk: sdkVersion + "@" + libXmtpVersion,
       installations: members,
       members,
     };
@@ -86,8 +85,7 @@ export const setupTestLifecycle = ({
         sendMetric("duration", Math.round(statValue * 1000), {
           metric_type: "network",
           metric_subtype: networkPhase,
-          libxmtp: libXmtpVersion,
-          sdk: sdkVersion,
+          sdk: sdkVersion + "@" + libXmtpVersion,
           operation: operationName,
           test: testNameExtracted,
           network_phase: networkPhase,

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -53,15 +53,14 @@ export const setupTestLifecycle = ({
       parseTestName(testName);
 
     // Get version info from workers if available
-    const libXmtpVersion = workers?.getCreator()?.libXmtpVersion || "unknown";
-    const sdkVersion = workers?.getCreator()?.sdkVersion || "unknown";
+    const sdk = workers?.getCreator()?.sdk || "unknown";
 
     const values: DurationMetricTags = {
       metric_type: "operation",
       metric_subtype: operationType,
       operation: operationName,
       test: testNameExtracted,
-      sdk: sdkVersion + "@" + libXmtpVersion,
+      sdk: sdk,
       installations: members,
       members,
     };
@@ -85,7 +84,7 @@ export const setupTestLifecycle = ({
         sendMetric("duration", Math.round(statValue * 1000), {
           metric_type: "network",
           metric_subtype: networkPhase,
-          sdk: sdkVersion + "@" + libXmtpVersion,
+          sdk,
           operation: operationName,
           test: testNameExtracted,
           network_phase: networkPhase,

--- a/scripts/versions.ts
+++ b/scripts/versions.ts
@@ -1,11 +1,11 @@
 import { execSync } from "child_process";
 import fs from "fs";
 import path from "path";
-import { sdkVersions } from "@helpers/client";
+import { VersionList } from "@helpers/client";
 import { Client, Conversation, Dm, Group } from "@xmtp/node-sdk";
 
-type VersionConfig = (typeof sdkVersions)[keyof typeof sdkVersions];
-const staticConfigs = Object.values(sdkVersions).map((version) => ({
+type VersionConfig = (typeof VersionList)[keyof typeof VersionList];
+const staticConfigs = Object.values(VersionList).map((version) => ({
   ...version,
   sdkPackage: version.sdkPackage,
   bindingsPackage: version.bindingsPackage,

--- a/scripts/versions.ts
+++ b/scripts/versions.ts
@@ -53,7 +53,7 @@ function discoverPackages(): VersionConfig[] {
 
     if (matchingBindings) {
       // Try to get actual version from package.json
-      let sdkVersion = "";
+      let nodeSdkVersion = "";
       let libXmtpVersion = "";
 
       try {
@@ -63,10 +63,10 @@ function discoverPackages(): VersionConfig[] {
             "utf8",
           ),
         );
-        sdkVersion = sdkPackageJson.version || "";
+        nodeSdkVersion = sdkPackageJson.version || "";
       } catch (error: unknown) {
         console.error(error);
-        sdkVersion = "unknown";
+        nodeSdkVersion = "unknown";
       }
 
       try {
@@ -85,7 +85,7 @@ function discoverPackages(): VersionConfig[] {
       configs.push({
         sdkPackage,
         bindingsPackage: matchingBindings,
-        sdkVersion,
+        nodeSdkVersion,
         libXmtpVersion,
         Client,
         Conversation,

--- a/slack-bot/helper.ts
+++ b/slack-bot/helper.ts
@@ -69,7 +69,6 @@ export interface ProcessedLogEntry {
   service: string;
   region: string | null;
   env: string | null;
-  libxmtp: string | null;
   message: string[];
 }
 
@@ -320,7 +319,6 @@ export class DatadogLogProcessor {
           service: (attrs.service as string) || this.service,
           region: (attrs.region as string) || null,
           env: (attrs.env as string) || null,
-          libxmtp: (attrs.libxmtp as string) || null,
           message: messageLines,
         };
       })

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -93,7 +93,7 @@ describe(testName, () => {
           metric_subtype: agent.name,
           agent: agent.name,
           address: agent.address,
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
         });
         expect(agentResponded).toBe(true);
       } catch (e) {

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -93,7 +93,6 @@ describe(testName, () => {
           metric_subtype: agent.name,
           agent: agent.name,
           address: agent.address,
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
         });
         expect(agentResponded).toBe(true);

--- a/suites/functional/regression.test.ts
+++ b/suites/functional/regression.test.ts
@@ -17,11 +17,7 @@ describe(testName, () => {
         workers = await getWorkers(["bob-" + "a" + "-" + version], testName);
 
         const bob = workers.get("bob");
-        console.log(
-          "Downgraded to ",
-          "node-sdk:" + String(bob?.sdkVersion),
-          "node-bindings:" + String(bob?.libXmtpVersion),
-        );
+        console.log("Downgraded to ", String(bob?.sdk));
         let convo = await bob?.client.conversations.newDm(receiverInboxId);
 
         expect(convo?.id).toBeDefined();
@@ -37,11 +33,7 @@ describe(testName, () => {
         workers = await getWorkers(["alice-" + "a" + "-" + version], testName);
 
         const alice = workers.get("alice");
-        console.log(
-          "Upgraded to ",
-          "node-sdk:" + String(alice?.sdkVersion),
-          "node-bindings:" + String(alice?.libXmtpVersion),
-        );
+        console.log("Upgraded to ", String(alice?.sdk));
         let convo = await alice?.client.conversations.newDm(receiverInboxId);
 
         expect(convo?.id).toBeDefined();

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -239,7 +239,7 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          sdk: offlineWorker.nodeSdkVersion,
+          sdk: offlineWorker.sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -251,7 +251,7 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          sdk: offlineWorker.nodeSdkVersion,
+          sdk: offlineWorker.sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -75,7 +75,6 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -89,7 +88,6 @@ describe(testName, async () => {
         expect(orderPercentage).toBeGreaterThan(0);
 
         sendMetric("order", orderPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -148,7 +146,6 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -161,7 +158,6 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -243,7 +239,6 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          libxmtp: offlineWorker.libXmtpVersion,
           sdk: offlineWorker.sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -256,7 +251,6 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          libxmtp: offlineWorker.libXmtpVersion,
           sdk: offlineWorker.sdkVersion,
           test: testName,
           metric_type: "delivery",

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -75,7 +75,7 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -88,7 +88,7 @@ describe(testName, async () => {
         expect(orderPercentage).toBeGreaterThan(0);
 
         sendMetric("order", orderPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -146,7 +146,7 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -158,7 +158,7 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -239,7 +239,7 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          sdk: offlineWorker.sdkVersion,
+          sdk: offlineWorker.nodeSdkVersion,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -251,7 +251,7 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          sdk: offlineWorker.sdkVersion,
+          sdk: offlineWorker.nodeSdkVersion,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",

--- a/suites/other/chaos.test.ts
+++ b/suites/other/chaos.test.ts
@@ -131,7 +131,6 @@ describe(testName, () => {
 
           console.debug(`Group ${groupId} - Completed: ${feature}`);
         }
-        workers.checkStatistics();
         await workers.checkForks();
       }
     } catch (error) {

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -553,7 +553,7 @@ export class WorkerClient extends Worker {
         // );
         return;
       }
-      let response = `${this.nameId} says: gm from sdk ${this.nodeSdkVersion} and libXmtp ${this.libXmtpVersion}`;
+      let response = `${this.nameId} says: gm from sdk ${this.nodeSdkVersion}@${this.libXmtpVersion}`;
       if (conversation && conversation.debugInfo !== undefined) {
         const debugInfo = await conversation.debugInfo();
         response += ` and epoch ${debugInfo?.epoch}`;

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -148,7 +148,7 @@ export class WorkerClient extends Worker {
   private typeofSync: typeOfSync;
   private typeOfResponse: typeOfResponse;
   private folder: string;
-  private sdkVersion: string;
+  private nodeSdkVersion: string;
   private libXmtpVersion: string;
   public address!: `0x${string}`;
   public client!: Client;
@@ -175,12 +175,12 @@ export class WorkerClient extends Worker {
     this.typeOfResponse = typeOfResponse;
     this.typeofStream = typeofStream;
     this.name = worker.name;
-    this.sdkVersion = worker.sdkVersion;
+    this.nodeSdkVersion = worker.nodeSdkVersion;
     this.libXmtpVersion = worker.libXmtpVersion;
     this.folder = worker.folder;
     this.env = env;
     this.apiUrl = apiUrl;
-    this.nameId = worker.name + "-" + worker.sdkVersion;
+    this.nameId = worker.name + "-" + worker.nodeSdkVersion;
     this.testName = worker.testName;
     this.walletKey = worker.walletKey;
     this.encryptionKeyHex = worker.encryptionKey;
@@ -305,7 +305,7 @@ export class WorkerClient extends Worker {
       data: {
         name: this.name,
         folder: this.folder,
-        sdkVersion: this.sdkVersion,
+        nodeSdkVersion: this.nodeSdkVersion,
         libXmtpVersion: this.libXmtpVersion,
       },
     });
@@ -313,7 +313,7 @@ export class WorkerClient extends Worker {
       this.walletKey as `0x${string}`,
       this.encryptionKeyHex,
       {
-        sdkVersion: this.sdkVersion,
+        sdkVersion: this.nodeSdkVersion,
         name: this.name,
         testName: this.testName,
         folder: this.folder,
@@ -553,7 +553,7 @@ export class WorkerClient extends Worker {
         // );
         return;
       }
-      let response = `${this.nameId} says: gm from sdk ${this.sdkVersion} and libXmtp ${this.libXmtpVersion}`;
+      let response = `${this.nameId} says: gm from sdk ${this.nodeSdkVersion} and libXmtp ${this.libXmtpVersion}`;
       if (conversation && conversation.debugInfo !== undefined) {
         const debugInfo = await conversation.debugInfo();
         response += ` and epoch ${debugInfo?.epoch}`;
@@ -1043,7 +1043,7 @@ export class WorkerClient extends Worker {
       this.walletKey as `0x${string}`,
       this.encryptionKeyHex,
       {
-        sdkVersion: this.sdkVersion,
+        sdkVersion: this.nodeSdkVersion,
         name: this.name,
         testName: this.testName,
         folder: newFolder, // Use new folder to ensure new database/installation

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -23,7 +23,7 @@ export interface WorkerBase {
   walletKey: string;
   encryptionKey: string;
   testName: string;
-  sdkVersion: string;
+  nodeSdkVersion: string;
   libXmtpVersion: string;
 }
 
@@ -31,13 +31,12 @@ export interface Worker extends WorkerBase {
   worker: WorkerClient;
   dbPath: string;
   client: Client;
-  sdkVersion: string;
-  libXmtpVersion: string;
   installationId: string;
   inboxId: string;
   env: XmtpEnv;
   folder: string;
   address: string;
+  sdk: string;
 }
 
 /**
@@ -123,24 +122,6 @@ export class WorkerManager {
     return allWorkers[Math.floor(Math.random() * allWorkers.length)];
   }
 
-  /**
-   * Gets the version of the first worker (as a representative version)
-   */
-  public getVersion(): string {
-    const firstBaseName = Object.keys(this.workers)[0];
-    if (!firstBaseName) return "unknown";
-
-    const firstInstallId = Object.keys(this.workers[firstBaseName])[0];
-    if (!firstInstallId) return "unknown";
-
-    return this.workers[firstBaseName][firstInstallId].sdkVersion;
-  }
-
-  public checkStatistics(): void {
-    // for (const worker of this.getAll()) {
-    //   console.debug(JSON.stringify(worker.client.apiStatistics(), null, 2));
-    // }
-  }
   public async checkForks(): Promise<void> {
     for (const worker of this.getAll()) {
       const groups = await worker.client.conversations.list();
@@ -205,7 +186,7 @@ export class WorkerManager {
           const installationCount =
             await currentWorker.client.preferences.inboxState();
           workersToPrint.push(
-            `${this.env}:${baseName}-${installationId} ${currentWorker.address} ${currentWorker.sdkVersion}-${currentWorker.libXmtpVersion} ${installationCount.installations.length} - ${formatBytes(
+            `${this.env}:${baseName}-${installationId} ${currentWorker.address} ${currentWorker.nodeSdkVersion}-${currentWorker.libXmtpVersion} ${installationCount.installations.length} - ${formatBytes(
               (await currentWorker.worker.getSQLiteFileSizes())?.total ?? 0,
             )}`,
           );
@@ -393,7 +374,7 @@ export class WorkerManager {
       testName: this.testName,
       walletKey,
       encryptionKey,
-      sdkVersion: sdkVersion,
+      nodeSdkVersion: sdkVersion,
       libXmtpVersion: libXmtpVersion,
     };
 
@@ -416,11 +397,10 @@ export class WorkerManager {
       client: initializedWorker.client,
       inboxId: initializedWorker.client.inboxId,
       dbPath: initializedWorker.dbPath,
-      sdkVersion: sdkVersion,
-      libXmtpVersion: libXmtpVersion,
       address: initializedWorker.address,
       installationId: initializedWorker.client.installationId,
       env: this.env,
+      sdk: sdkVersion + "@" + libXmtpVersion,
       folder,
       worker: workerClient,
     };

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -4,8 +4,8 @@ import path from "path";
 import {
   formatBytes,
   generateEncryptionKeyHex,
-  sdkVersions,
   sleep,
+  VersionList,
 } from "@helpers/client";
 import { type Client, type Group, type XmtpEnv } from "@xmtp/node-sdk";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
@@ -362,7 +362,8 @@ export class WorkerManager {
     const folder = providedInstallId || getNextFolderName();
 
     const sdkVersion = parts.length > 2 ? parts[2] : getLatestVersion();
-    const libXmtpVersion = getLibxmtpVersion(sdkVersion);
+    const libXmtpVersion = getLibXmtpVersion(sdkVersion);
+    const nodeSdkVersion = getNodeSdkVersion(sdkVersion);
 
     // Get or generate keys
     const { walletKey, encryptionKey } = this.ensureKeys(baseName);
@@ -374,8 +375,8 @@ export class WorkerManager {
       testName: this.testName,
       walletKey,
       encryptionKey,
-      nodeSdkVersion: sdkVersion,
-      libXmtpVersion: libXmtpVersion,
+      nodeSdkVersion,
+      libXmtpVersion,
     };
 
     // Create and initialize the worker
@@ -477,12 +478,18 @@ export function getDataSubFolderCount() {
   return fs.readdirSync(`${preBasePath}/.data`).length;
 }
 export function getLatestVersion(): string {
-  return Object.keys(sdkVersions).pop() as string;
+  return Object.keys(VersionList).pop() as string;
 }
 
-export function getLibxmtpVersion(sdkVersion: string): string {
+export function getNodeSdkVersion(sdkVersion: string): string {
   return (
-    sdkVersions[Number(sdkVersion) as keyof typeof sdkVersions]
+    VersionList[Number(sdkVersion) as keyof typeof VersionList]
+      ?.nodeSdkVersion || "unknown"
+  );
+}
+export function getLibXmtpVersion(sdkVersion: string): string {
+  return (
+    VersionList[Number(sdkVersion) as keyof typeof VersionList]
       ?.libXmtpVersion || "unknown"
   );
 }


### PR DESCRIPTION
### Consolidate SDK version tracking by replacing separate `libxmtp` and `sdk` properties with combined `sdk` property across worker management, client helpers, and metric reporting
The codebase consolidates version tracking by combining Node SDK version and libXmtp version into a single `sdk` property formatted as "version@commit". The changes affect multiple components:

- Worker management interfaces in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/662/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) replace separate `sdkVersion` and `libXmtpVersion` properties with combined `sdk` property
- Client helper functions in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/662/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) rename `sdkVersion` to `nodeSdkVersion` and modify version retrieval logic
- Metric reporting across test suites removes `libxmtp` tags and uses combined `sdk` tags instead
- Datadog dashboard configuration in [dashboard.json](https://github.com/xmtp/xmtp-qa-tools/pull/662/files#diff-5785484dc1a10990ce46804ab84bd99b826b906d24ebd24ce27ebf01af763bce) updates query parameters from `$libxmtp` to `$sdk`
- Interface definitions remove `libxmtp` properties from `BaseMetricTags` and `ProcessedLogEntry`

#### 📍Where to Start
Start with the `Worker` interface changes in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/662/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) to understand how the combined `sdk` property replaces separate version tracking.

----

_[Macroscope](https://app.macroscope.com) summarized 70b7019._