### PR TITLE
Update error patterns and improve session ID handling

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -399,7 +399,9 @@ export async function sendSlackNotification(options: {
   const tagMessage = shouldTagFabri ? " <@fabri>" : "";
 
   const sections = [
-    `*${options.testName} ⚠️* ${tagMessage} | \`${process.env.XMTP_ENV}\` | \`${process.env.GEOLOCATION}\` | <${workflowRunUrl}|View Run>`,
+    `*${options.testName} ⚠️* ${tagMessage}`,
+    `\`${process.env.XMTP_ENV}\` | \`${process.env.GEOLOCATION}\``,
+    `<${workflowRunUrl}|View Run>`,
     `Logs:\n\`\`\`${sanitizeLogs(Array.from(options.errorLogs).join("\n"))}\`\`\``,
   ];
 

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -24,6 +24,7 @@ export const PATTERNS = {
         "FAIL  suites/functional/playwright.test.ts > playwright > conversation stream for new member",
       ],
     },
+
     {
       testName: "Functional",
       uniqueErrorLines: [
@@ -34,7 +35,7 @@ export const PATTERNS = {
     {
       testName: "Agents-dms",
       uniqueErrorLines: [
-        "FAIL  suites/agents/agents.test.ts > agents > production: tokenbot : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
+        "FAIL  suites/agents/agents-dms.test.ts > agents-dms > production: tokenbot DM : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
       ],
     },
     {

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -2,7 +2,7 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import metrics from "datadog-metrics";
 import fetch from "node-fetch";
-import { shouldFilterOutTest } from "./analyzer";
+import { extractFailLines, shouldFilterOutTest } from "./analyzer";
 
 // Consolidated interfaces
 interface MetricData {
@@ -327,6 +327,7 @@ export async function sendDatadogLog(
     service: "xmtp-qa-tools",
     source: "xmtp-qa-tools",
     channel: context.channel || "general",
+    failLines: extractFailLines(new Set(lines)),
     repository: process.env.GITHUB_REPOSITORY as string,
     workflowName: process.env.GITHUB_WORKFLOW as string,
     workflowRunUrl: workflowRunUrl,

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -552,6 +552,8 @@ export async function verifyBotMessageStream(
   let result: VerifyStreamResult | undefined;
 
   while (attempts < maxRetries) {
+    const sessionId = `bot-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+
     result = await collectAndTimeEventsWithStats({
       receivers,
       startCollectors: (r) =>
@@ -564,9 +566,9 @@ export async function verifyBotMessageStream(
       triggerEvents: async () => {
         const sentAt = Date.now();
         await group.send(triggerMessage);
-        return [{ content: triggerMessage, sentAt }];
+        return [{ sessionId, sentAt }];
       },
-      getKey: extractContent,
+      getKey: () => sessionId, // Use consistent sessionId for both sent and received
       getMessage: extractContent,
       statsLabel: "bot-response:",
       count: 1,


### PR DESCRIPTION
### Implement session ID tracking for bot message verification and update error patterns in test analysis
- Modifies `verifyBotMessageStream` function in [streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/726/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to generate unique session IDs for message correlation instead of using message content
- Updates error pattern matching for 'Agents-dms' test in [analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/726/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) to point to new test file path and reformats Slack notification messages
- Adds `failLines` field to Datadog log payload in [datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/726/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) by importing and using `extractFailLines` function

#### 📍Where to Start
Start with the `verifyBotMessageStream` function in [streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/726/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to understand the session ID implementation changes.

----

_[Macroscope](https://app.macroscope.com) summarized 791fbe9._