### PR TITLE
Rename test files for consistency and clarity

### DIFF
--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -20,6 +20,7 @@ export const setupTestLifecycle = ({
 }) => {
   beforeAll(() => {
     const describeName = getDescribeName();
+    console.debug("describeName", describeName);
     loadEnv(describeName);
   });
   let skipNetworkStats = false;

--- a/suites/agents/agents-dms.test.ts
+++ b/suites/agents/agents-dms.test.ts
@@ -3,7 +3,7 @@ import { sendMetric } from "@helpers/datadog";
 import { verifyBotMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getWorkers } from "@workers/manager";
-import { IdentifierKind, type Dm } from "@xmtp/node-sdk";
+import { IdentifierKind, type Dm, type XmtpEnv } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 import productionAgents from "./agents.json";
 import { type AgentConfig } from "./helper";
@@ -11,8 +11,8 @@ import { type AgentConfig } from "./helper";
 const testName = "agents";
 
 describe(testName, async () => {
-  const env = process.env.XMTP_ENV as "dev" | "production";
-  const workers = await getWorkers(["alice"], { env });
+  const env = process.env.XMTP_ENV as XmtpEnv;
+  const workers = await getWorkers(["alice"]);
 
   setupTestLifecycle({});
 

--- a/suites/agents/agents-groups.test.ts
+++ b/suites/agents/agents-groups.test.ts
@@ -2,7 +2,7 @@ import { streamTimeout } from "@helpers/client";
 import { sendMetric } from "@helpers/datadog";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getWorkers } from "@workers/manager";
-import { IdentifierKind } from "@xmtp/node-sdk";
+import { IdentifierKind, type XmtpEnv } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 import productionAgents from "./agents.json";
 import { type AgentConfig } from "./helper";
@@ -10,8 +10,8 @@ import { type AgentConfig } from "./helper";
 const testName = "agents-groups";
 
 describe(testName, async () => {
-  const env = process.env.XMTP_ENV as "dev" | "production";
-  const workers = await getWorkers(["alice", "bob"], { env });
+  const env = process.env.XMTP_ENV as XmtpEnv;
+  const workers = await getWorkers(["alice", "bob"]);
 
   setupTestLifecycle({});
 


### PR DESCRIPTION
### Rename test files for consistency and clarity and update agent test files to use XmtpEnv type from @xmtp/node-sdk
- Renames [suites/agents/agent-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/713/files#diff-f1dde79fae158e51128cf8413ab01117afed4d2117ba3a663d69bce46e23871c) to [suites/agents/agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/713/files#diff-bb8296cd180fddaeacac442a33c7b8eb00c648f56e8b17041a0a3994dc85a569) for naming consistency
- Updates both agent test files to import `XmtpEnv` type from `@xmtp/node-sdk` and replaces hardcoded union type with `XmtpEnv` for environment variable typing
- Modifies `getWorkers` function calls in both test files to remove the explicit environment parameter, now only passing user arrays

#### 📍Where to Start
Start with the renamed [suites/agents/agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/713/files#diff-bb8296cd180fddaeacac442a33c7b8eb00c648f56e8b17041a0a3994dc85a569) file to review the file rename and type changes.

----

_[Macroscope](https://app.macroscope.com) summarized f479d16._