### PR TITLE
Add installation generation with groups and conversations

### DIFF
--- a/inboxes/gen.ts
+++ b/inboxes/gen.ts
@@ -10,12 +10,16 @@ import { Client, type XmtpEnv } from "@xmtp/node-sdk";
 
 const BASE_LOGPATH = "./logs";
 const INBOXES_DIR = "./inboxes";
+const INSTALLATIONS_DIR = "./inboxes/installations";
 let debugMode = false;
 
 // === Tweakable Defaults ===
 const DEFAULT_COUNT = 200;
 const DEFAULT_ENVS: XmtpEnv[] = ["local"];
 const DEFAULT_INSTALLATIONS = 2;
+const DEFAULT_INSTALLATIONS_COUNT = 2;
+const DEFAULT_GROUPS_PER_INSTALLATION = 200;
+const DEFAULT_CONVERSATIONS_PER_GROUP = 200;
 // =========================
 
 interface InboxData {
@@ -24,6 +28,18 @@ interface InboxData {
   dbEncryptionKey: string;
   inboxId: string;
   installations: number;
+}
+
+interface InstallationData {
+  accountAddress: string;
+  walletKey: string;
+  dbEncryptionKey: string;
+  inboxId: string;
+  installationId: string;
+  dbPath: string;
+  env: XmtpEnv;
+  groupsCreated: number;
+  conversationsCreated: number;
 }
 
 const debugLog = (...args: unknown[]) => {
@@ -171,7 +187,7 @@ function showFileStats(
 
 function showHelp() {
   console.log(
-    `\nXMTP Generator Utility\n\nUsage:\n  yarn gen [options]\n\nOptions:\n  --count <number>                Total number of accounts to ensure exist\n  --envs <envs>                   Comma-separated environments (local,dev,production) (default: local)\n  --installations <number>        Number of installations per account per network (default: 1)\n  --debug                         Enable debug logging\n  --help                          Show this help message\n`,
+    `\nXMTP Generator Utility\n\nUsage:\n  yarn gen [options]\n\nOptions:\n  --count <number>                Total number of accounts to ensure exist\n  --envs <envs>                   Comma-separated environments (local,dev,production) (default: local)\n  --installations <number>        Number of installations per account per network (default: 1)\n  --create-installations <number> Create installations with populated databases (default: 10)\n  --groups-per-installation <number> Number of groups per installation (default: 200)\n  --conversations-per-group <number> Number of conversations per group (default: 200)\n  --debug                         Enable debug logging\n  --help                          Show this help message\n`,
   );
 }
 
@@ -370,15 +386,178 @@ async function smartUpdate({
   );
 }
 
+async function createGroupsAndConversations(
+  client: Client,
+  targetGroups: number,
+  conversationsPerGroup: number,
+  allInboxes: InboxData[],
+): Promise<{ groupsCreated: number; conversationsCreated: number }> {
+  let groupsCreated = 0;
+  let conversationsCreated = 0;
+
+  await client.conversations.sync();
+  const progress = new ProgressBar(targetGroups);
+
+  for (let i = 0; i < targetGroups; i++) {
+    try {
+      const groupSize = Math.floor(Math.random() * 4) + 2;
+      const randomInboxes = allInboxes
+        .filter((inbox) => inbox.inboxId !== client.inboxId)
+        .sort(() => 0.5 - Math.random())
+        .slice(0, groupSize - 1)
+        .map((inbox) => inbox.inboxId);
+
+      const group = await client.conversations.newGroup(randomInboxes, {
+        groupName: `Test Group ${i + 1}`,
+        groupDescription: `Auto-generated test group ${i + 1}`,
+      });
+
+      groupsCreated++;
+
+      for (let j = 0; j < conversationsPerGroup; j++) {
+        try {
+          await group.send(`Message ${j + 1} in Test Group ${i + 1}`);
+          conversationsCreated++;
+        } catch (error) {
+          debugLog(`Failed to send message ${j + 1}:`, error);
+        }
+      }
+
+      progress.update();
+    } catch (error) {
+      debugLog(`Failed to create group ${i + 1}:`, error);
+      progress.update();
+    }
+  }
+
+  progress.finish();
+  return { groupsCreated, conversationsCreated };
+}
+
+async function generateInstallationsWithContent({
+  count = DEFAULT_INSTALLATIONS_COUNT,
+  env = "local" as XmtpEnv,
+  groupsPerInstallation = DEFAULT_GROUPS_PER_INSTALLATION,
+  conversationsPerGroup = DEFAULT_CONVERSATIONS_PER_GROUP,
+}: {
+  count?: number;
+  env?: XmtpEnv;
+  groupsPerInstallation?: number;
+  conversationsPerGroup?: number;
+}) {
+  if (env === "local") loadEnv("installation-generation");
+
+  console.log(
+    `\n🚀 Generating ${count} installations with ${groupsPerInstallation} groups, ${conversationsPerGroup} conversations each`,
+  );
+
+  if (!fs.existsSync(INSTALLATIONS_DIR)) {
+    fs.mkdirSync(INSTALLATIONS_DIR, { recursive: true });
+  }
+
+  // Load existing inboxes for group members
+  const inboxFiles = ["5.json", "25.json", "20.json", "15.json", "10.json"];
+  let allInboxes: InboxData[] = [];
+
+  for (const file of inboxFiles) {
+    const inboxes = readJson(`${INBOXES_DIR}/${file}`);
+    if (inboxes && inboxes.length > 0) {
+      allInboxes = inboxes;
+      break;
+    }
+  }
+
+  if (allInboxes.length < 10) {
+    console.error(
+      "❌ Not enough existing inboxes found. Please run 'yarn gen --count 100' first.",
+    );
+    return;
+  }
+
+  const installations: InstallationData[] = [];
+  const progress = new ProgressBar(count);
+
+  for (let i = 0; i < count; i++) {
+    try {
+      const walletKey = `0x${Buffer.from(crypto.getRandomValues(new Uint8Array(32))).toString("hex")}`;
+      const signer = createSigner(walletKey as `0x${string}`);
+      const identifier = await signer.getIdentifier();
+      const accountAddress = identifier.identifier;
+      const dbEncryptionKey = generateEncryptionKeyHex();
+      const dbPath = `${INSTALLATIONS_DIR}/installation-${i + 1}-${env}`;
+
+      const client = await Client.create(signer, {
+        dbEncryptionKey: getEncryptionKeyFromHex(dbEncryptionKey),
+        dbPath,
+        env,
+      });
+
+      const { groupsCreated, conversationsCreated } =
+        await createGroupsAndConversations(
+          client,
+          groupsPerInstallation,
+          conversationsPerGroup,
+          allInboxes,
+        );
+
+      installations.push({
+        accountAddress,
+        walletKey,
+        dbEncryptionKey,
+        inboxId: client.inboxId,
+        installationId: client.installationId,
+        dbPath,
+        env,
+        groupsCreated,
+        conversationsCreated,
+      });
+
+      progress.update();
+      debugLog(
+        `✅ Installation ${i + 1}: ${groupsCreated} groups, ${conversationsCreated} conversations`,
+      );
+    } catch (error) {
+      console.error(`❌ Failed to create installation ${i + 1}:`, error);
+      progress.update();
+    }
+  }
+
+  progress.finish();
+
+  const installationsFile = `${INSTALLATIONS_DIR}/installations-${env}.json`;
+  writeJson(installationsFile, installations);
+
+  const totalGroups = installations.reduce(
+    (sum, inst) => sum + inst.groupsCreated,
+    0,
+  );
+  const totalConversations = installations.reduce(
+    (sum, inst) => sum + inst.conversationsCreated,
+    0,
+  );
+
+  console.log(
+    `\n✅ Created ${installations.length} installations with ${totalGroups} groups and ${totalConversations} conversations`,
+  );
+  console.log(`📁 Files saved to: ${INSTALLATIONS_DIR}/`);
+
+  return installations;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   if (args.includes("--help") || args.includes("-h")) {
     showHelp();
     return;
   }
+
   let count: number | undefined = undefined,
     envs: XmtpEnv[] | undefined = undefined,
-    installations: number | undefined = undefined;
+    installations: number | undefined = undefined,
+    createInstallations: number | undefined = undefined,
+    groupsPerInstallation: number | undefined = undefined,
+    conversationsPerGroup: number | undefined = undefined;
+
   args.forEach((arg, i) => {
     if (arg === "--count") count = parseInt(args[i + 1], 10);
     if (arg === "--envs")
@@ -386,8 +565,35 @@ async function main() {
         .split(",")
         .map((e) => e.trim().toLowerCase()) as XmtpEnv[];
     if (arg === "--installations") installations = parseInt(args[i + 1], 10);
+    if (arg === "--create-installations")
+      createInstallations = parseInt(args[i + 1], 10);
+    if (arg === "--groups-per-installation")
+      groupsPerInstallation = parseInt(args[i + 1], 10);
+    if (arg === "--conversations-per-group")
+      conversationsPerGroup = parseInt(args[i + 1], 10);
     if (arg === "--debug") debugMode = true;
   });
+
+  // If --create-installations is specified, run the new functionality
+  if (
+    createInstallations !== undefined ||
+    args.includes("--create-installations")
+  ) {
+    const env = envs?.[0] || "local";
+    const installationCount =
+      createInstallations || DEFAULT_INSTALLATIONS_COUNT;
+    await generateInstallationsWithContent({
+      count: installationCount,
+      env,
+      groupsPerInstallation:
+        groupsPerInstallation || DEFAULT_GROUPS_PER_INSTALLATION,
+      conversationsPerGroup:
+        conversationsPerGroup || DEFAULT_CONVERSATIONS_PER_GROUP,
+    });
+    return;
+  }
+
+  // Otherwise, run the existing functionality
   if (count === undefined) count = DEFAULT_COUNT;
   if (envs === undefined) envs = DEFAULT_ENVS;
   if (installations === undefined) installations = DEFAULT_INSTALLATIONS;


### PR DESCRIPTION
### Add installation generation with groups and conversations to support testing with populated databases in inboxes/gen.ts
The changes introduce new functionality to generate test installations with populated databases containing groups and conversations. The file [inboxes/gen.ts](https://github.com/xmtp/xmtp-qa-tools/pull/746/files#diff-de930ceb53c88c95bf942b547ed974baf822204b5be21197d97227a2ee5c9bb3) adds a new `InstallationData` interface to track installation metadata, implements `createGroupsAndConversations` and `generateInstallationsWithContent` functions to create groups with random members and populate them with messages, and extends the command-line interface with `--create-installations`, `--groups-per-installation`, and `--conversations-per-group` options. The main function now detects whether to create installations with content or use the original inbox generation functionality based on the provided arguments.

#### 📍Where to Start
Start with the `main` function in [inboxes/gen.ts](https://github.com/xmtp/xmtp-qa-tools/pull/746/files#diff-de930ceb53c88c95bf942b547ed974baf822204b5be21197d97227a2ee5c9bb3) to understand how the new command-line arguments are processed and how the installation generation flow is triggered.

----

_[Macroscope](https://app.macroscope.com) summarized ec65769._