### PR TITLE
Refactor artifact names for clarity and consistency

### DIFF
--- a/.github/actions/xmtp-test-cleanup/action.yml
+++ b/.github/actions/xmtp-test-cleanup/action.yml
@@ -20,7 +20,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: logs-env-${{ inputs.environment }}-${{ inputs.test-name }}
+        name: ${{ inputs.environment }}-${{ inputs.test-name }}-logs
         path: |
           logs/**/*
           .env
@@ -33,7 +33,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: install-db-${{ inputs.environment }}-${{ inputs.test-name }}
+        name: ${{ inputs.environment }}-${{ inputs.test-name }}-dbs
         path: |
           .data/**/*
         if-no-files-found: ignore


### PR DESCRIPTION
### Standardize GitHub Actions artifact naming pattern to environment-test-name-type format in xmtp-test-cleanup action
Changes the artifact naming convention in [action.yml](https://github.com/xmtp/xmtp-qa-tools/pull/759/files#diff-9530a6e682063d60cdc6473418b3ff6f79303b2221927982de870305477a327f) from mixed formats to a consistent `environment-test-name-type` pattern. The logs artifact name changes from `logs-env-${{ inputs.environment }}-${{ inputs.test-name }}` to `${{ inputs.environment }}-${{ inputs.test-name }}-logs`, and the database files artifact name changes from `install-db-${{ inputs.environment }}-${{ inputs.test-name }}` to `${{ inputs.environment }}-${{ inputs.test-name }}-dbs`.

#### 📍Where to Start
Start with the artifact name definitions in [action.yml](https://github.com/xmtp/xmtp-qa-tools/pull/759/files#diff-9530a6e682063d60cdc6473418b3ff6f79303b2221927982de870305477a327f) where the naming patterns are updated.

----

_[Macroscope](https://app.macroscope.com) summarized 0635a37._