### PR TITLE
Improve Slack notification format for better clarity

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -339,9 +339,10 @@ export async function sendSlackNotification(options: {
 
   const shouldTagFabri = options.errorLogs.size >= PATTERNS.minFailLines;
   const tagMessage = shouldTagFabri ? " <@fabri>" : "";
+  const icon = shouldTagFabri ? "🚨" : "⚠️";
 
   const sections = [
-    `*${options.testName} ⚠️* ${tagMessage}`,
+    `*Test*: ${options.testName} ${icon} ${tagMessage}`,
     `\`${process.env.XMTP_ENV}\` | \`${process.env.GEOLOCATION}\``,
     `<${workflowRunUrl}|View Run>`,
     `Logs:\n\`\`\`${sanitizeLogs(Array.from(options.errorLogs).join("\n"))}\`\`\``,


### PR DESCRIPTION
### Modify Slack notification format in `sendSlackNotification` function to display different icons based on failure severity and add Test label for better clarity
The `sendSlackNotification` function in [analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/731/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) now uses conditional icon selection where 🚨 displays for high-severity failures when `shouldTagFabri` is true and ⚠️ displays for lower-severity failures. The notification message format changes from `*${options.testName} ⚠️* ${tagMessage}` to `*Test*: ${options.testName} ${icon} ${tagMessage}` to include a Test label prefix.

#### 📍Where to Start
Start with the `sendSlackNotification` function in [analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/731/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193).

----

_[Macroscope](https://app.macroscope.com) summarized 5d0aa75._