### PR TITLE
Increase MAX_GROUP_SIZE for improved processing capacity

### DIFF
--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -20,7 +20,7 @@ jobs:
       GEOLOCATION: ${{ vars.GEOLOCATION }}
       WORKER_COUNT: 5
       BATCH_SIZE: 50
-      MAX_GROUP_SIZE: 150
+      MAX_GROUP_SIZE: 200
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:


### PR DESCRIPTION
### Increase MAX_GROUP_SIZE from 150 to 200 in Large workflow for improved processing capacity
The `MAX_GROUP_SIZE` environment variable in [.github/workflows/Large.yml](https://github.com/xmtp/xmtp-qa-tools/pull/688/files#diff-eeb4321752b07db328a5d02b895bd4286bf8c514fa40da28f800f309287c15a0) is modified from 150 to 200.

#### 📍Where to Start
Start with the environment variable configuration in [.github/workflows/Large.yml](https://github.com/xmtp/xmtp-qa-tools/pull/688/files#diff-eeb4321752b07db328a5d02b895bd4286bf8c514fa40da28f800f309287c15a0).

----

_[Macroscope](https://app.macroscope.com) summarized 179974f._