### PR TITLE
Add test cases for additional agent identifiers

### DIFF
--- a/suites/agents/agents-tagged.test.ts
+++ b/suites/agents/agents-tagged.test.ts
@@ -1,5 +1,6 @@
 import { verifyBotMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { getAddresses } from "@inboxes/utils";
 import { getWorkers } from "@workers/manager";
 import {
   IdentifierKind,
@@ -47,6 +48,10 @@ describe(testName, async () => {
         .client.conversations.newGroupWithIdentifiers([
           {
             identifier: agent.address,
+            identifierKind: IdentifierKind.Ethereum,
+          },
+          {
+            identifier: getAddresses(1)[0],
             identifierKind: IdentifierKind.Ethereum,
           },
         ]);

--- a/suites/agents/agents-untagged.test.ts
+++ b/suites/agents/agents-untagged.test.ts
@@ -1,11 +1,13 @@
 import { verifyBotMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
+import { getAddresses } from "@inboxes/utils";
 import { getWorkers } from "@workers/manager";
 import {
   IdentifierKind,
   type Conversation,
   type XmtpEnv,
 } from "@xmtp/node-sdk";
+import { getAddress } from "viem";
 import { describe, expect, it } from "vitest";
 import productionAgents from "./agents.json";
 import { type AgentConfig } from "./helper";
@@ -38,6 +40,10 @@ describe(testName, async () => {
         .client.conversations.newGroupWithIdentifiers([
           {
             identifier: agent.address,
+            identifierKind: IdentifierKind.Ethereum,
+          },
+          {
+            identifier: getAddresses(1)[0],
             identifierKind: IdentifierKind.Ethereum,
           },
         ]);


### PR DESCRIPTION
### Add additional Ethereum address participants to agent test group conversations for tagged and untagged message testing
- Modifies group conversation creation in [agents-tagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/730/files#diff-27341650cd787e4903ca1cc50b151d4032b7a33fb36694108a846a96a88237ab) to include a second participant obtained from `getAddresses(1)[0]` with `IdentifierKind.Ethereum`
- Modifies group conversation creation in [agents-untagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/730/files#diff-8a849c6d5ab8542b6c3442755495d273106e12136edc7afb303c7863c1b11b72) to include a second participant obtained from `getAddresses(1)[0]` with `IdentifierKind.Ethereum`
- Adds import statements for `getAddresses` from `@inboxes/utils` in both test files

#### 📍Where to Start
Start with the conversation creation logic in [agents-tagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/730/files#diff-27341650cd787e4903ca1cc50b151d4032b7a33fb36694108a846a96a88237ab) where the additional participant is added to the group conversation.

----

_[Macroscope](https://app.macroscope.com) summarized 54b8d35._