### PR TITLE
Improve notification message clarity for test failures

### DIFF
--- a/helpers/notifications.ts
+++ b/helpers/notifications.ts
@@ -109,8 +109,8 @@ function generateMessage(options: SlackNotificationOptions): string {
   const region = process.env.GEOLOCATION || "Unknown Region";
 
   const sections = [
-    `*Test Failure ❌*${tagMessage}`,
-    `*Test:* <${URLS.GITHUB_ACTIONS}/${repository}/actions/workflows/${workflowName}.yml|${testName}>`,
+    `*${testName}*: ⚠️ - ${tagMessage}`,
+    `*Workflow URL:* <${URLS.GITHUB_ACTIONS}/${repository}/actions/workflows/${workflowName}.yml|${testName}>`,
     `*Environment:* \`${environment}\``,
     `*General dashboard:* <${URLS.DATADOG_DASHBOARD}|View>`,
     `*Geolocation:* \`${region}\``,


### PR DESCRIPTION
### Improve notification message clarity for test failures by modifying the `generateMessage` function in helpers/notifications.ts to display test names and workflow URLs more clearly
The `generateMessage` function in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/720/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc) modifies Slack notification message formatting by replacing the generic "Test Failure ❌" header with the actual test name followed by a warning symbol "⚠️", and changes the second line label from "Test" to "Workflow URL" for the GitHub Actions link.

#### 📍Where to Start
Start with the `generateMessage` function in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/720/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc).

----

_[Macroscope](https://app.macroscope.com) summarized 08cc10b._