### PR TITLE
Refactor logging and notification for better clarity

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -18,22 +18,10 @@ export const PATTERNS = {
       ],
     },
     {
-      testName: "Functional",
+      testName: "Agents-tagged",
       uniqueErrorLines: [
-        "FAIL  suites/functional/playwright.test.ts > playwright > conversation stream for new member",
-      ],
-    },
-    {
-      testName: "Functional",
-      uniqueErrorLines: [
-        "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation with async",
-        "FAIL  suites/functional/playwright.test.ts > playwright > newGroup and message stream",
-      ],
-    },
-    {
-      testName: "Agents",
-      uniqueErrorLines: [
-        "FAIL  suites/agents/agents.test.ts > agents > production: tokenbot : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
+        "FAIL  suites/agents/agents-tagged.test.ts [ suites/agents/agents-tagged.test.ts ]",
+        "FAIL  suites/agents/agents-tagged.test.ts > agents-tagged",
       ],
     },
   ],

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -43,10 +43,17 @@ export const PATTERNS = {
       ],
     },
     {
-      testName: "Functional",
+      testName: "Agents-tagged",
       uniqueErrorLines: [
-        "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation with async",
-        "FAIL  suites/functional/playwright.test.ts > playwright > newGroup and message stream",
+        "FAIL  suites/agents/agents-tagged.test.ts [ suites/agents/agents-tagged.test.ts ]",
+        "FAIL  suites/agents/agents-tagged.test.ts > agents-tagged",
+      ],
+    },
+    {
+      testName: "Agents-untagged",
+      uniqueErrorLines: [
+        "FAIL  suites/agents/agents-untagged.test.ts [ suites/agents/agents-untagged.test.ts ]",
+        "FAIL  suites/agents/agents-untagged.test.ts > agents-untagged",
       ],
     },
     {

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -18,6 +18,13 @@ export const PATTERNS = {
       ],
     },
     {
+      testName: "Agents-untagged",
+      uniqueErrorLines: [
+        "FAIL  suites/agents/agents-untagged.test.ts [ suites/agents/agents-untagged.test.ts ]",
+        "FAIL  suites/agents/agents-untagged.test.ts > agents-untagged",
+      ],
+    },
+    {
       testName: "Agents-tagged",
       uniqueErrorLines: [
         "FAIL  suites/agents/agents-tagged.test.ts [ suites/agents/agents-tagged.test.ts ]",

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -18,17 +18,41 @@ export const PATTERNS = {
       ],
     },
     {
-      testName: "Agents-untagged",
+      testName: "Functional",
       uniqueErrorLines: [
-        "FAIL  suites/agents/agents-untagged.test.ts [ suites/agents/agents-untagged.test.ts ]",
-        "FAIL  suites/agents/agents-untagged.test.ts > agents-untagged",
+        "FAIL  suites/functional/playwright.test.ts > playwright > conversation stream for new member",
       ],
     },
     {
-      testName: "Agents-tagged",
+      testName: "Functional",
       uniqueErrorLines: [
-        "FAIL  suites/agents/agents-tagged.test.ts [ suites/agents/agents-tagged.test.ts ]",
-        "FAIL  suites/agents/agents-tagged.test.ts > agents-tagged",
+        "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation with async",
+        "FAIL  suites/functional/playwright.test.ts > playwright > newGroup and message stream",
+      ],
+    },
+    {
+      testName: "Agents-dms",
+      uniqueErrorLines: [
+        "FAIL  suites/agents/agents.test.ts > agents > production: tokenbot : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
+      ],
+    },
+    {
+      testName: "Functional",
+      uniqueErrorLines: [
+        "FAIL  suites/functional/playwright.test.ts > playwright > conversation stream for new member",
+      ],
+    },
+    {
+      testName: "Functional",
+      uniqueErrorLines: [
+        "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation with async",
+        "FAIL  suites/functional/playwright.test.ts > playwright > newGroup and message stream",
+      ],
+    },
+    {
+      testName: "Agents-dms",
+      uniqueErrorLines: [
+        "FAIL  suites/agents/agents.test.ts > agents > production: tokenbot : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
       ],
     },
   ],

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -398,7 +398,6 @@ export function flushMetrics(): Promise<void> {
 export async function sendDatadogLog(
   lines: string[],
   context: Record<string, unknown> = {},
-  options?: { channel?: string },
 ): Promise<void> {
   const apiKey = process.env.DATADOG_API_KEY;
   if (!apiKey) return;
@@ -407,7 +406,7 @@ export async function sendDatadogLog(
   const workflowName = process.env.GITHUB_WORKFLOW || "Unknown Workflow";
   const environment = process.env.ENVIRONMENT || process.env.XMTP_ENV;
   const region = process.env.GEOLOCATION || "Unknown Region";
-  const channel = options?.channel || context.channel || "general";
+  const channel = context.channel || "general";
 
   const logPayload = {
     message: lines.join("\n"),

--- a/helpers/notifications.ts
+++ b/helpers/notifications.ts
@@ -117,17 +117,14 @@ export async function sendSlackNotification(
 
   if (options.errorLogs && options.errorLogs.size > 0) {
     const failLines = extractFailLines(options.errorLogs);
-    await sendDatadogLog(
-      Array.from(options.errorLogs),
-      {
-        test: options.testName,
-        failLines: Array.from(failLines).length,
-        env: process.env.ENVIRONMENT || process.env.XMTP_ENV,
-        region: process.env.GEOLOCATION,
-        sdk: "latest",
-      },
-      { channel: options.channel },
-    );
+    await sendDatadogLog(Array.from(options.errorLogs), {
+      channel: options.channel,
+      test: options.testName,
+      failLines: Array.from(failLines).length,
+      env: process.env.ENVIRONMENT || process.env.XMTP_ENV,
+      region: process.env.GEOLOCATION,
+      sdk: "latest",
+    });
   }
 
   // Check if test should be filtered out


### PR DESCRIPTION
### Remove dashboard links, environment information, and timestamps from Slack notification messages for better clarity
- Remove URL generation, dashboard links, environment information, geolocation, timestamps, and custom links from `generateMessage` function in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/723/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc)
- Add new test issue categories including "Agents-tagged", "Agents-untagged", "Functional", and rename "Agents" to "Agents-dms" in `PATTERNS.KNOWN_ISSUES` array in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/723/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193)
- Remove `options` parameter from `sendDatadogLog` function and extract environment variables directly for repository, workflow, environment, and region in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/723/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3)
- Remove `URLS` constant object, `SERVICE_IDS` record, and `generateUrl` function from [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/723/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc)

#### 📍Where to Start
Start with the `generateMessage` function in [helpers/notifications.ts](https://github.com/xmtp/xmtp-qa-tools/pull/723/files#diff-634d9674f8298dce72c561f34883343049a4348d7f451287f74507074b7e5fdc) to see the core notification message changes.

----

_[Macroscope](https://app.macroscope.com) summarized b1ac9da._