### PR TITLE
Add timeout notification for failed test workflows

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -41,6 +41,20 @@ jobs:
         run: yarn
       - name: Run tests
         run: yarn test ${{ matrix.test }} --no-fail --debug
+      - name: Send timeout notification
+        if: failure() && steps.run-tests.conclusion == 'failure'
+        run: |
+          node -e "
+          const { sendSlackNotification } = require('./helpers/notifications');
+          sendSlackNotification({
+            testName: '${{ matrix.test }}',
+            label: 'error',
+            errorLogs: new Set(['Workflow timed out after 10 minutes']),
+            env: '${{ matrix.environment }}',
+            jobStatus: 'timeout',
+            channel: 'notify-qa-tools'
+          }).catch(console.error);
+          "
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -37,19 +37,18 @@ import {
   Dm as Dm210,
   Group as Group210,
 } from "@xmtp/node-sdk-210";
-// NOTE: These SDK versions are currently unavailable
-// import {
-//   Client as Client220,
-//   Conversation as Conversation220,
-//   Dm as Dm220,
-//   Group as Group220,
-// } from "@xmtp/node-sdk-220";
-// import {
-//   Client as Client300,
-//   Conversation as Conversation300,
-//   Dm as Dm300,
-//   Group as Group300,
-// } from "@xmtp/node-sdk-300";
+import {
+  Client as Client220,
+  Conversation as Conversation220,
+  Dm as Dm220,
+  Group as Group220,
+} from "@xmtp/node-sdk-220";
+import {
+  Client as Client300,
+  Conversation as Conversation300,
+  Dm as Dm300,
+  Group as Group300,
+} from "@xmtp/node-sdk-300";
 import {
   Client as ClientMls,
   Conversation as ConversationMls,
@@ -117,27 +116,26 @@ export const VersionList = {
     nodeVersion: "2.1.0",
     libXmtpVersion: "7b9b4d0",
   },
-  // NOTE: These SDK versions are currently unavailable
-  // 220: {
-  //   Client: Client220,
-  //   Conversation: Conversation220,
-  //   Dm: Dm220,
-  //   Group: Group220,
-  //   sdkPackage: "node-sdk-220",
-  //   bindingsPackage: "node-bindings-122",
-  //   nodeVersion: "2.2.0",
-  //   libXmtpVersion: "d0f0b67",
-  // },
-  // 300: {
-  //   Client: Client300,
-  //   Conversation: Conversation300,
-  //   Dm: Dm300,
-  //   Group: Group300,
-  //   sdkPackage: "node-sdk-300",
-  //   bindingsPackage: "node-bindings-125",
-  //   nodeVersion: "3.0.1",
-  //   libXmtpVersion: "dc3e8c8",
-  // },
+  220: {
+    Client: Client220,
+    Conversation: Conversation220,
+    Dm: Dm220,
+    Group: Group220,
+    sdkPackage: "node-sdk-220",
+    bindingsPackage: "node-bindings-122",
+    nodeVersion: "2.2.0",
+    libXmtpVersion: "d0f0b67",
+  },
+  300: {
+    Client: Client300,
+    Conversation: Conversation300,
+    Dm: Dm300,
+    Group: Group300,
+    sdkPackage: "node-sdk-300",
+    bindingsPackage: "node-bindings-125",
+    nodeVersion: "3.0.1",
+    libXmtpVersion: "dc3e8c8",
+  },
 };
 
 export type GroupMetadataContent = {

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -2,7 +2,6 @@ import { getFixedNames } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getInboxIds } from "@inboxes/utils";
-import { typeofStream } from "@workers/main";
 import { getWorkers, type Worker } from "@workers/manager";
 import { afterAll, describe, expect, it } from "vitest";
 import {

--- a/suites/other/storage.test.ts
+++ b/suites/other/storage.test.ts
@@ -2,7 +2,6 @@ import { formatBytes } from "@helpers/client";
 import { logError } from "@helpers/logger";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getRandomInboxIds } from "@inboxes/utils";
-import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 


### PR DESCRIPTION
### Add timeout notification for failed test workflows to GitHub Actions Performance workflow
- Adds a conditional notification step to the GitHub Actions workflow in [.github/workflows/Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/684/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) that sends timeout notifications when tests fail using a Node.js script
- Enables support for SDK versions 220 and 300 by uncommenting import statements and version configuration entries in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/684/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1)
- Removes unused `typeofStream` import statements from test files in [suites/metrics/large/syncs.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/684/files#diff-82af031f05768910e2b17f121a74d9b12c5733d36988255d34fa15ccac4bfcfd) and [suites/other/storage.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/684/files#diff-649357e62c27c746ff49ae1beaad5d03e7fd52d468f73c8fabce9a66e2df518d)

#### 📍Where to Start
Start with the new timeout notification step in [.github/workflows/Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/684/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) to understand the failure notification mechanism.

----

_[Macroscope](https://app.macroscope.com) summarized 4db8e47._