### PR TITLE
Add new agents for csx and gang with alert settings

### DIFF
--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -18,6 +18,27 @@
     "shouldRespondOnTagged": true
   },
   {
+    "name": "csx",
+    "baseName": "csx.base.eth",
+    "address": "0x74563b2e03f8539ea0ee99a2d6c6b4791e652901",
+    "sendMessage": "hola",
+    "expectedMessage": ["chat", "invalid"],
+    "networks": ["dev", "production"],
+    "slackChannel": "#csx-alerts",
+    "shouldRespondOnTagged": false
+  },
+
+  {
+    "name": "gang",
+    "baseName": "gang.base.eth",
+    "address": "0x6461bf53ddb33b525c84bf60d6bb31fa10828474",
+    "sendMessage": "hola",
+    "expectedMessage": ["chat", "invalid"],
+    "networks": ["dev", "production"],
+    "slackChannel": "#gang-alerts",
+    "shouldRespondOnTagged": false
+  },
+  {
     "name": "flaunchy",
     "baseName": "flaunchy.base.eth",
     "address": "0x557463B158F70e4E269bB7BCcF6C587e3BC878F4",


### PR DESCRIPTION
### Add new agents for csx and gang with alert settings to the agents configuration
Adds two new agent configurations to [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/722/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) with complete settings including base names, addresses, message configurations, network assignments, and Slack alert channels. The `csx` agent uses address `0x74563b2e03f8539ea0ee99a2d6c6b4791e652901` with `#csx-alerts` channel, while the `gang` agent uses address `0x6461bf53ddb33b525c84bf60d6bb31fa10828474` with `#gang-alerts` channel. Both agents are configured for `dev` and `production` networks with `hola` send messages and `chat`/`invalid` expected responses.

#### 📍Where to Start
Start with the new agent configurations in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/722/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) to review the added `csx` and `gang` agent entries.

----

_[Macroscope](https://app.macroscope.com) summarized ebb3a03._