### PR TITLE
Improve logging and error handling in notifications

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -320,8 +320,9 @@ export async function logUpload(logFileName: string, testName: string) {
     console.debug(`shouldUploadLogs: ${shouldUploadLogs}`);
     if (shouldUploadLogs) await sendDatadogLog(errorLogs, testName, failLines);
     const shouldSendNotification = failLines.length >= PATTERNS.minFailLines;
+    console.log(`shouldSendNotification: ${shouldSendNotification}`);
     if (shouldSendNotification)
-      await sendSlackNotification(errorLogs, testName);
+      await sendSlackNotification(errorLogs, testName, failLines);
   }
 }
 

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -289,22 +289,24 @@ export function shouldFilterOutTest(
 ): boolean {
   const jobStatus = process.env.GITHUB_JOB_STATUS || "failed";
   if (jobStatus === "success") {
-    console.log(`Slack notification skipped (status: ${jobStatus})`);
+    console.warn(`Slack notification skipped (status: ${jobStatus})`);
     return true;
   }
 
   const branchName = (process.env.GITHUB_REF || "").replace("refs/heads/", "");
   if (branchName !== "main" && process.env.GITHUB_ACTIONS) {
-    console.log(`Slack notification skipped (branch: ${branchName})`);
+    console.warn(`Slack notification skipped (branch: ${branchName})`);
     return true;
   }
 
   if (!errorLogs || errorLogs.size === 0) {
+    console.warn("No error logs, skipping");
     return true;
   }
 
-  if (failLines.length === 0) {
-    return true; // Don't show if tests don't fail
+  if (Array.isArray(failLines) && failLines.length === 0) {
+    console.warn("No failLines logs, skipping");
+    return true;
   }
 
   return false;

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -316,11 +316,11 @@ export async function sendDatadogLog(
     service: "xmtp-qa-tools",
     source: "xmtp-qa-tools",
     test,
-    failLines: Array.isArray(failLines) ? failLines.length : 0,
+    failLines: failLines.length,
     repository: process.env.GITHUB_REPOSITORY as string,
     workflowName: process.env.GITHUB_WORKFLOW as string,
     workflowRunUrl: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
-    environment: process.env.XMTP_ENV,
+    env: process.env.XMTP_ENV,
     region: process.env.GEOLOCATION as string,
     sdk: getLatestSdkVersion(),
   };

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -324,7 +324,7 @@ export async function sendDatadogLog(
     region: process.env.GEOLOCATION as string,
     sdk: getLatestSdkVersion(),
   };
-
+  console.debug(logPayload);
   try {
     await fetch("https://http-intake.logs.datadoghq.com/v1/input", {
       method: "POST",

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -324,7 +324,7 @@ export async function sendDatadogLog(
     region: process.env.GEOLOCATION as string,
     sdk: getLatestSdkVersion(),
   };
-  console.debug(logPayload);
+
   try {
     await fetch("https://http-intake.logs.datadoghq.com/v1/input", {
       method: "POST",

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -4,6 +4,7 @@ import path from "path";
 import {
   extractErrorLogs,
   extractFailLines,
+  logUpload,
   sendSlackNotification,
   shouldFilterOutTest,
 } from "@helpers/analyzer";
@@ -391,20 +392,7 @@ async function runVitestTest(
           `\n❌ Test suite "${testName}" failed after ${options.maxAttempts} attempts.`,
         );
 
-        if (options.explicitLogFlag) {
-          const apiKey = process.env.DATADOG_API_KEY;
-          if (!apiKey) return;
-
-          const errorLogs = extractErrorLogs(logger.logFileName, 20);
-
-          if (errorLogs.size > 0) {
-            const failLines = extractFailLines(errorLogs);
-            if (shouldFilterOutTest(errorLogs, failLines)) {
-              await sendDatadogLog(errorLogs, testName, failLines);
-              await sendSlackNotification(errorLogs, testName, failLines);
-            }
-          }
-        }
+        if (options.explicitLogFlag) await logUpload(logger.logFileName);
 
         logger.close();
 

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -1,16 +1,9 @@
 import { execSync, spawn } from "child_process";
 import fs from "fs";
 import path from "path";
-import {
-  extractErrorLogs,
-  extractFailLines,
-  logUpload,
-  sendSlackNotification,
-  shouldFilterOutTest,
-} from "@helpers/analyzer";
+import { logUpload } from "@helpers/analyzer";
 import { createTestLogger } from "@helpers/logger";
 import "dotenv/config";
-import { sendDatadogLog } from "@helpers/datadog";
 
 interface RetryOptions {
   maxAttempts: number;
@@ -392,7 +385,8 @@ async function runVitestTest(
           `\n❌ Test suite "${testName}" failed after ${options.maxAttempts} attempts.`,
         );
 
-        if (options.explicitLogFlag) await logUpload(logger.logFileName);
+        if (options.explicitLogFlag)
+          await logUpload(logger.logFileName, testName);
 
         logger.close();
 


### PR DESCRIPTION
### Centralize error log processing and notification logic by adding `logUpload` function to [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/744/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) and set maximum error logs to 20
- Creates new `logUpload` function in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/744/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) that centralizes error log extraction, filtering, and notification sending for test failures
- Modifies `extractErrorLogs` function to always limit error logs to 20 using new `PATTERNS.maxErrorLogs` constant instead of optional parameter
- Updates `sendSlackNotification` function to always tag @fabri and use Slack link formatting for workflow URLs
- Changes `sendDatadogLog` function in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/744/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to use `env` property instead of `environment` in log payload
- Replaces complex error handling logic in `runVitestTest` function within [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/744/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) with single call to new `logUpload` function

#### 📍Where to Start
Start with the new `logUpload` function in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/744/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) to understand the centralized error handling logic, then review how it's called from `runVitestTest` in [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/744/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810).

----

_[Macroscope](https://app.macroscope.com) summarized bb974c9._