### PR TITLE
Refactor client creation for improved clarity and simplicity

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -276,12 +276,9 @@ export const getDbPath = (description: string = "xmtp") => {
 export async function createClient(
   walletKey: `0x${string}`,
   encryptionKeyHex: string,
-  workerData: {
-    sdkVersion: string;
-    name: string;
-    testName: string;
-    folder: string;
-  },
+  sdkVersion: number,
+  name: string,
+  folder: string,
   env: XmtpEnv,
   apiUrl?: string,
 ): Promise<{
@@ -293,19 +290,13 @@ export async function createClient(
 }> {
   const encryptionKey = getEncryptionKeyFromHex(encryptionKeyHex);
 
-  const sdkVersion = Number(workerData.sdkVersion);
   // Use type assertion to access the static version property
   const libXmtpVersion =
     VersionList[sdkVersion as keyof typeof VersionList].libXmtpVersion;
 
   const account = privateKeyToAccount(walletKey);
   const address = account.address;
-  const dbPath = getDbPathOfInstallation(
-    workerData.name,
-    address,
-    workerData.folder,
-    env,
-  );
+  const dbPath = getDbPathOfInstallation(name, address, folder, env);
 
   // Use type assertion to handle the client creation
   const client = await regressionClient(

--- a/suites/metrics/large/membership.test.ts
+++ b/suites/metrics/large/membership.test.ts
@@ -4,7 +4,7 @@ import { verifyMembershipStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getInboxIds } from "@inboxes/utils";
 import { typeofStream } from "@workers/main";
-import { getWorkers, type WorkerManager } from "@workers/manager";
+import { getWorkers } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
 import { afterAll, describe, expect, it } from "vitest";
 import {

--- a/suites/metrics/large/messages.test.ts
+++ b/suites/metrics/large/messages.test.ts
@@ -4,7 +4,7 @@ import { verifyMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getInboxIds } from "@inboxes/utils";
 import { typeofStream } from "@workers/main";
-import { getWorkers, type WorkerManager } from "@workers/manager";
+import { getWorkers } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { afterAll, describe, expect, it } from "vitest";
 import {

--- a/suites/metrics/large/metadata.test.ts
+++ b/suites/metrics/large/metadata.test.ts
@@ -4,7 +4,7 @@ import { verifyMetadataStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getInboxIds } from "@inboxes/utils";
 import { typeofStream } from "@workers/main";
-import { getWorkers, type WorkerManager } from "@workers/manager";
+import { getWorkers } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { afterAll, describe, expect, it } from "vitest";
 import {

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -3,7 +3,7 @@ import { logError } from "@helpers/logger";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getInboxIds } from "@inboxes/utils";
 import { typeofStream } from "@workers/main";
-import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
+import { getWorkers, type Worker } from "@workers/manager";
 import { afterAll, describe, expect, it } from "vitest";
 import {
   m_large_BATCH_SIZE,

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -141,7 +141,6 @@ type StreamMessage =
 export class WorkerClient extends Worker {
   public name: string;
   public sdk: string;
-  private testName: string;
   private nameId: string;
   private walletKey: string;
   private encryptionKeyHex: string;
@@ -183,7 +182,6 @@ export class WorkerClient extends Worker {
     this.env = env;
     this.apiUrl = apiUrl;
     this.nameId = worker.name + "-" + worker.sdkVersion;
-    this.testName = worker.testName;
     this.walletKey = worker.walletKey;
     this.encryptionKeyHex = worker.encryptionKey;
     this.setupEventHandlers();
@@ -314,12 +312,9 @@ export class WorkerClient extends Worker {
     const { client, dbPath, address } = await createClient(
       this.walletKey as `0x${string}`,
       this.encryptionKeyHex,
-      {
-        sdkVersion: this.sdkVersion,
-        name: this.name,
-        testName: this.testName,
-        folder: this.folder,
-      },
+      Number(this.sdkVersion),
+      this.name,
+      this.folder,
       this.env,
       this.apiUrl,
     );
@@ -1044,12 +1039,9 @@ export class WorkerClient extends Worker {
     const { client, dbPath, address } = await createClient(
       this.walletKey as `0x${string}`,
       this.encryptionKeyHex,
-      {
-        sdkVersion: this.sdkVersion,
-        name: this.name,
-        testName: this.testName,
-        folder: newFolder, // Use new folder to ensure new database/installation
-      },
+      Number(this.sdkVersion),
+      this.name,
+      newFolder,
       this.env,
     );
 


### PR DESCRIPTION
### Refactor `createClient` function signature to accept direct parameters instead of `workerData` object and remove unused `WorkerManager` type imports
The `createClient` function in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/668/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) now accepts parameters directly (`sdkVersion`, `name`, `folder`) instead of through a `workerData` object, with `testName` parameter removed entirely and `sdkVersion` now passed as a number. The `WorkerClient` class in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/668/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) removes the `testName` property and updates function calls to match the new parameter structure. Multiple test files remove unused `WorkerManager` type imports while retaining functional imports.

#### 📍Where to Start
Start with the `createClient` function in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/668/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to understand the new parameter structure, then review the updated function calls in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/668/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1).

----

_[Macroscope](https://app.macroscope.com) summarized 20d2f8f._