### PR TITLE
Add known issues to documentation

### DIFF
--- a/helpers/known_issues.json
+++ b/helpers/known_issues.json
@@ -22,7 +22,8 @@
   {
     "testName": "Agents-dms",
     "uniqueErrorLines": [
-      "FAIL  suites/agents/agents-dms.test.ts > agents-dms > production: tokenbot DM : 0x9E73e4126bb22f79f89b6281352d01dd3d203466"
+      "FAIL  suites/agents/agents-dms.test.ts > agents-dms > production: tokenbot DM : 0x9E73e4126bb22f79f89b6281352d01dd3d203466",
+      "FAIL  suites/agents/agents-dms.test.ts > agents-dms > production: byte DM : 0xdfc00a0B28Df3c07b0942300E896C97d62014499"
     ]
   },
   {


### PR DESCRIPTION
### Add known test failure for byte DM with address 0xdfc00a0B28Df3c07b0942300E896C97d62014499 to documentation tracking system
Adds a new entry to the known issues JSON file for tracking test failures. The entry documents a `byte DM` test failure with the specific address `0xdfc00a0B28Df3c07b0942300E896C97d62014499` in [known_issues.json](https://github.com/xmtp/xmtp-qa-tools/pull/734/files#diff-b869a3bb9452b59b227a22b6eb4c3ebe9cfb2e9f77ae757f82b7570e9040f3b9).

#### 📍Where to Start
Start with the new entry added to [known_issues.json](https://github.com/xmtp/xmtp-qa-tools/pull/734/files#diff-b869a3bb9452b59b227a22b6eb4c3ebe9cfb2e9f77ae757f82b7570e9040f3b9).

----

_[Macroscope](https://app.macroscope.com) summarized 01947b7._