### PR TITLE
remove failing test to improve test suite reliability

### DIFF
--- a/suites/functional/dms.test.ts
+++ b/suites/functional/dms.test.ts
@@ -65,8 +65,4 @@ describe(testName, async () => {
     ]);
     expect(verifyResult.allReceived).toBe(true);
   });
-
-  it("should fail on purpose", () => {
-    expect(true).toBe(false);
-  });
 });


### PR DESCRIPTION
### Remove failing test case from DMS test suite to improve test suite reliability
Removes an intentionally failing test case `should fail on purpose` from the DMS conversation test suite in [suites/functional/dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/764/files#diff-bf59a0998d74f48f9c0cc7364d9e3f1234650add19ae4908dc573a9064092181). The test case asserted that `true` equals `false`, which would always fail and prevent the test suite from completing successfully.

#### 📍Where to Start
Start with the test suite in [suites/functional/dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/764/files#diff-bf59a0998d74f48f9c0cc7364d9e3f1234650add19ae4908dc573a9064092181) to see the removed test case.

----

_[Macroscope](https://app.macroscope.com) summarized 13a1a43._