### PR TITLE
Refactor test setup to use dynamic describe names

### DIFF
--- a/.cursor/rules/testing-framework.mdc
+++ b/.cursor/rules/testing-framework.mdc
@@ -21,9 +21,7 @@ describe(testName, async () => {
   // Simplified API - versioning enabled by default
   const workers = await getWorkers(["alice", "bob"]);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should do something", async () => {
     try {
@@ -451,7 +449,7 @@ try {
 
 - Use `useVersions: true` option for version testing
 - Use `typeofStream.Message` for message streaming
-- Always call `setupTestLifecycle()` for proper cleanup
+- Always call `setupTestLifecycle({})` for proper cleanup
 - Test file naming: `*.test.ts` in `suites/` directory
 
 ## Key Imports

--- a/.cursor/rules/testing-framework.mdc
+++ b/.cursor/rules/testing-framework.mdc
@@ -22,7 +22,6 @@ describe(testName, async () => {
   const workers = await getWorkers(["alice", "bob"]);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -1,11 +1,5 @@
 import type { WorkerManager } from "@workers/manager";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  type ExpectStatic,
-} from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, expect } from "vitest";
 import { loadEnv } from "./client";
 import {
   flushMetrics,
@@ -16,13 +10,10 @@ import {
 } from "./datadog";
 
 export const setupTestLifecycle = ({
-  expect,
   workers,
   getCustomDuration,
   setCustomDuration,
 }: {
-  testName: string;
-  expect: ExpectStatic;
   workers?: WorkerManager;
   getCustomDuration?: () => number | undefined;
   setCustomDuration?: (v: number | undefined) => void;
@@ -36,7 +27,6 @@ export const setupTestLifecycle = ({
   beforeEach(() => {
     start = performance.now();
     const currentTestName = expect.getState().currentTestName;
-    console.warn(currentTestName);
     console.time(currentTestName);
     if (setCustomDuration) setCustomDuration(undefined); // Reset before each test if available
   });

--- a/suites/README.md
+++ b/suites/README.md
@@ -392,7 +392,6 @@ describe(testName, async () => {
   const workers = await getWorkers(["alice", "bob"]);
 
   setupTestLifecycle({
-    expect,
     workers,
     testName,
   });

--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -19,7 +19,7 @@
   {
     "name": "squabble",
     "baseName": "squabble.base.eth",
-    "address": "0x557463B158F70e4E269bB7BCcF6C587e3BC878F4",
+    "address": "0xD60d560c9Ae4ad9b7C252FacE7B664A8d7A426da",
     "sendMessage": "@squabble.base.eth",
     "networks": ["production"],
     "slackChannel": "#squabble-alerts"

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -17,7 +17,6 @@ describe(testName, async () => {
   const workers = await getWorkers(1);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/agents/agents.test.ts
+++ b/suites/agents/agents.test.ts
@@ -16,9 +16,7 @@ describe(testName, async () => {
   const env = process.env.XMTP_ENV as "dev" | "production";
   const workers = await getWorkers(1);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   const filteredAgents = (productionAgents as AgentConfig[]).filter((agent) => {
     return agent.networks.includes(env);

--- a/suites/bench/bench.test.ts
+++ b/suites/bench/bench.test.ts
@@ -26,7 +26,6 @@ describe(testName, () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {

--- a/suites/bench/bench.test.ts
+++ b/suites/bench/bench.test.ts
@@ -26,7 +26,6 @@ describe(testName, () => {
   };
 
   setupTestLifecycle({
-    expect,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {
       customDuration = v;

--- a/suites/bench/bench.test.ts
+++ b/suites/bench/bench.test.ts
@@ -13,9 +13,7 @@ export const TOTAL = 200;
 export const CHECK_INSTALLATIONS = [2, 5, 10, 15, 20, 25];
 export const MIN_MAX_INSTALLATIONS = [1000, 2000];
 
-const testName = "bench";
-
-describe(testName, () => {
+describe("bench", () => {
   let workers: WorkerManager;
 
   const summaryMap: Record<string, SummaryEntry> = {};

--- a/suites/browser/browser.test.ts
+++ b/suites/browser/browser.test.ts
@@ -7,9 +7,7 @@ import { typeofStream } from "@workers/main";
 import { getWorkers, type Worker } from "@workers/manager";
 import { beforeAll, describe, expect, it } from "vitest";
 
-const testName = "browser";
-
-describe(testName, () => {
+describe("browser", () => {
   let groupId: string;
   const headless = false;
   let xmtpTester: playwright;

--- a/suites/browser/browser.test.ts
+++ b/suites/browser/browser.test.ts
@@ -17,9 +17,7 @@ describe(testName, () => {
   let xmtpChat: Worker;
   let receiver: Worker;
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
   beforeAll(async () => {
     const convoStreamBot = await getWorkers(2);
     const names = convoStreamBot.getAll().map((w) => w.name);

--- a/suites/browser/browser.test.ts
+++ b/suites/browser/browser.test.ts
@@ -18,7 +18,6 @@ describe(testName, () => {
   let receiver: Worker;
 
   setupTestLifecycle({
-    testName,
     expect,
   });
   beforeAll(async () => {

--- a/suites/bugs/bug_addmember/test.test.ts
+++ b/suites/bugs/bug_addmember/test.test.ts
@@ -17,9 +17,7 @@ describe(testName, async () => {
 
   let group: Group;
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should create a group", async () => {
     try {

--- a/suites/bugs/bug_addmember/test.test.ts
+++ b/suites/bugs/bug_addmember/test.test.ts
@@ -6,9 +6,7 @@ import { getWorkers } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "bug_addmember";
-
-describe(testName, async () => {
+describe("bug_addmember", async () => {
   const workers = await getWorkers(["bob"]);
   const receiverWorkers = await getWorkers(["alice"]);
 

--- a/suites/bugs/bug_addmember/test.test.ts
+++ b/suites/bugs/bug_addmember/test.test.ts
@@ -18,7 +18,6 @@ describe(testName, async () => {
   let group: Group;
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/bugs/bug_kpke/bug_kpke.test.ts
+++ b/suites/bugs/bug_kpke/bug_kpke.test.ts
@@ -16,7 +16,6 @@ describe(testName, () => {
   });
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/bugs/bug_kpke/bug_kpke.test.ts
+++ b/suites/bugs/bug_kpke/bug_kpke.test.ts
@@ -5,9 +5,7 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import { IdentifierKind, type Dm } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
-const testName = "bug_kpke";
-
-describe(testName, () => {
+describe("bug_kpke", () => {
   let workers: WorkerManager;
   let conversation: Dm;
 

--- a/suites/bugs/bug_kpke/bug_kpke.test.ts
+++ b/suites/bugs/bug_kpke/bug_kpke.test.ts
@@ -15,9 +15,7 @@ describe(testName, () => {
     workers = await getWorkers(1);
   });
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should send message to specific address", async () => {
     try {

--- a/suites/bugs/bug_panic/test.test.ts
+++ b/suites/bugs/bug_panic/test.test.ts
@@ -1,9 +1,7 @@
 import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
-const testName = "bug_panic";
-
-describe(testName, () => {
+describe("bug_panic", () => {
   it("newGroupByInboxIds: should measure creating a group with inbox ids", async () => {
     const workers = await getWorkers(50);
     const workerArray = workers.getAll();

--- a/suites/bugs/bug_stitch/README.md
+++ b/suites/bugs/bug_stitch/README.md
@@ -18,7 +18,7 @@ yarn test bug_stitch
 
 ```typescript
 // 1. Initialize first client
-const workers = await getWorkers(["ivy-a-202"], testName, env);
+const workers = await getWorkers(["ivy-a-202"], env);
 ivy100 = workers.get("ivy", "a");
 ivy100?.worker.startStream(typeofStream.Message);
 
@@ -31,7 +31,7 @@ await ivy100?.worker.clearDB();
 await ivy100?.worker.initialize();
 
 // 4. Initialize second client
-const workers2 = await getWorkers(["ivy-b-105"], testName, env);
+const workers2 = await getWorkers(["ivy-b-105"], env);
 ivy104 = workers2.get("ivy", "b");
 ivy104?.worker.startStream(typeofStream.Message);
 ```

--- a/suites/bugs/bug_stitch/stitch.test.ts
+++ b/suites/bugs/bug_stitch/stitch.test.ts
@@ -20,9 +20,7 @@ const users: {
   },
 };
 
-const testName = "bug_stitch";
-
-describe(testName, () => {
+describe("bug_stitch", () => {
   const randomName =
     defaultNames[Math.floor(Math.random() * defaultNames.length)];
   for (const user of Object.keys(users)) {

--- a/suites/bugs/bug_welcome/welcome.test.ts
+++ b/suites/bugs/bug_welcome/welcome.test.ts
@@ -2,9 +2,7 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
-const testName = "bug_welcome";
-
-describe(testName, () => {
+describe("bug_welcome", () => {
   let workers: WorkerManager;
   let group: Group;
 

--- a/suites/commits/commits.test.ts
+++ b/suites/commits/commits.test.ts
@@ -3,7 +3,7 @@ import { setupTestLifecycle } from "@helpers/vitest";
 import { getRandomInboxIds } from "@inboxes/utils";
 import { getWorkers, type Worker } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 
 // Count of groups to create
 const groupCount = 5;

--- a/suites/commits/commits.test.ts
+++ b/suites/commits/commits.test.ts
@@ -33,10 +33,7 @@ const randomInboxIdsCount = 30; // How many inboxIds to use randomly in the add/
 const installationCount = 5; // How many installations to use randomly in the createInstallation operations
 
 describe("commits", () => {
-  setupTestLifecycle({
-    testName: "commits",
-    expect,
-  });
+  setupTestLifecycle({});
 
   const createOperations = async (worker: Worker, group: Group) => {
     // This syncs all and can contribute to the fork

--- a/suites/functional/callbacks.test.ts
+++ b/suites/functional/callbacks.test.ts
@@ -10,7 +10,6 @@ describe(testName, async () => {
 
   const names = workers.getAll().map((w) => w.name);
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/callbacks.test.ts
+++ b/suites/functional/callbacks.test.ts
@@ -9,9 +9,7 @@ describe(testName, async () => {
   const workers = await getWorkers(5);
 
   const names = workers.getAll().map((w) => w.name);
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should receive messages using await async", async () => {
     const sender = workers.get(names[0])!;

--- a/suites/functional/callbacks.test.ts
+++ b/suites/functional/callbacks.test.ts
@@ -3,9 +3,7 @@ import { getWorkers } from "@workers/manager";
 import { type DecodedMessage, type Dm } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "callbacks";
-
-describe(testName, async () => {
+describe("callbacks", async () => {
   const workers = await getWorkers(5);
 
   const names = workers.getAll().map((w) => w.name);

--- a/suites/functional/clients.test.ts
+++ b/suites/functional/clients.test.ts
@@ -23,7 +23,6 @@ describe(testName, async () => {
   ]);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/clients.test.ts
+++ b/suites/functional/clients.test.ts
@@ -22,9 +22,7 @@ describe(testName, async () => {
     "oscar",
   ]);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should measure XMTP client creation performance and initialization", async () => {
     try {

--- a/suites/functional/clients.test.ts
+++ b/suites/functional/clients.test.ts
@@ -4,9 +4,7 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import { Client, IdentifierKind, type Identifier } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "clients";
-
-describe(testName, async () => {
+describe("clients", async () => {
   let workers: WorkerManager;
 
   workers = await getWorkers([

--- a/suites/functional/codec.test.ts
+++ b/suites/functional/codec.test.ts
@@ -13,7 +13,6 @@ describe(testName, async () => {
   workers = await getWorkers(2);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/codec.test.ts
+++ b/suites/functional/codec.test.ts
@@ -12,9 +12,7 @@ describe(testName, async () => {
   let workers: WorkerManager;
   workers = await getWorkers(2);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should handle codec errors gracefully when sending unsupported content types", async () => {
     try {

--- a/suites/functional/codec.test.ts
+++ b/suites/functional/codec.test.ts
@@ -6,9 +6,7 @@ import {
 } from "@xmtp/content-type-reaction";
 import { describe, expect, it } from "vitest";
 
-const testName = "codec";
-
-describe(testName, async () => {
+describe("codec", async () => {
   let workers: WorkerManager;
   workers = await getWorkers(2);
 

--- a/suites/functional/consent.test.ts
+++ b/suites/functional/consent.test.ts
@@ -12,7 +12,6 @@ describe(testName, async () => {
   workers = await getWorkers(2);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/consent.test.ts
+++ b/suites/functional/consent.test.ts
@@ -4,9 +4,7 @@ import { setupTestLifecycle } from "@helpers/vitest";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
-const testName = "consent";
-
-describe(testName, async () => {
+describe("consent", async () => {
   let workers: WorkerManager;
 
   workers = await getWorkers(2);

--- a/suites/functional/consent.test.ts
+++ b/suites/functional/consent.test.ts
@@ -11,9 +11,7 @@ describe(testName, async () => {
 
   workers = await getWorkers(2);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should stream consent state changes when users are blocked or unblocked", async () => {
     try {

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -27,7 +27,6 @@ describe(testName, async () => {
   let convo: Dm;
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -6,6 +6,7 @@ import { IdentifierKind, type Dm } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
 describe("dms", async () => {
+  setupTestLifecycle({});
   const workers = await getWorkers(
     [
       "henry",
@@ -23,8 +24,6 @@ describe("dms", async () => {
   );
 
   let convo: Dm;
-
-  setupTestLifecycle({});
 
   it("newDm: should create a new DM conversation using inbox ID", async () => {
     try {

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -5,9 +5,7 @@ import { getWorkers } from "@workers/manager";
 import { IdentifierKind, type Dm } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "dms";
-
-describe(testName, async () => {
+describe("dms", async () => {
   const workers = await getWorkers(
     [
       "henry",

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -26,9 +26,7 @@ describe(testName, async () => {
 
   let convo: Dm;
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("newDm: should create a new DM conversation using inbox ID", async () => {
     try {

--- a/suites/functional/groups.test.ts
+++ b/suites/functional/groups.test.ts
@@ -7,9 +7,7 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import { type Conversation, type Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "groups";
-
-describe(testName, async () => {
+describe("groups", async () => {
   let workers: WorkerManager;
   workers = await getWorkers([
     "henry",

--- a/suites/functional/groups.test.ts
+++ b/suites/functional/groups.test.ts
@@ -28,9 +28,7 @@ describe(testName, async () => {
   // Create a mapping to store group conversations by size
   const groupsBySize: Record<number, Conversation> = {};
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   for (let i = batchSize; i <= total; i += batchSize) {
     it(`should create a group with ${i} participants`, async () => {

--- a/suites/functional/groups.test.ts
+++ b/suites/functional/groups.test.ts
@@ -29,7 +29,6 @@ describe(testName, async () => {
   const groupsBySize: Record<number, Conversation> = {};
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/installations.test.ts
+++ b/suites/functional/installations.test.ts
@@ -6,9 +6,7 @@ import { describe, expect, it } from "vitest";
 const testName = "installations";
 
 describe(testName, () => {
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should manage multiple device installations with shared identity and separate storage", async () => {
     const names = ["random1", "random2", "random3", "random4", "random5"];

--- a/suites/functional/installations.test.ts
+++ b/suites/functional/installations.test.ts
@@ -3,9 +3,7 @@ import { typeofStream } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
-const testName = "installations";
-
-describe(testName, () => {
+describe("installations", () => {
   setupTestLifecycle({});
 
   it("should manage multiple device installations with shared identity and separate storage", async () => {

--- a/suites/functional/installations.test.ts
+++ b/suites/functional/installations.test.ts
@@ -7,7 +7,6 @@ const testName = "installations";
 
 describe(testName, () => {
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/metadata.test.ts
+++ b/suites/functional/metadata.test.ts
@@ -21,9 +21,7 @@ describe(testName, async () => {
     "oscar",
   ]);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   beforeAll(async () => {
     group = (await workers

--- a/suites/functional/metadata.test.ts
+++ b/suites/functional/metadata.test.ts
@@ -4,9 +4,7 @@ import { getWorkers } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
-const testName = "metadata";
-
-describe(testName, async () => {
+describe("metadata", async () => {
   let group: Group;
 
   const workers = await getWorkers([

--- a/suites/functional/metadata.test.ts
+++ b/suites/functional/metadata.test.ts
@@ -22,7 +22,6 @@ describe(testName, async () => {
   ]);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/offline.test.ts
+++ b/suites/functional/offline.test.ts
@@ -17,7 +17,6 @@ describe(testName, async () => {
   const randomSuffix = Math.random().toString(36).substring(2, 10);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/offline.test.ts
+++ b/suites/functional/offline.test.ts
@@ -1,15 +1,12 @@
 import { logError } from "@helpers/logger";
 import { setupTestLifecycle } from "@helpers/vitest";
-import { typeofStream } from "@workers/main";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "recovery";
-
 const amountofMessages = 5;
 
-describe(testName, async () => {
+describe("recovery", async () => {
   let group: Group;
   let workers: WorkerManager;
   workers = await getWorkers(["random1", "random2", "random3"]);

--- a/suites/functional/offline.test.ts
+++ b/suites/functional/offline.test.ts
@@ -16,9 +16,7 @@ describe(testName, async () => {
 
   const randomSuffix = Math.random().toString(36).substring(2, 10);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should recover all missed messages after client reconnection following offline period", async () => {
     try {

--- a/suites/functional/order.test.ts
+++ b/suites/functional/order.test.ts
@@ -17,9 +17,7 @@ describe(testName, async () => {
   let group: Group;
   const randomSuffix = Math.random().toString(36).substring(2, 15);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should verify message ordering accuracy when receiving messages via pull synchronization", async () => {
     try {

--- a/suites/functional/order.test.ts
+++ b/suites/functional/order.test.ts
@@ -18,7 +18,6 @@ describe(testName, async () => {
   const randomSuffix = Math.random().toString(36).substring(2, 15);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/order.test.ts
+++ b/suites/functional/order.test.ts
@@ -6,9 +6,7 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "order";
-
-describe(testName, async () => {
+describe("order", async () => {
   const amount = 5; // Number of messages to collect per receiver
   let workers: WorkerManager;
 

--- a/suites/functional/playwright.test.ts
+++ b/suites/functional/playwright.test.ts
@@ -17,9 +17,7 @@ describe(testName, () => {
   let xmtpChat: Worker;
   let receiver: Worker;
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   beforeAll(async () => {
     const convoStreamBot = await getWorkers(2);

--- a/suites/functional/playwright.test.ts
+++ b/suites/functional/playwright.test.ts
@@ -18,7 +18,6 @@ describe(testName, () => {
   let receiver: Worker;
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/playwright.test.ts
+++ b/suites/functional/playwright.test.ts
@@ -7,9 +7,7 @@ import { typeofStream } from "@workers/main";
 import { getWorkers, type Worker } from "@workers/manager";
 import { beforeAll, describe, expect, it } from "vitest";
 
-const testName = "playwright";
-
-describe(testName, () => {
+describe("playwright", () => {
   let groupId: string;
   const headless = true;
   let xmtpTester: playwright;

--- a/suites/functional/regression.test.ts
+++ b/suites/functional/regression.test.ts
@@ -4,8 +4,7 @@ import { getInboxIds } from "@inboxes/utils";
 import { getWorkers, type WorkerManager } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
-const testName = "regression";
-describe(testName, () => {
+describe("regression", () => {
   let workers: WorkerManager;
   //limit to 2 versions for testing
   const versions = sdkVersionOptions.slice(0, 3);

--- a/suites/functional/streams.test.ts
+++ b/suites/functional/streams.test.ts
@@ -23,7 +23,6 @@ describe(testName, async () => {
 
   // Setup test lifecycle
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/functional/streams.test.ts
+++ b/suites/functional/streams.test.ts
@@ -15,9 +15,7 @@ import { getWorkers } from "@workers/manager";
 import { type Dm, type Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "streams";
-
-describe(testName, async () => {
+describe("streams", async () => {
   let group: Group;
   let workers = await getWorkers(5);
 

--- a/suites/functional/streams.test.ts
+++ b/suites/functional/streams.test.ts
@@ -22,9 +22,7 @@ describe(testName, async () => {
   let workers = await getWorkers(5);
 
   // Setup test lifecycle
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should stream group membership updates when members are added to existing groups", async () => {
     try {

--- a/suites/functional/sync.test.ts
+++ b/suites/functional/sync.test.ts
@@ -5,9 +5,7 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "sync-comparison";
-
-describe(testName, async () => {
+describe("sync-comparison", async () => {
   let workers: WorkerManager;
   let testGroup: Group;
 
@@ -15,7 +13,7 @@ describe(testName, async () => {
   const testWorkers = ["henry", "ivy", "jack", "karen", "larry"];
   workers = await getWorkers(testWorkers);
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   it("should establish test environment by creating group with all participants", async () => {
     try {

--- a/suites/functional/sync.test.ts
+++ b/suites/functional/sync.test.ts
@@ -15,7 +15,7 @@ describe(testName, async () => {
   const testWorkers = ["henry", "ivy", "jack", "karen", "larry"];
   workers = await getWorkers(testWorkers);
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   it("should establish test environment by creating group with all participants", async () => {
     try {

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -39,7 +39,6 @@ describe(testName, async () => {
   });
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
   });

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -39,7 +39,6 @@ describe(testName, async () => {
   });
 
   setupTestLifecycle({
-    expect,
     workers,
   });
 

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -7,15 +7,6 @@ import type { Group } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
 const testName = "m_delivery";
-export async function getWorkersFromGroup(
-  group: Group,
-  workers: WorkerManager,
-): Promise<Worker[]> {
-  await group.sync();
-  const memberIds = (await group.members()).map((m) => m.inboxId);
-  return workers.getAll().filter((w) => memberIds.includes(w.client.inboxId));
-}
-
 describe(testName, async () => {
   const amountofMessages = parseInt(process.env.DELIVERY_AMOUNT ?? "10");
   const receiverAmount = parseInt(process.env.DELIVERY_RECEIVERS ?? "4");
@@ -258,3 +249,12 @@ describe(testName, async () => {
     }
   });
 });
+
+export async function getWorkersFromGroup(
+  group: Group,
+  workers: WorkerManager,
+): Promise<Worker[]> {
+  await group.sync();
+  const memberIds = (await group.members()).map((m) => m.inboxId);
+  return workers.getAll().filter((w) => memberIds.includes(w.client.inboxId));
+}

--- a/suites/metrics/large/conversations.test.ts
+++ b/suites/metrics/large/conversations.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    expect,
     workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {

--- a/suites/metrics/large/conversations.test.ts
+++ b/suites/metrics/large/conversations.test.ts
@@ -13,9 +13,7 @@ import {
   type SummaryEntry,
 } from "./helpers";
 
-const testName = "m_large_conversations";
-
-describe(testName, async () => {
+describe("m_large_conversations", async () => {
   let workers = await getWorkers(m_large_WORKER_COUNT);
 
   let newGroup: Group;

--- a/suites/metrics/large/conversations.test.ts
+++ b/suites/metrics/large/conversations.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
     getCustomDuration: () => customDuration,

--- a/suites/metrics/large/cumulative_syncs.test.ts
+++ b/suites/metrics/large/cumulative_syncs.test.ts
@@ -29,7 +29,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    expect,
     workers,
     getCustomDuration: () => customDuration,
     setCustomDuration,

--- a/suites/metrics/large/cumulative_syncs.test.ts
+++ b/suites/metrics/large/cumulative_syncs.test.ts
@@ -29,7 +29,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
     getCustomDuration: () => customDuration,

--- a/suites/metrics/large/cumulative_syncs.test.ts
+++ b/suites/metrics/large/cumulative_syncs.test.ts
@@ -10,9 +10,7 @@ import {
   type SummaryEntry,
 } from "./helpers";
 
-const testName = "m_large_cumulative_syncs";
-
-describe(testName, async () => {
+describe("m_large_cumulative_syncs", async () => {
   let workers: WorkerManager;
 
   const summaryMap: Record<number, SummaryEntry> = {};

--- a/suites/metrics/large/membership.test.ts
+++ b/suites/metrics/large/membership.test.ts
@@ -13,9 +13,7 @@ import {
   type SummaryEntry,
 } from "./helpers";
 
-const testName = "m_large_membership";
-
-describe(testName, async () => {
+describe("m_large_membership", async () => {
   let newGroup: Group;
 
   const summaryMap: Record<number, SummaryEntry> = {};

--- a/suites/metrics/large/membership.test.ts
+++ b/suites/metrics/large/membership.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    expect,
     workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {

--- a/suites/metrics/large/membership.test.ts
+++ b/suites/metrics/large/membership.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
     getCustomDuration: () => customDuration,

--- a/suites/metrics/large/messages.test.ts
+++ b/suites/metrics/large/messages.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    expect,
     workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {

--- a/suites/metrics/large/messages.test.ts
+++ b/suites/metrics/large/messages.test.ts
@@ -13,9 +13,7 @@ import {
   type SummaryEntry,
 } from "./helpers";
 
-const testName = "m_large_messages";
-
-describe(testName, async () => {
+describe("m_large_messages", async () => {
   let workers = await getWorkers(m_large_WORKER_COUNT);
 
   let newGroup: Group;

--- a/suites/metrics/large/messages.test.ts
+++ b/suites/metrics/large/messages.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
     getCustomDuration: () => customDuration,

--- a/suites/metrics/large/metadata.test.ts
+++ b/suites/metrics/large/metadata.test.ts
@@ -13,9 +13,7 @@ import {
   type SummaryEntry,
 } from "./helpers";
 
-const testName = "m_large_metadata";
-
-describe(testName, async () => {
+describe("m_large_metadata", async () => {
   let workers = await getWorkers(m_large_WORKER_COUNT);
 
   let newGroup: Group;

--- a/suites/metrics/large/metadata.test.ts
+++ b/suites/metrics/large/metadata.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    expect,
     workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {

--- a/suites/metrics/large/metadata.test.ts
+++ b/suites/metrics/large/metadata.test.ts
@@ -28,7 +28,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
     getCustomDuration: () => customDuration,

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -29,7 +29,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    expect,
     workers,
     getCustomDuration: () => customDuration,
     setCustomDuration,

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -10,9 +10,7 @@ import {
   type SummaryEntry,
 } from "./helpers";
 
-const testName = "m_large_syncs";
-
-describe(testName, async () => {
+describe("m_large_syncs", async () => {
   const summaryMap: Record<number, SummaryEntry> = {};
 
   let workers = await getWorkers((m_large_TOTAL / m_large_BATCH_SIZE) * 2 + 1, {

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -29,7 +29,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
     getCustomDuration: () => customDuration,

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -6,9 +6,7 @@ import { getWorkers } from "@workers/manager";
 import { Client, IdentifierKind, type Dm, type Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "m_performance";
-
-describe(testName, async () => {
+describe("m_performance", async () => {
   const batchSize = parseInt(process.env.BATCH_SIZE ?? "5");
   const total = parseInt(process.env.MAX_GROUP_SIZE ?? "10");
   let dm: Dm | undefined;

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -22,7 +22,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    expect,
     workers,
     getCustomDuration: () => customDuration,
     setCustomDuration: (v) => {

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -22,7 +22,6 @@ describe(testName, async () => {
   };
 
   setupTestLifecycle({
-    testName,
     expect,
     workers,
     getCustomDuration: () => customDuration,

--- a/suites/mobile/mobile.test.ts
+++ b/suites/mobile/mobile.test.ts
@@ -31,7 +31,6 @@ describe(testName, () => {
   let globalGroupCounter = 0;
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/mobile/mobile.test.ts
+++ b/suites/mobile/mobile.test.ts
@@ -23,9 +23,7 @@ console.log(HELP_TEXT);
 const receiverObj = getManualUsers(["fabri-convos-oneoff"])[0];
 const receiverInboxId = receiverObj.inboxId;
 
-const testName = "bot-stress";
-
-describe(testName, () => {
+describe("bot-stress", () => {
   let workers: WorkerManager;
   let bot: Worker;
   let globalGroupCounter = 0;

--- a/suites/mobile/mobile.test.ts
+++ b/suites/mobile/mobile.test.ts
@@ -30,9 +30,7 @@ describe(testName, () => {
   let bot: Worker;
   let globalGroupCounter = 0;
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   beforeAll(async () => {
     try {

--- a/suites/networkchaos/dm-duplicate-prevention.test.ts
+++ b/suites/networkchaos/dm-duplicate-prevention.test.ts
@@ -16,7 +16,7 @@ describe(testName, async () => {
   // Start message streams for duplicate prevention test
   workers.startStream(typeofStream.Message);
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   const node2 = new DockerContainer("multinode-node2-1"); // Henry
 

--- a/suites/networkchaos/dm-duplicate-prevention.test.ts
+++ b/suites/networkchaos/dm-duplicate-prevention.test.ts
@@ -6,9 +6,7 @@ import { type Dm } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 import { DockerContainer } from "../../network-stability-utilities/container";
 
-const testName = "dm-duplicate-chaos";
-
-describe(testName, async () => {
+describe("dm-duplicate-chaos", async () => {
   const workers = await getWorkers({
     henry: "http://localhost:5556",
     randomguy: "http://localhost:6556",

--- a/suites/networkchaos/dm-duplicate-prevention.test.ts
+++ b/suites/networkchaos/dm-duplicate-prevention.test.ts
@@ -14,7 +14,7 @@ describe("dm-duplicate-chaos", async () => {
   // Start message streams for duplicate prevention test
   workers.startStream(typeofStream.Message);
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   const node2 = new DockerContainer("multinode-node2-1"); // Henry
 

--- a/suites/networkchaos/group-client-partition.test.ts
+++ b/suites/networkchaos/group-client-partition.test.ts
@@ -16,7 +16,7 @@ describe(testName, async () => {
     user4: "http://localhost:6556",
   });
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   const partitionPort = 6556;
 

--- a/suites/networkchaos/group-client-partition.test.ts
+++ b/suites/networkchaos/group-client-partition.test.ts
@@ -6,9 +6,7 @@ import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 import * as iptables from "../../network-stability-utilities/iptables";
 
-const testName = "group-client-partition";
-
-describe(testName, async () => {
+describe("group-client-partition", async () => {
   const workers = await getWorkers({
     user1: "http://localhost:5556",
     user2: "http://localhost:5556",

--- a/suites/networkchaos/group-client-partition.test.ts
+++ b/suites/networkchaos/group-client-partition.test.ts
@@ -14,7 +14,7 @@ describe("group-client-partition", async () => {
     user4: "http://localhost:6556",
   });
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   const partitionPort = 6556;
 

--- a/suites/networkchaos/group-partition-delayedreceive.test.ts
+++ b/suites/networkchaos/group-partition-delayedreceive.test.ts
@@ -17,7 +17,7 @@ describe(testName, async () => {
   });
   // Start message and response streams for the chaos testing
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   const node1 = new DockerContainer("multinode-node1-1");
   const node2 = new DockerContainer("multinode-node2-1");

--- a/suites/networkchaos/group-partition-delayedreceive.test.ts
+++ b/suites/networkchaos/group-partition-delayedreceive.test.ts
@@ -6,9 +6,7 @@ import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 import { DockerContainer } from "../../network-stability-utilities/container";
 
-const testName = "group-partition-delayedreceive";
-
-describe(testName, async () => {
+describe("group-partition-delayedreceive", async () => {
   const workers = await getWorkers({
     user1: "http://localhost:5556",
     user2: "http://localhost:5556",

--- a/suites/networkchaos/group-partition-delayedreceive.test.ts
+++ b/suites/networkchaos/group-partition-delayedreceive.test.ts
@@ -15,7 +15,7 @@ describe("group-partition-delayedreceive", async () => {
   });
   // Start message and response streams for the chaos testing
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   const node1 = new DockerContainer("multinode-node1-1");
   const node2 = new DockerContainer("multinode-node2-1");

--- a/suites/networkchaos/group-reconciliation.test.ts
+++ b/suites/networkchaos/group-reconciliation.test.ts
@@ -14,7 +14,7 @@ describe("group-reconciliation", async () => {
     user4: "http://localhost:8556",
   });
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   let group: Group;
 

--- a/suites/networkchaos/group-reconciliation.test.ts
+++ b/suites/networkchaos/group-reconciliation.test.ts
@@ -16,7 +16,7 @@ describe(testName, async () => {
     user4: "http://localhost:8556",
   });
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   let group: Group;
 

--- a/suites/networkchaos/group-reconciliation.test.ts
+++ b/suites/networkchaos/group-reconciliation.test.ts
@@ -6,9 +6,7 @@ import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 import { DockerContainer } from "../../network-stability-utilities/container";
 
-const testName = "group-reconciliation";
-
-describe(testName, async () => {
+describe("group-reconciliation", async () => {
   const workers = await getWorkers({
     user1: "http://localhost:5556",
     user2: "http://localhost:6556",

--- a/suites/networkchaos/keyrotation.test.ts
+++ b/suites/networkchaos/keyrotation.test.ts
@@ -26,7 +26,7 @@ describe(testName, async () => {
   // Start message and response streams for the stress testing
   workers.startStream(typeofStream.MessageandResponse);
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   it("should handle staggered key rotations and network chaos under load", async () => {
     const group = await workers.createGroupBetweenAll(

--- a/suites/networkchaos/keyrotation.test.ts
+++ b/suites/networkchaos/keyrotation.test.ts
@@ -24,7 +24,7 @@ describe("keyrotation-chaos", async () => {
   // Start message and response streams for the stress testing
   workers.startStream(typeofStream.MessageandResponse);
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   it("should handle staggered key rotations and network chaos under load", async () => {
     const group = await workers.createGroupBetweenAll(

--- a/suites/networkchaos/keyrotation.test.ts
+++ b/suites/networkchaos/keyrotation.test.ts
@@ -5,9 +5,7 @@ import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 import { DockerContainer } from "../../network-stability-utilities/container";
 
-const testName = "keyrotation-chaos";
-
-describe(testName, async () => {
+describe("keyrotation-chaos", async () => {
   const allNodes = [
     new DockerContainer("multinode-node1-1"),
     new DockerContainer("multinode-node2-1"),

--- a/suites/networkchaos/networkchaos.test.ts
+++ b/suites/networkchaos/networkchaos.test.ts
@@ -22,7 +22,7 @@ describe("networkchaos", async () => {
 
   const workers = await getWorkers(userDescriptors);
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   it("should survive sustained latency + jitter + packet loss under group message load", async () => {
     const group = await workers.createGroupBetweenAll(

--- a/suites/networkchaos/networkchaos.test.ts
+++ b/suites/networkchaos/networkchaos.test.ts
@@ -24,7 +24,7 @@ describe(testName, async () => {
 
   const workers = await getWorkers(userDescriptors);
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   it("should survive sustained latency + jitter + packet loss under group message load", async () => {
     const group = await workers.createGroupBetweenAll(

--- a/suites/networkchaos/networkchaos.test.ts
+++ b/suites/networkchaos/networkchaos.test.ts
@@ -4,9 +4,7 @@ import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 import { DockerContainer } from "../../network-stability-utilities/container";
 
-const testName = "networkchaos";
-
-describe(testName, async () => {
+describe("networkchaos", async () => {
   const allNodes = [
     new DockerContainer("multinode-node1-1"),
     new DockerContainer("multinode-node2-1"),

--- a/suites/networkchaos/node-blackhole.test.ts
+++ b/suites/networkchaos/node-blackhole.test.ts
@@ -17,7 +17,7 @@ describe("group-node-blackhole", async () => {
   // Start message and response streams for the chaos testing
   workers.startStream(typeofStream.MessageandResponse);
 
-  setupTestLifecycle({ expect });
+  setupTestLifecycle({});
 
   const node1 = new DockerContainer("multinode-node1-1");
   const node2 = new DockerContainer("multinode-node2-1");

--- a/suites/networkchaos/node-blackhole.test.ts
+++ b/suites/networkchaos/node-blackhole.test.ts
@@ -7,8 +7,7 @@ import type { Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 import { DockerContainer } from "../../network-stability-utilities/container";
 
-const testName = "group-node-blackhole";
-describe(testName, async () => {
+describe("group-node-blackhole", async () => {
   const workers = await getWorkers({
     user1: "http://localhost:5556",
     user2: "http://localhost:5556",

--- a/suites/networkchaos/node-blackhole.test.ts
+++ b/suites/networkchaos/node-blackhole.test.ts
@@ -18,7 +18,7 @@ describe(testName, async () => {
   // Start message and response streams for the chaos testing
   workers.startStream(typeofStream.MessageandResponse);
 
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   const node1 = new DockerContainer("multinode-node1-1");
   const node2 = new DockerContainer("multinode-node2-1");

--- a/suites/other/chaos.test.ts
+++ b/suites/other/chaos.test.ts
@@ -15,7 +15,7 @@ import {
   type WorkerManager,
 } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, it } from "vitest";
 
 export const features = [
   "verifyMessageStream",

--- a/suites/other/chaos.test.ts
+++ b/suites/other/chaos.test.ts
@@ -25,9 +25,7 @@ export const features = [
   "addRandomInstallations",
   "createGroup",
 ];
-const testName = "group";
 const testConfig = {
-  testName: testName,
   groupName: `Group ${getTime()}`,
   epochs: 3,
   manualUsers: getManualUsers([(process.env.XMTP_ENV as string) + "-testing"]),
@@ -38,7 +36,7 @@ const testConfig = {
   freshInstalls: false,
 } as const;
 
-describe(testName, () => {
+describe("chaos", () => {
   let workers: WorkerManager;
   let creator: Worker;
   let allInboxIds: string[] = [];

--- a/suites/other/chaos.test.ts
+++ b/suites/other/chaos.test.ts
@@ -44,9 +44,7 @@ describe(testName, () => {
   let allInboxIds: string[] = [];
   let allGroups: string[] = [];
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   beforeAll(async () => {
     // Initialize workers

--- a/suites/other/chaos.test.ts
+++ b/suites/other/chaos.test.ts
@@ -45,7 +45,6 @@ describe(testName, () => {
   let allGroups: string[] = [];
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/other/notifications.test.ts
+++ b/suites/other/notifications.test.ts
@@ -4,12 +4,10 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import type { Conversation, Group } from "@xmtp/node-sdk";
 import { describe, it } from "vitest";
 
-const testName = "notifications";
-
 const receiverObj = getManualUsers(["fabri-convos-dev"])[0];
 const receiverInboxId = receiverObj.inboxId;
 
-describe(testName, () => {
+describe("notifications", () => {
   let group: Conversation;
   let workers: WorkerManager;
 

--- a/suites/other/rate-limited.test.ts
+++ b/suites/other/rate-limited.test.ts
@@ -4,9 +4,7 @@ import { typeofStream, typeOfSync } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
-const testName = "rate-limited";
-
-describe(testName, async () => {
+describe("rate-limited", async () => {
   const workers = await getWorkers(8);
   // Start message and response streams for rate limiting test
   workers.startStream(typeofStream.MessageandResponse);

--- a/suites/other/rate-limited.test.ts
+++ b/suites/other/rate-limited.test.ts
@@ -16,9 +16,7 @@ describe(testName, async () => {
 
   let targetInboxId: string;
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should send high-volume parallel messages from multiple worker threads to test rate limiting", async () => {
     try {

--- a/suites/other/rate-limited.test.ts
+++ b/suites/other/rate-limited.test.ts
@@ -17,7 +17,6 @@ describe(testName, async () => {
   let targetInboxId: string;
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/suites/other/spam.test.ts
+++ b/suites/other/spam.test.ts
@@ -13,7 +13,7 @@ const spamInboxIds = [
 const testName = "spam";
 
 describe(testName, () => {
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   it("should generate storage efficiency table for different group sizes", async () => {
     try {

--- a/suites/other/spam.test.ts
+++ b/suites/other/spam.test.ts
@@ -10,10 +10,9 @@ const targetSizeMB = 10;
 const spamInboxIds = [
   "c10e8c13c833f1826e98fb0185403c2c4d5737cc432d575468613abf9adae26b",
 ];
-const testName = "spam";
 
-describe(testName, () => {
-  setupTestLifecycle({ expect });
+describe("spam", () => {
+  setupTestLifecycle({});
 
   it("should generate storage efficiency table for different group sizes", async () => {
     try {

--- a/suites/other/storage.test.ts
+++ b/suites/other/storage.test.ts
@@ -19,7 +19,7 @@ const targetSizeMB = 5;
 const testName = "storage";
 
 describe(testName, () => {
-  setupTestLifecycle({ testName, expect });
+  setupTestLifecycle({ expect });
 
   it("should generate storage efficiency table for different group sizes", async () => {
     const results: StorageMetrics[] = [];

--- a/suites/other/storage.test.ts
+++ b/suites/other/storage.test.ts
@@ -16,10 +16,9 @@ interface StorageMetrics {
 
 const memberCounts = [2, 10, 50, 100, 150, 200];
 const targetSizeMB = 5;
-const testName = "storage";
 
-describe(testName, () => {
-  setupTestLifecycle({ expect });
+describe("storage", () => {
+  setupTestLifecycle({});
 
   it("should generate storage efficiency table for different group sizes", async () => {
     const results: StorageMetrics[] = [];

--- a/workers/README.md
+++ b/workers/README.md
@@ -9,9 +9,7 @@ import { setupTestLifecycle } from "@helpers/vitest";
 import { getWorkers } from "@workers/manager";
 import { describe, expect, it } from "vitest";
 
-const testName = "my-test";
-
-describe(testName, async () => {
+describe("my-test", async () => {
   const workers = await getWorkers(["alice", "bob"]);
 
   setupTestLifecycle({});

--- a/workers/README.md
+++ b/workers/README.md
@@ -15,7 +15,6 @@ describe(testName, async () => {
   const workers = await getWorkers(["alice", "bob"]);
 
   setupTestLifecycle({
-    testName,
     expect,
   });
 

--- a/workers/README.md
+++ b/workers/README.md
@@ -14,9 +14,7 @@ const testName = "my-test";
 describe(testName, async () => {
   const workers = await getWorkers(["alice", "bob"]);
 
-  setupTestLifecycle({
-    expect,
-  });
+  setupTestLifecycle({});
 
   it("should do something", async () => {
     try {
@@ -172,7 +170,7 @@ try {
 
 - Use `getWorkersWithVersions()` for version testing
 - Use `typeofStream.Message` for message streaming
-- Always call `setupTestLifecycle()` for proper cleanup
+- Always call `setupTestLifecycle({})` for proper cleanup
 - Test file naming: `*.test.ts` in `suites/` directory
 
 ## Key Imports


### PR DESCRIPTION
### Refactor test setup to use dynamic describe names by removing testName and expect parameters from setupTestLifecycle function
The changes modify the `setupTestLifecycle` function in [helpers/vitest.ts](https://github.com/xmtp/xmtp-qa-tools/pull/699/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4) to automatically extract test names from stack traces instead of requiring explicit parameters. The function removes the `testName` and `expect` parameters and introduces a new `getDescribeName()` function that analyzes the call stack to determine the test name from `.test.ts` files. All test files across the codebase are updated to use the simplified API by passing an empty object `{}` to `setupTestLifecycle()` and hardcoding test names directly in `describe()` functions rather than using separate variables. Documentation files are updated to reflect the new API usage pattern.

#### 📍Where to Start
Start with the `setupTestLifecycle` function and the new `getDescribeName()` function in [helpers/vitest.ts](https://github.com/xmtp/xmtp-qa-tools/pull/699/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4) to understand how the dynamic test name extraction works.

----

_[Macroscope](https://app.macroscope.com) summarized 2222a56._