### PR TITLE
Separate logs and env from installation DBs

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -40,15 +40,25 @@ jobs:
         run: yarn
       - name: Run tests
         run: yarn test ${{ matrix.test }} --debug --no-fail
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}-${{ matrix.test }}
+          name: logs-env-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          overwrite: true
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-${{ matrix.environment }}-${{ matrix.test }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           overwrite: true
           include-hidden-files: true

--- a/.github/workflows/Browser.yml
+++ b/.github/workflows/Browser.yml
@@ -39,15 +39,25 @@ jobs:
         run: yarn
       - name: Run tests
         run: yarn test ${{ matrix.test }} --no-fail --debug
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: logs-env-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          overwrite: true
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-${{ matrix.environment }}-${{ matrix.test }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           overwrite: true
           include-hidden-files: true

--- a/.github/workflows/Delivery.yml
+++ b/.github/workflows/Delivery.yml
@@ -40,15 +40,24 @@ jobs:
         run: yarn
       - name: Run tests
         run: yarn test ${{ matrix.test }} --no-fail --debug
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: logs-env-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-${{ matrix.environment }}-${{ matrix.test }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 90

--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -40,15 +40,24 @@ jobs:
         run: yarn
       - name: Run tests
         run: yarn test ${{ matrix.test }} --debug --no-fail
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: logs-env-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-${{ matrix.environment }}-${{ matrix.test }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 90

--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -42,15 +42,25 @@ jobs:
         run: yarn
       - name: Run tests
         run: yarn test ${{ matrix.test }} --no-fail --debug
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: logs-env-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          overwrite: true
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-${{ matrix.environment }}-${{ matrix.test }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           overwrite: true
           include-hidden-files: true

--- a/.github/workflows/NetworkChaos.yml
+++ b/.github/workflows/NetworkChaos.yml
@@ -69,15 +69,25 @@ jobs:
             npx vitest run $FILE
           fi
 
-      - name: Upload Test Artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: chaos-artifacts-${{ matrix.test_file }}
+          name: logs-env-chaos-${{ matrix.test_file }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          overwrite: true
+          include-hidden-files: true
+          retention-days: 30
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-chaos-${{ matrix.test_file }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           overwrite: true
           include-hidden-files: true

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -55,15 +55,25 @@ jobs:
             channel: ${{ secrets.SLACK_CHANNEL }}
           }).catch(console.error);
           "
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: logs-env-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          overwrite: true
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-${{ matrix.environment }}-${{ matrix.test }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           overwrite: true
           include-hidden-files: true

--- a/.github/workflows/Regression.yml
+++ b/.github/workflows/Regression.yml
@@ -41,15 +41,25 @@ jobs:
         run: yarn script versions
       - name: Run tests
         run: yarn test ${{ matrix.test }} --no-fail --debug
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: logs-env-${{ matrix.environment }}-${{ matrix.test }}
           path: |
             logs/**/*
-            .data/**/*
             .env
+          if-no-files-found: ignore
+          overwrite: true
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-${{ matrix.environment }}-${{ matrix.test }}
+          path: |
+            .data/**/*
           if-no-files-found: ignore
           overwrite: true
           include-hidden-files: true

--- a/.github/workflows/SelfTest.yml
+++ b/.github/workflows/SelfTest.yml
@@ -41,15 +41,24 @@ jobs:
           cd qa-tools-test
           timeout 300s yarn dms
 
-      - name: Upload test artifacts
+      - name: Upload logs and environment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.environment }}
+          name: logs-env-selftest
           path: |
-            logs/**/*
-            .data/**/*
-            .env
+            qa-tools-test/logs/**/*
+            qa-tools-test/.env
+          if-no-files-found: ignore
+          include-hidden-files: true
+          retention-days: 90
+      - name: Upload installation databases
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-db-selftest
+          path: |
+            qa-tools-test/.data/**/*
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 90


### PR DESCRIPTION
Split GitHub Actions test artifact uploads into separate files for logs/environment and installation databases to improve organization.