### PR TITLE
Add error pattern for agents test failures

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -30,6 +30,12 @@ export const PATTERNS = {
         "FAIL  suites/functional/playwright.test.ts > playwright > newGroup and message stream",
       ],
     },
+    {
+      testName: "Agents",
+      uniqueErrorLines: [
+        "FAIL  suites/agents/agents.test.ts > agents > production: tokenbot : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
+      ],
+    },
   ],
   minFailLines: 3,
   minumumLineLength: 40,


### PR DESCRIPTION
### Add error pattern for agents test failures to categorize specific failing test case in analyzer
Adds a new entry to the `KNOWN_ISSUES` array within the `PATTERNS` object in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/693/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193). The new pattern targets test failures related to 'Agents' with the specific failing test case `FAIL suites/agents/agents.test.ts > agents > production: tokenbot : 0x9E73e4126bb22f79f89b6281352d01dd3d203466`.

#### 📍Where to Start
Start with the `PATTERNS.KNOWN_ISSUES` array in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/693/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) to see the new error pattern entry.

----

_[Macroscope](https://app.macroscope.com) summarized 569580e._