### PR TITLE
Update squabble address

### DIFF
--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -19,7 +19,7 @@
   {
     "name": "squabble",
     "baseName": "squabble.base.eth",
-    "address": "0x557463B158F70e4E269bB7BCcF6C587e3BC878F4",
+    "address": "0xD60d560c9Ae4ad9b7C252FacE7B664A8d7A426da",
     "sendMessage": "@squabble.base.eth",
     "networks": ["production"],
     "slackChannel": "#squabble-alerts"


### PR DESCRIPTION
### Update squabble address in agents configuration from 0x557463B158F70e4E269bB7BCcF6C587e3BC878F4 to 0xD60d560c9Ae4ad9b7C252FacE7B664A8d7A426da for deployment consistency
The address value in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/698/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) is modified from `0x557463B158F70e4E269bB7BCcF6C587e3BC878F4` to `0xD60d560c9Ae4ad9b7C252FacE7B664A8d7A426da`, changing which Ethereum address the system references for agent configuration.

#### 📍Where to Start
Start with the address change in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/698/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5).

----

_[Macroscope](https://app.macroscope.com) summarized 19a8383._