### PR TITLE
Update groupTesting settings for agent configurations

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test: [agents-dms, agents-groups]
+        test: [agents-dms]
         environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -5,9 +5,8 @@
     "address": "0x557463B158F70e4E269bB7BCcF6C587e3BC878F4",
     "sendMessage": "hi",
     "networks": ["production"],
-    "disabled": false,
     "slackChannel": "#flaunchy-alerts",
-    "groupTesting": true
+    "groupTesting": false
   },
   {
     "name": "mamo",
@@ -15,7 +14,8 @@
     "address": "0x99B10779557cc52c6E3a97C9A6C3446f021290cc",
     "sendMessage": "hi",
     "networks": ["production"],
-    "slackChannel": "#mamo-alerts"
+    "slackChannel": "#mamo-alerts",
+    "groupTesting": true
   },
   {
     "name": "squabble",
@@ -42,7 +42,8 @@
     "sendMessage": "hola",
     "expectedMessage": ["chat", "invalid"],
     "networks": ["dev", "production"],
-    "slackChannel": "#csx-alerts"
+    "slackChannel": "#csx-alerts",
+    "groupTesting": false
   },
 
   {
@@ -52,7 +53,8 @@
     "sendMessage": "hola",
     "expectedMessage": ["chat", "invalid"],
     "networks": ["dev", "production"],
-    "slackChannel": "#gang-alerts"
+    "slackChannel": "#gang-alerts",
+    "groupTesting": false
   },
   {
     "name": "elsa",
@@ -60,7 +62,8 @@
     "address": "0xe15aa1ba585aea8a4639331ce5f9aec86f8c4541",
     "sendMessage": "hi",
     "networks": ["production"],
-    "slackChannel": "#elsa-alerts"
+    "slackChannel": "#elsa-alerts",
+    "groupTesting": true
   },
   {
     "name": "byte",
@@ -68,7 +71,8 @@
     "address": "0xdfc00a0B28Df3c07b0942300E896C97d62014499",
     "sendMessage": "hi",
     "networks": ["production"],
-    "slackChannel": "#byte-alerts"
+    "slackChannel": "#byte-alerts",
+    "groupTesting": true
   },
   {
     "name": "gm",
@@ -76,7 +80,8 @@
     "address": "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0",
     "sendMessage": "hola",
     "networks": ["production"],
-    "slackChannel": "#gm-alerts"
+    "slackChannel": "#gm-alerts",
+    "groupTesting": true
   },
   {
     "name": "bankr",
@@ -84,7 +89,8 @@
     "address": "0x7f1c0d2955f873fc91f1728c19b2ed7be7a9684d",
     "sendMessage": "hey there how are you?",
     "networks": ["production"],
-    "slackChannel": "#bankr-alerts"
+    "slackChannel": "#bankr-alerts",
+    "groupTesting": true
   },
   {
     "name": "tokenbot",
@@ -101,6 +107,7 @@
     "address": "0x75681fDc873f82030630e1005f611Fa932eE1A14",
     "sendMessage": "/help",
     "networks": ["production"],
-    "slackChannel": "#tbachat-alerts"
+    "slackChannel": "#tbachat-alerts",
+    "groupTesting": true
   }
 ]

--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -20,8 +20,8 @@
   {
     "name": "squabble",
     "baseName": "squabble.base.eth",
-    "address": "0xaE59E04E2649bC725d5A91AcF13be6EE5E83f04b",
-    "sendMessage": "gm",
+    "address": "0xD60d560c9Ae4ad9b7C252FacE7B664A8d7A426da",
+    "sendMessage": "@squabble.base.eth",
     "networks": ["production"],
     "slackChannel": "#squabble-alerts",
     "groupTesting": true


### PR DESCRIPTION
### Update groupTesting settings for agent configurations by disabling group testing at the top level and enabling it selectively for specific agents
- Modifies the GitHub workflow in [Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/710/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) to remove `agents-groups` from the test matrix, leaving only `agents-dms` tests to run in both dev and production environments
- Updates the agents configuration in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/710/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) by changing the top-level `groupTesting` property from true to false, removing the `disabled: false` property, and adding individual `groupTesting` settings to specific agent configurations (true for mamo-alerts, elsa-alerts, byte-alerts, gm-alerts, bankr-alerts, and tbachat-alerts; false for csx-alerts and gang-alerts)

#### 📍Where to Start
Start with the agents configuration changes in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/710/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) to understand how group testing has been reconfigured at both the global and individual agent levels.

----

_[Macroscope](https://app.macroscope.com) summarized 907cd3d._