### PR TITLE
Remove libxmtp references to streamline metrics tracking

### DIFF
--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -23,7 +23,6 @@ interface BaseMetricTags {
   metric_subtype?: string;
   env?: string;
   region?: string;
-  libxmtp: string;
   sdk: string;
   operation?: string;
   test: string;

--- a/helpers/notifications.ts
+++ b/helpers/notifications.ts
@@ -166,7 +166,7 @@ export async function sendSlackNotification(
       failLines: Array.from(failLines).length,
       env: process.env.ENVIRONMENT || process.env.XMTP_ENV,
       region: process.env.GEOLOCATION,
-      libxmtp: "latest",
+      sdk: "latest",
     });
   }
 

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -61,7 +61,6 @@ export const setupTestLifecycle = ({
       metric_subtype: operationType,
       operation: operationName,
       test: testNameExtracted,
-      libxmtp: libXmtpVersion,
       sdk: sdkVersion,
       installations: members,
       members,
@@ -86,7 +85,6 @@ export const setupTestLifecycle = ({
         sendMetric("duration", Math.round(statValue * 1000), {
           metric_type: "network",
           metric_subtype: networkPhase,
-          libxmtp: libXmtpVersion,
           sdk: sdkVersion,
           operation: operationName,
           test: testNameExtracted,

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -52,16 +52,12 @@ export const setupTestLifecycle = ({
     const { testNameExtracted, operationType, operationName, members } =
       parseTestName(testName);
 
-    // Get version info from workers if available
-    const libXmtpVersion = workers?.getCreator()?.libXmtpVersion || "unknown";
-    const sdkVersion = workers?.getCreator()?.sdkVersion || "unknown";
-
     const values: DurationMetricTags = {
       metric_type: "operation",
       metric_subtype: operationType,
       operation: operationName,
       test: testNameExtracted,
-      sdk: sdkVersion,
+      sdk: workers?.getCreator()?.sdk || "unknown",
       installations: members,
       members,
     };
@@ -85,7 +81,7 @@ export const setupTestLifecycle = ({
         sendMetric("duration", Math.round(statValue * 1000), {
           metric_type: "network",
           metric_subtype: networkPhase,
-          sdk: sdkVersion,
+          sdk: workers?.getCreator()?.sdk || "unknown",
           operation: operationName,
           test: testNameExtracted,
           network_phase: networkPhase,

--- a/slack-bot/helper.ts
+++ b/slack-bot/helper.ts
@@ -69,7 +69,7 @@ export interface ProcessedLogEntry {
   service: string;
   region: string | null;
   env: string | null;
-  libxmtp: string | null;
+  sdk: string | null;
   message: string[];
 }
 
@@ -320,7 +320,7 @@ export class DatadogLogProcessor {
           service: (attrs.service as string) || this.service,
           region: (attrs.region as string) || null,
           env: (attrs.env as string) || null,
-          libxmtp: (attrs.libxmtp as string) || null,
+          sdk: (attrs.sdk as string) || null,
           message: messageLines,
         };
       })

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -93,7 +93,7 @@ describe(testName, () => {
           metric_subtype: agent.name,
           agent: agent.name,
           address: agent.address,
-          libxmtp: workers.getCreator().libXmtpVersion,
+
           sdk: workers.getCreator().sdkVersion,
         });
         expect(agentResponded).toBe(true);

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -94,7 +94,7 @@ describe(testName, () => {
           agent: agent.name,
           address: agent.address,
 
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
         });
         expect(agentResponded).toBe(true);
       } catch (e) {

--- a/suites/functional/regression.test.ts
+++ b/suites/functional/regression.test.ts
@@ -17,11 +17,7 @@ describe(testName, () => {
         workers = await getWorkers(["bob-" + "a" + "-" + version], testName);
 
         const bob = workers.get("bob");
-        console.log(
-          "Downgraded to ",
-          "node-sdk:" + String(bob?.sdk),
-          "node-bindings:" + String(bob?.libXmtpVersion),
-        );
+        console.log("Downgraded to ", "sdk:" + String(bob?.sdk));
         let convo = await bob?.client.conversations.newDm(receiverInboxId);
 
         expect(convo?.id).toBeDefined();
@@ -37,11 +33,7 @@ describe(testName, () => {
         workers = await getWorkers(["alice-" + "a" + "-" + version], testName);
 
         const alice = workers.get("alice");
-        console.log(
-          "Upgraded to ",
-          "node-sdk:" + String(alice?.sdkVersion),
-          "node-bindings:" + String(alice?.libXmtpVersion),
-        );
+        console.log("Upgraded to ", "sdk:" + String(alice?.sdk));
         let convo = await alice?.client.conversations.newDm(receiverInboxId);
 
         expect(convo?.id).toBeDefined();

--- a/suites/functional/regression.test.ts
+++ b/suites/functional/regression.test.ts
@@ -19,7 +19,7 @@ describe(testName, () => {
         const bob = workers.get("bob");
         console.log(
           "Downgraded to ",
-          "node-sdk:" + String(bob?.sdkVersion),
+          "node-sdk:" + String(bob?.sdk),
           "node-bindings:" + String(bob?.libXmtpVersion),
         );
         let convo = await bob?.client.conversations.newDm(receiverInboxId);

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -75,7 +75,6 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -89,7 +88,6 @@ describe(testName, async () => {
         expect(orderPercentage).toBeGreaterThan(0);
 
         sendMetric("order", orderPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -148,7 +146,6 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -161,7 +158,6 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          libxmtp: workers.getCreator().libXmtpVersion,
           sdk: workers.getCreator().sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -243,7 +239,6 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          libxmtp: offlineWorker.libXmtpVersion,
           sdk: offlineWorker.sdkVersion,
           test: testName,
           metric_type: "delivery",
@@ -256,7 +251,6 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          libxmtp: offlineWorker.libXmtpVersion,
           sdk: offlineWorker.sdkVersion,
           test: testName,
           metric_type: "delivery",

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -75,7 +75,7 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -88,7 +88,7 @@ describe(testName, async () => {
         expect(orderPercentage).toBeGreaterThan(0);
 
         sendMetric("order", orderPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -146,7 +146,7 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -158,7 +158,7 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          sdk: workers.getCreator().sdkVersion,
+          sdk: workers.getCreator().sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -239,7 +239,7 @@ describe(testName, async () => {
         expect(receptionPercentage).toBeGreaterThan(0);
 
         sendMetric("delivery", receptionPercentage, {
-          sdk: offlineWorker.sdkVersion,
+          sdk: offlineWorker.sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",
@@ -251,7 +251,7 @@ describe(testName, async () => {
       if (orderPercentage > 0) {
         expect(orderPercentage).toBeGreaterThan(0);
         sendMetric("order", orderPercentage, {
-          sdk: offlineWorker.sdkVersion,
+          sdk: offlineWorker.sdk,
           test: testName,
           metric_type: "delivery",
           conversation_type: "group",

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -140,6 +140,7 @@ type StreamMessage =
 
 export class WorkerClient extends Worker {
   public name: string;
+  public sdk: string;
   private testName: string;
   private nameId: string;
   private walletKey: string;
@@ -177,6 +178,7 @@ export class WorkerClient extends Worker {
     this.name = worker.name;
     this.sdkVersion = worker.sdkVersion;
     this.libXmtpVersion = worker.libXmtpVersion;
+    this.sdk = worker.sdkVersion + "@" + worker.libXmtpVersion;
     this.folder = worker.folder;
     this.env = env;
     this.apiUrl = apiUrl;

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -19,6 +19,7 @@ import {
 
 export interface WorkerBase {
   name: string;
+  sdk: string;
   folder: string;
   walletKey: string;
   encryptionKey: string;
@@ -31,8 +32,6 @@ export interface Worker extends WorkerBase {
   worker: WorkerClient;
   dbPath: string;
   client: Client;
-  sdkVersion: string;
-  libXmtpVersion: string;
   installationId: string;
   inboxId: string;
   env: XmtpEnv;
@@ -389,6 +388,7 @@ export class WorkerManager {
     // Create the base worker data
     const workerData: WorkerBase = {
       name: baseName,
+      sdk: sdkVersion + "@" + libXmtpVersion,
       folder,
       testName: this.testName,
       walletKey,


### PR DESCRIPTION
### Consolidate libxmtp and SDK version tracking by replacing separate libxmtp properties with combined sdk properties across metrics, logging, and worker interfaces
This change consolidates version tracking by removing the separate `libxmtp` property from interfaces and metric tags, replacing it with a combined `sdk` property that contains both SDK and libXMTP version information. The changes affect multiple components:

- Removes the required `libxmtp` field from `BaseMetricTags` interface in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3)
- Updates property names from `libxmtp` to `sdk` in logging calls in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc) and [slack-bot/helper.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-b2aac312173569255d6967c4b037e3b4299018c3af143a96a174732d80482451)
- Consolidates version tracking in test metrics by removing `libxmtp` properties and using only `sdk` properties in [helpers/vitest.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4), [suites/agents/agents.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-63e5e0cb3c24a7cd4bcf9f798d609c75b28c5b47a39520e13b16a0e2af8ea596), and [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916)
- Adds new `sdk` property to worker classes that combines `sdkVersion` and `libXmtpVersion` with '@' separator in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) and [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42)
- Simplifies version logging in regression tests to use single `sdk` property in [suites/functional/regression.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-ef05b3a653c4cbfedd1525239ad31e13517ab8213add5a2d6971f678057ac2bc)

#### 📍Where to Start
Start with the `BaseMetricTags` interface in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to understand the core interface change, then review the `WorkerBase` interface in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/665/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) to see how the new `sdk` property is structured.

----

_[Macroscope](https://app.macroscope.com) summarized 26ad005._