### PR TITLE
Add tests for environments with no configured agents

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -13,12 +13,6 @@ export const PATTERNS = {
       ],
     },
     {
-      testName: "Dms",
-      uniqueErrorLines: [
-        "FAIL  suites/functional/dms.test.ts > dms > fail on purpose",
-      ],
-    },
-    {
       testName: "Functional",
       uniqueErrorLines: [
         "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation with async",

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -21,13 +21,6 @@ export const PATTERNS = {
     {
       testName: "Functional",
       uniqueErrorLines: [
-        "FAIL  suites/functional/playwright.test.ts > playwright > conversation stream for new member",
-      ],
-    },
-
-    {
-      testName: "Functional",
-      uniqueErrorLines: [
         "FAIL  suites/functional/callbacks.test.ts > callbacks > should receive conversation with async",
         "FAIL  suites/functional/playwright.test.ts > playwright > newGroup and message stream",
       ],
@@ -42,26 +35,6 @@ export const PATTERNS = {
       testName: "Functional",
       uniqueErrorLines: [
         "FAIL  suites/functional/playwright.test.ts > playwright > conversation stream for new member",
-      ],
-    },
-    {
-      testName: "Agents-tagged",
-      uniqueErrorLines: [
-        "FAIL  suites/agents/agents-tagged.test.ts [ suites/agents/agents-tagged.test.ts ]",
-        "FAIL  suites/agents/agents-tagged.test.ts > agents-tagged",
-      ],
-    },
-    {
-      testName: "Agents-untagged",
-      uniqueErrorLines: [
-        "FAIL  suites/agents/agents-untagged.test.ts [ suites/agents/agents-untagged.test.ts ]",
-        "FAIL  suites/agents/agents-untagged.test.ts > agents-untagged",
-      ],
-    },
-    {
-      testName: "Agents-dms",
-      uniqueErrorLines: [
-        "FAIL  suites/agents/agents.test.ts > agents > production: tokenbot : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
       ],
     },
   ],

--- a/suites/agents/agents-dms.test.ts
+++ b/suites/agents/agents-dms.test.ts
@@ -22,6 +22,15 @@ describe(testName, async () => {
     return agent.networks.includes(env);
   });
 
+  // Handle case where no agents are configured for the current environment
+  if (filteredAgents.length === 0) {
+    it(`${env}: No agents configured for this environment`, () => {
+      console.log(`No agents found for environment: ${env}`);
+      expect(true).toBe(true); // Pass the test
+    });
+    return;
+  }
+
   // Test each agent in DMs
   for (const agent of filteredAgents) {
     it(`${env}: ${agent.name} DM : ${agent.address}`, async () => {

--- a/suites/agents/agents-tagged.test.ts
+++ b/suites/agents/agents-tagged.test.ts
@@ -21,6 +21,15 @@ describe(testName, async () => {
     return agent.networks.includes(env) && agent.shouldRespondOnTagged;
   });
 
+  // Handle case where no agents are configured for the current environment
+  if (filteredAgents.length === 0) {
+    it(`${env}: No agents configured for this environment`, () => {
+      console.log(`No agents found for environment: ${env}`);
+      expect(true).toBe(true); // Pass the test
+    });
+    return;
+  }
+
   for (const agent of filteredAgents) {
     it(`${env}: ${agent.name} should respond to tagged/command message : ${agent.address}`, async () => {
       const isSlashCommand = agent.sendMessage.startsWith("/");

--- a/suites/agents/agents-untagged.test.ts
+++ b/suites/agents/agents-untagged.test.ts
@@ -21,6 +21,15 @@ describe(testName, async () => {
     return agent.networks.includes(env) && agent.shouldRespondOnTagged;
   });
 
+  // Handle case where no agents are configured for the current environment
+  if (filteredAgents.length === 0) {
+    it(`${env}: No agents configured for this environment`, () => {
+      console.log(`No agents found for environment: ${env}`);
+      expect(true).toBe(true); // Pass the test
+    });
+    return;
+  }
+
   for (const agent of filteredAgents) {
     it(`${env}: ${agent.name} should not respond to untagged "hi" : ${agent.address}`, async () => {
       console.debug("sending message to agent", agent.name, agent.address);

--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -65,8 +65,4 @@ describe(testName, async () => {
     ]);
     expect(verifyResult.allReceived).toBe(true);
   });
-
-  it("fail on purpose", () => {
-    throw new Error("fail on purpose");
-  });
 });


### PR DESCRIPTION
### Add conditional test handling for environments with no configured agents in agent test suites
The changes add conditional blocks to three agent test files that check if `filteredAgents.length === 0` and create a passing test case when no agents are configured for the current environment. Each test suite now includes early return logic that prevents execution of agent-specific tests when the filtered agents array is empty, instead logging a message and passing with `expect(true).toBe(true)`.

- [agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/727/files#diff-bb8296cd180fddaeacac442a33c7b8eb00c648f56e8b17041a0a3994dc85a569) - adds conditional handling for empty agent configurations
- [agents-tagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/727/files#diff-27341650cd787e4903ca1cc50b151d4032b7a33fb36694108a846a96a88237ab) - adds conditional handling for empty agent configurations  
- [agents-untagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/727/files#diff-8a849c6d5ab8542b6c3442755495d273106e12136edc7afb303c7863c1b11b72) - adds conditional handling for empty agent configurations

#### 📍Where to Start
Start with the conditional block checking `filteredAgents.length === 0` in [agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/727/files#diff-bb8296cd180fddaeacac442a33c7b8eb00c648f56e8b17041a0a3994dc85a569) to understand the pattern applied across all three test files.

----

_[Macroscope](https://app.macroscope.com) summarized 22c8ee3._