### PR TITLE
Fix performance test suite bug

### DIFF
--- a/helpers/README.md
+++ b/helpers/README.md
@@ -83,7 +83,7 @@ The `analyzer.ts` module provides log analysis and error detection capabilities 
 
 ```typescript
 // Extract error logs from test output
-const errorLogs = extractErrorLogs(testName, 50);
+const errorLogs = await extractErrorLogs(testName, 50);
 
 // Check if test failures match known issues
 const shouldFilter = shouldFilterOutTest(errorLogs);

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -388,7 +388,7 @@ async function runVitestTest(
 
         // Only send Slack notification when debug flags are explicitly used
         if (options.explicitLogFlag) {
-          const errorLogs = extractErrorLogs(logger.logFileName, 20);
+          const errorLogs = await extractErrorLogs(logger.logFileName, 20);
           if (errorLogs.size > 0) {
             await sendSlackNotification({
               testName,


### PR DESCRIPTION
Refactor log file processing to use streaming to prevent `ERR_STRING_TOO_LONG` errors with large files.

The previous implementation used `fs.readFileSync` to read entire log files into memory, which caused the test runner to crash with an `ERR_STRING_TOO_LONG` error when performance test logs exceeded Node.js's maximum string length limit (~536MB). This PR introduces a streaming approach to process log files line by line, avoiding memory exhaustion, and adds a file size check to prevent processing excessively large files.