### PR TITLE
Evaluate and remove testName parameter

### DIFF
--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -19,7 +19,6 @@ describe(testName, () => {
   beforeAll(async () => {
     workers = await getWorkers(
       getRandomNames(1),
-      testName,
       typeofStream.Message,
       typeOfResponse.None,
       typeOfSync.None,

--- a/suites/bench/bench.test.ts
+++ b/suites/bench/bench.test.ts
@@ -53,7 +53,6 @@ describe(testName, () => {
         try {
           workers = await getWorkers(
             getRandomNames(WORKER_COUNT),
-            testName,
             typeofStream.GroupUpdated,
           );
           const newGroup = (await workers

--- a/suites/bench/bench.test.ts
+++ b/suites/bench/bench.test.ts
@@ -98,7 +98,7 @@ describe(testName, () => {
           );
 
           const zWorkerName = "random" + `${i}-${installation}`;
-          const zWorker = await getWorkers([zWorkerName], testName);
+          const zWorker = await getWorkers([zWorkerName]);
           await newGroup.addMembers([zWorker.getCreator().client.inboxId]);
           const zSyncAllStart = performance.now();
           await zWorker.getCreator().client.conversations.syncAll();

--- a/suites/browser/browser.test.ts
+++ b/suites/browser/browser.test.ts
@@ -25,12 +25,10 @@ describe(testName, () => {
   beforeAll(async () => {
     const convoStreamBot = await getWorkers(
       [names[0], names[1]],
-      testName,
       typeofStream.Conversation,
     );
     const gmBotWorker = await getWorkers(
       [names[2]],
-      testName,
       typeofStream.Message,
       typeOfResponse.Gm,
     );

--- a/suites/bugs/bug_addmember/test.test.ts
+++ b/suites/bugs/bug_addmember/test.test.ts
@@ -10,10 +10,9 @@ import { describe, expect, it } from "vitest";
 const testName = "bug_addmember";
 
 describe(testName, async () => {
-  const workers = await getWorkers(["bob"], testName);
-  const receiverWorkers = await getWorkers(
-    ["alice"],
-    testName,
+  const workers = await getWorkers(["bob"]);
+      const receiverWorkers = await getWorkers(
+      ["alice"],
     typeofStream.Conversation,
     typeOfResponse.None,
     typeOfSync.None,

--- a/suites/bugs/bug_kpke/bug_kpke.test.ts
+++ b/suites/bugs/bug_kpke/bug_kpke.test.ts
@@ -16,7 +16,6 @@ describe(testName, () => {
   beforeAll(async () => {
     workers = await getWorkers(
       getFixedNames(1),
-      testName,
       typeofStream.Message,
     );
   });

--- a/suites/bugs/bug_panic/test.test.ts
+++ b/suites/bugs/bug_panic/test.test.ts
@@ -6,7 +6,7 @@ const testName = "bug_panic";
 
 describe(testName, () => {
   it("newGroupByInboxIds: should measure creating a group with inbox ids", async () => {
-    const workers = await getWorkers(getFixedNames(50), testName);
+    const workers = await getWorkers(getFixedNames(50));
     const workerArray = workers.getAll();
     const groupByInboxIds = await workers.createGroupBetweenAll();
     for (const worker of workerArray) {

--- a/suites/bugs/bug_stitch/stitch.test.ts
+++ b/suites/bugs/bug_stitch/stitch.test.ts
@@ -34,7 +34,7 @@ describe(testName, () => {
       it("should initialize clients and sync conversations", async () => {
         try {
           console.log(`Setting up test for ${user}`);
-          const workers = await getWorkers([randomName], testName);
+          const workers = await getWorkers([randomName]);
           randomWorker = workers.get(randomName) as Worker;
           const newConvo =
             await randomWorker.client.conversations.newDm(receiver);
@@ -51,7 +51,7 @@ describe(testName, () => {
       it("should create new DM and group conversations", async () => {
         try {
           console.log(`Setting up test for ${user}`);
-          const workers = await getWorkers([randomName + "-b"], testName);
+          const workers = await getWorkers([randomName + "-b"]);
           randomWorker = workers.get(randomName, "b") as Worker;
           const sender = randomWorker?.client;
           const newConvo = await sender.conversations.newDm(receiver);
@@ -73,7 +73,7 @@ describe(testName, () => {
       it("should create new DM and group conversations", async () => {
         try {
           console.log(`Setting up test for ${user}`);
-          const workers = await getWorkers([randomName + "-c"], testName);
+          const workers = await getWorkers([randomName + "-c"]);
           randomWorker = workers.get(randomName, "c") as Worker;
           const sender = randomWorker?.client;
           const newConvo = await sender.conversations.newDm(receiver);

--- a/suites/bugs/bug_welcome/welcome.test.ts
+++ b/suites/bugs/bug_welcome/welcome.test.ts
@@ -12,8 +12,8 @@ describe(testName, () => {
 
   beforeAll(async () => {
     const names = getFixedNames(10);
-    workers = await getWorkers(names, testName, typeofStream.Message);
-    await getWorkers(names, testName, typeofStream.Conversation);
+      workers = await getWorkers(names, typeofStream.Message);
+  await getWorkers(names, typeofStream.Conversation);
   });
 
   it("stream: send the stream", async () => {

--- a/suites/commits/commits.test.ts
+++ b/suites/commits/commits.test.ts
@@ -89,7 +89,6 @@ describe("commits", () => {
   it("should perform concurrent operations with multiple users across 5 groups", async () => {
     let workers = await getWorkers(
       workerNames,
-      "commits",
       typeofStreamForTest,
       typeOfResponseForTest,
       typeOfSyncForTest,

--- a/suites/functional/callbacks.test.ts
+++ b/suites/functional/callbacks.test.ts
@@ -11,7 +11,6 @@ describe(testName, async () => {
   const names = getRandomNames(5);
   const workers = await getWorkers(
     getWorkersWithVersions(names),
-    testName,
     typeofStream.Message,
   );
 

--- a/suites/functional/clients.test.ts
+++ b/suites/functional/clients.test.ts
@@ -24,7 +24,6 @@ describe(testName, async () => {
       "nancy",
       "oscar",
     ]),
-    testName,
     typeofStream.Message,
   );
 
@@ -35,7 +34,7 @@ describe(testName, async () => {
 
   it("should measure XMTP client creation performance and initialization", async () => {
     try {
-      const client = await getWorkers(["randomclient"], testName);
+      const client = await getWorkers(["randomclient"]);
       expect(client).toBeDefined();
     } catch (e) {
       logError(e, expect.getState().currentTestName);

--- a/suites/functional/codec.test.ts
+++ b/suites/functional/codec.test.ts
@@ -14,7 +14,6 @@ describe(testName, async () => {
   let workers: WorkerManager;
   workers = await getWorkers(
     getWorkersWithVersions(getFixedNames(2)),
-    testName,
     typeofStream.Message,
   );
 

--- a/suites/functional/consent.test.ts
+++ b/suites/functional/consent.test.ts
@@ -13,7 +13,6 @@ describe(testName, async () => {
 
   workers = await getWorkers(
     getWorkersWithVersions(getFixedNames(5)),
-    testName,
     typeofStream.Consent,
   );
 

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -25,7 +25,6 @@ describe(testName, async () => {
 
   const workers = await getWorkers(
     workerDescriptors,
-    testName,
     typeofStream.Message,
   );
   let convo: Dm;

--- a/suites/functional/groups.test.ts
+++ b/suites/functional/groups.test.ts
@@ -24,7 +24,6 @@ describe(testName, async () => {
       "nancy",
       "oscar",
     ]),
-    testName,
     typeofStream.Message,
   );
   const batchSize = 5;

--- a/suites/functional/installations.test.ts
+++ b/suites/functional/installations.test.ts
@@ -16,7 +16,6 @@ describe(testName, () => {
     const names = ["random1", "random2 ", "random3", "random4", "random5"];
     let initialWorkers = await getWorkers(
       getWorkersWithVersions(names),
-      testName,
       typeofStream.Message,
     );
     expect(initialWorkers.get(names[0])?.folder).toBe("a");
@@ -25,7 +24,6 @@ describe(testName, () => {
     // Create a different installation of alice
     const secondaryWorkers = await getWorkers(
       [names[0] + "-desktop", names[1] + "-b"],
-      testName,
     );
     // Merge the new workers with the existing ones
     expect(secondaryWorkers.get(names[0], "desktop")?.folder).toBe("desktop");
@@ -49,7 +47,6 @@ describe(testName, () => {
     // Create charlie only when we need him
     const terciaryWorkers = await getWorkers(
       getWorkersWithVersions([names[2]]),
-      testName,
       typeofStream.Message,
     );
 
@@ -68,7 +65,7 @@ describe(testName, () => {
     expect(charlieConvs?.length).toBeGreaterThan(0);
 
     // Create a backup installation for charlie
-    const fourthWorkers = await getWorkers([names[2] + "-c"], testName);
+    const fourthWorkers = await getWorkers([names[2] + "-c"]);
     // Backup installation should also be able to access the conversation after syncing
     await fourthWorkers.get(names[2])?.client.conversations.sync();
     const backupConvs = await fourthWorkers
@@ -88,7 +85,6 @@ describe(testName, () => {
         names[4],
         names[4] + "-" + randomString,
       ],
-      testName,
     );
 
     // Count initial installations

--- a/suites/functional/metadata.test.ts
+++ b/suites/functional/metadata.test.ts
@@ -23,7 +23,6 @@ describe(testName, async () => {
       "nancy",
       "oscar",
     ]),
-    testName,
     typeofStream.GroupUpdated,
   );
 

--- a/suites/functional/offline.test.ts
+++ b/suites/functional/offline.test.ts
@@ -15,7 +15,6 @@ describe(testName, async () => {
   let workers: WorkerManager;
   workers = await getWorkers(
     getWorkersWithVersions(["random1", "random2", "random3"]),
-    testName,
     typeofStream.Message,
   );
 

--- a/suites/functional/order.test.ts
+++ b/suites/functional/order.test.ts
@@ -15,7 +15,6 @@ describe(testName, async () => {
 
   workers = await getWorkers(
     getWorkersWithVersions(getFixedNames(5)),
-    testName,
     typeofStream.Message,
   );
 

--- a/suites/functional/playwright.test.ts
+++ b/suites/functional/playwright.test.ts
@@ -25,12 +25,10 @@ describe(testName, () => {
   beforeAll(async () => {
     const convoStreamBot = await getWorkers(
       [names[0], names[1]],
-      testName,
       typeofStream.Conversation,
     );
     const gmBotWorker = await getWorkers(
       [names[2]],
-      testName,
       typeofStream.Message,
       typeOfResponse.Gm,
     );

--- a/suites/functional/regression.test.ts
+++ b/suites/functional/regression.test.ts
@@ -14,7 +14,7 @@ describe(testName, () => {
   for (const version of versions) {
     it(`downgrade to ${version}`, async () => {
       try {
-        workers = await getWorkers(["bob-" + "a" + "-" + version], testName);
+        workers = await getWorkers(["bob-" + "a" + "-" + version]);
 
         const bob = workers.get("bob");
         console.log("Downgraded to ", "sdk:" + String(bob?.sdk));
@@ -30,7 +30,7 @@ describe(testName, () => {
   for (const version of versions.reverse()) {
     it(`upgrade to ${version}`, async () => {
       try {
-        workers = await getWorkers(["alice-" + "a" + "-" + version], testName);
+        workers = await getWorkers(["alice-" + "a" + "-" + version]);
 
         const alice = workers.get("alice");
         console.log("Upgraded to ", "sdk:" + String(alice?.sdk));

--- a/suites/functional/streams.test.ts
+++ b/suites/functional/streams.test.ts
@@ -21,7 +21,7 @@ const testName = "streams";
 describe(testName, async () => {
   let group: Group;
   const names = getWorkersWithVersions(getFixedNames(5));
-  let workers = await getWorkers(names, testName);
+  let workers = await getWorkers(names);
 
   // Setup test lifecycle
   setupTestLifecycle({
@@ -31,7 +31,7 @@ describe(testName, async () => {
 
   it("should stream group membership updates when members are added to existing groups", async () => {
     try {
-      workers = await getWorkers(names, testName, typeofStream.GroupUpdated);
+      workers = await getWorkers(names, typeofStream.GroupUpdated);
       // Initialize workers
       group = await workers.createGroupBetweenAll();
 
@@ -50,7 +50,7 @@ describe(testName, async () => {
 
   it("should stream consent state changes when managing permissions for group members", async () => {
     try {
-      workers = await getWorkers(names, testName, typeofStream.Consent);
+      workers = await getWorkers(names, typeofStream.Consent);
 
       const verifyResult = await verifyConsentStream(
         workers.getCreator(),
@@ -66,7 +66,7 @@ describe(testName, async () => {
 
   it("should stream direct messages in real-time between two participants", async () => {
     try {
-      workers = await getWorkers(names, testName, typeofStream.Message);
+      workers = await getWorkers(names, typeofStream.Message);
       // Create direct message
       const creator = workers.getCreator();
       const receiver = workers.getReceiver();
@@ -90,7 +90,7 @@ describe(testName, async () => {
 
   it("should stream real-time notifications when new members are added to groups", async () => {
     try {
-      workers = await getWorkers(names, testName, typeofStream.Conversation);
+      workers = await getWorkers(names, typeofStream.Conversation);
       const creator = workers.getCreator();
       const receiver = workers.getReceiver();
       // Create group with alice as the creator
@@ -113,7 +113,7 @@ describe(testName, async () => {
 
   it("should stream group messages in real-time across multiple participants", async () => {
     try {
-      workers = await getWorkers(names, testName, typeofStream.Message);
+      workers = await getWorkers(names, typeofStream.Message);
       const newGroup = await workers.createGroupBetweenAll();
 
       // Verify message delivery
@@ -132,7 +132,7 @@ describe(testName, async () => {
 
   it("should stream group metadata updates when group name or description changes", async () => {
     try {
-      workers = await getWorkers(names, testName, typeofStream.GroupUpdated);
+      workers = await getWorkers(names, typeofStream.GroupUpdated);
       // Initialize workers
       group = await workers.createGroupBetweenAll();
 
@@ -151,7 +151,7 @@ describe(testName, async () => {
   it("should stream new conversation events when participants are invited to join", async () => {
     try {
       // Initialize fresh workers specifically for conversation stream testing
-      workers = await getWorkers(names, testName, typeofStream.Conversation);
+      workers = await getWorkers(names, typeofStream.Conversation);
 
       // Use the dedicated conversation stream verification helper
       const verifyResult = await verifyConversationStream(
@@ -169,7 +169,7 @@ describe(testName, async () => {
   it("should stream conversation updates when members are dynamically added to existing groups", async () => {
     try {
       // Initialize fresh workers specifically for conversation stream testing
-      workers = await getWorkers(names, testName, typeofStream.Conversation);
+      workers = await getWorkers(names, typeofStream.Conversation);
       group = (await workers
         .getCreator()
         .client.conversations.newGroup([])) as Group;

--- a/suites/functional/sync.test.ts
+++ b/suites/functional/sync.test.ts
@@ -16,7 +16,6 @@ describe(testName, async () => {
   const testWorkers = ["henry", "ivy", "jack", "karen", "larry"];
   workers = await getWorkers(
     getWorkersWithVersions(testWorkers),
-    testName,
     typeofStream.Message,
   );
   setupTestLifecycle({ testName, expect });

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -27,7 +27,6 @@ describe(testName, async () => {
   );
   let workers = await getWorkers(
     getFixedNames(receiverAmount),
-    testName,
     typeofStream.Message,
   );
   let group: Group;

--- a/suites/metrics/large/conversations.test.ts
+++ b/suites/metrics/large/conversations.test.ts
@@ -20,7 +20,6 @@ const testName = "m_large_conversations";
 describe(testName, async () => {
   let workers = await getWorkers(
     getFixedNames(m_large_WORKER_COUNT),
-    testName,
     typeofStream.Conversation,
   );
   let newGroup: Group;

--- a/suites/metrics/large/cumulative_syncs.test.ts
+++ b/suites/metrics/large/cumulative_syncs.test.ts
@@ -21,7 +21,6 @@ describe(testName, async () => {
 
   workers = await getWorkers(
     getFixedNames((m_large_TOTAL / m_large_BATCH_SIZE) * 2 + 1),
-    testName,
     typeofStream.None,
   );
   let allWorkers: Worker[];

--- a/suites/metrics/large/membership.test.ts
+++ b/suites/metrics/large/membership.test.ts
@@ -24,7 +24,6 @@ describe(testName, async () => {
 
   let workers = await getWorkers(
     getFixedNames(m_large_WORKER_COUNT),
-    testName,
     typeofStream.GroupUpdated,
   );
 

--- a/suites/metrics/large/messages.test.ts
+++ b/suites/metrics/large/messages.test.ts
@@ -20,7 +20,6 @@ const testName = "m_large_messages";
 describe(testName, async () => {
   let workers = await getWorkers(
     getFixedNames(m_large_WORKER_COUNT),
-    testName,
     typeofStream.Message,
   );
   let newGroup: Group;

--- a/suites/metrics/large/metadata.test.ts
+++ b/suites/metrics/large/metadata.test.ts
@@ -20,7 +20,6 @@ const testName = "m_large_metadata";
 describe(testName, async () => {
   let workers = await getWorkers(
     getFixedNames(m_large_WORKER_COUNT),
-    testName,
     typeofStream.GroupUpdated,
   );
 

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -19,7 +19,6 @@ describe(testName, async () => {
 
   let workers = await getWorkers(
     getFixedNames((m_large_TOTAL / m_large_BATCH_SIZE) * 2 + 1),
-    testName,
     typeofStream.None,
   );
   let allWorkers: Worker[];

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -17,7 +17,7 @@ describe(testName, async () => {
   let dm: Dm | undefined;
   let workers: WorkerManager;
 
-  workers = await getWorkers(getFixedNames(10), testName, typeofStream.Message);
+  workers = await getWorkers(getFixedNames(10), typeofStream.Message);
   const creator = workers.getCreator();
   console.warn("creator is:", creator.name);
   const creatorClient = creator.client;
@@ -38,7 +38,7 @@ describe(testName, async () => {
 
   it("clientCreate: should measure creating a client", async () => {
     try {
-      const client = await getWorkers(["randomclient"], testName);
+      const client = await getWorkers(["randomclient"]);
       expect(client).toBeDefined();
     } catch (e) {
       logError(e, expect.getState().currentTestName);
@@ -47,7 +47,7 @@ describe(testName, async () => {
   });
   it("canMessage: should measure canMessage", async () => {
     try {
-      const client = await getWorkers(["randomclient"], testName);
+      const client = await getWorkers(["randomclient"]);
       if (!client) {
         throw new Error("Client not found");
       }

--- a/suites/mobile/mobile.test.ts
+++ b/suites/mobile/mobile.test.ts
@@ -40,7 +40,6 @@ describe(testName, () => {
     try {
       workers = await getWorkers(
         ["bot"],
-        testName,
         typeofStream.None,
         typeOfResponse.None,
         typeOfSync.None,

--- a/suites/networkchaos/dm-duplicate-prevention.test.ts
+++ b/suites/networkchaos/dm-duplicate-prevention.test.ts
@@ -16,7 +16,6 @@ describe(testName, async () => {
       henry: "http://localhost:5556",
       randomguy: "http://localhost:6556",
     },
-    testName,
     typeofStream.Message,
   );
 

--- a/suites/networkchaos/group-client-partition.test.ts
+++ b/suites/networkchaos/group-client-partition.test.ts
@@ -19,7 +19,6 @@ describe(testName, async () => {
       user3: "http://localhost:6556",
       user4: "http://localhost:6556",
     },
-    testName,
     typeofStream.Message,
     typeOfResponse.Gm,
   );

--- a/suites/networkchaos/group-partition-delayedreceive.test.ts
+++ b/suites/networkchaos/group-partition-delayedreceive.test.ts
@@ -19,7 +19,6 @@ describe(testName, async () => {
       user3: "http://localhost:6556",
       user4: "http://localhost:6556",
     },
-    testName,
     typeofStream.Message,
     typeOfResponse.Gm,
   );

--- a/suites/networkchaos/group-reconciliation.test.ts
+++ b/suites/networkchaos/group-reconciliation.test.ts
@@ -19,7 +19,6 @@ describe(testName, async () => {
       user3: "http://localhost:7556",
       user4: "http://localhost:8556",
     },
-    testName,
     typeofStream.Message,
     typeOfResponse.Gm,
   );

--- a/suites/networkchaos/keyrotation.test.ts
+++ b/suites/networkchaos/keyrotation.test.ts
@@ -26,7 +26,6 @@ describe(testName, async () => {
 
   const workers = await getWorkers(
     userDescriptors,
-    testName,
     typeofStream.Message,
     typeOfResponse.Gm,
   );

--- a/suites/networkchaos/networkchaos.test.ts
+++ b/suites/networkchaos/networkchaos.test.ts
@@ -27,7 +27,6 @@ describe(testName, async () => {
 
   const workers = await getWorkers(
     userDescriptors,
-    testName,
     typeofStream.Message,
     typeOfResponse.Gm,
   );

--- a/suites/networkchaos/node-blackhole.test.ts
+++ b/suites/networkchaos/node-blackhole.test.ts
@@ -19,7 +19,6 @@ describe(testName, async () => {
       user3: "http://localhost:6556",
       user4: "http://localhost:6556",
     },
-    testName,
     typeofStream.Message,
     typeOfResponse.Gm,
   );

--- a/suites/other/chaos.test.ts
+++ b/suites/other/chaos.test.ts
@@ -49,7 +49,6 @@ describe(testName, () => {
     // Initialize workers
     workers = await getWorkers(
       ["bot", ...testConfig.workerNames],
-      testConfig.testName,
       testConfig.typeofStream,
       testConfig.typeOfResponse,
       testConfig.typeOfSync,

--- a/suites/other/notifications.test.ts
+++ b/suites/other/notifications.test.ts
@@ -16,7 +16,6 @@ describe(testName, () => {
   it(`should create notification test group and add ${receiverObj.name} as super admin`, async () => {
     workers = await getWorkers(
       ["alice", "bob", "sam", "walt", "tina"],
-      testName,
       typeofStream.Message,
       typeOfResponse.Gm,
       typeOfSync.None,

--- a/suites/other/rate-limited.test.ts
+++ b/suites/other/rate-limited.test.ts
@@ -9,7 +9,6 @@ const testName = "rate-limited";
 describe(testName, async () => {
   const workers = await getWorkers(
     ["henry", "ivy", "jack", "karen", "larry", "mary", "nancy", "oscar"],
-    testName,
     typeofStream.Message,
     typeOfResponse.Gm,
     typeOfSync.Both,

--- a/suites/other/spam.test.ts
+++ b/suites/other/spam.test.ts
@@ -20,7 +20,6 @@ describe(testName, () => {
     try {
       const workers = await getWorkers(
         ["bot"],
-        testName,
         typeofStream.None,
         typeOfResponse.None,
         typeOfSync.None,

--- a/suites/other/storage.test.ts
+++ b/suites/other/storage.test.ts
@@ -30,7 +30,6 @@ describe(testName, () => {
     const receiverName = `receiver${randomSuffix}-${memberCount}`;
     const workers = await getWorkers(
       [name, receiverName],
-      testName,
       typeofStream.None,
       typeOfResponse.None,
       typeOfSync.None,

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -23,7 +23,6 @@ export interface WorkerBase {
   folder: string;
   walletKey: string;
   encryptionKey: string;
-  testName: string;
   sdkVersion: string;
   libXmtpVersion: string;
 }
@@ -45,7 +44,6 @@ export interface Worker extends WorkerBase {
  */
 export class WorkerManager {
   private workers: Record<string, Record<string, Worker>>;
-  private testName: string;
   private activeWorkers: WorkerClient[] = [];
   private typeofStream: typeofStream = typeofStream.Message;
   private typeOfResponse: typeOfResponse = typeOfResponse.Gm;
@@ -60,13 +58,11 @@ export class WorkerManager {
    * Constructor creates an empty manager or populates it with existing workers
    */
   constructor(
-    testName: string,
     typeofStreamType: typeofStream = typeofStream.Message,
     typeOfResponseType: typeOfResponse = typeOfResponse.Gm,
     typeOfSyncType: typeOfSync = typeOfSync.None,
     env: XmtpEnv,
   ) {
-    this.testName = testName;
     this.typeofStream = typeofStreamType;
     this.typeOfResponse = typeOfResponseType;
     this.typeOfSync = typeOfSyncType;
@@ -390,7 +386,6 @@ export class WorkerManager {
       name: baseName,
       sdk: sdkVersion + "@" + libXmtpVersion,
       folder,
-      testName: this.testName,
       walletKey,
       encryptionKey,
       sdkVersion: sdkVersion,
@@ -440,14 +435,12 @@ export class WorkerManager {
  */
 export async function getWorkers(
   descriptorsOrMap: string[] | Record<string, string>,
-  testName: string,
   typeofStreamType: typeofStream = typeofStream.None,
   typeOfResponseType: typeOfResponse = typeOfResponse.None,
   typeOfSyncType: typeOfSync = typeOfSync.None,
   env: XmtpEnv = process.env.XMTP_ENV as XmtpEnv,
 ): Promise<WorkerManager> {
   const manager = new WorkerManager(
-    testName,
     typeofStreamType,
     typeOfResponseType,
     typeOfSyncType,


### PR DESCRIPTION
Remove `testName` parameter from `getWorkers` as it is not functionally used by the workers framework.