### PR TITLE
Remove Slack notifications for workflow failures

### DIFF
--- a/.github/workflows/AgentExamplesRepo.yml
+++ b/.github/workflows/AgentExamplesRepo.yml
@@ -49,7 +49,3 @@ jobs:
             echo "Error: Agent did not reach 'Waiting for messages...' state"
             exit 1
           fi
-
-      - name: Send Slack notification on failure
-        if: failure() || cancelled()
-        run: yarn workflow-failure "AgentExamplesRepo"

--- a/.github/workflows/PackageCompatibility.yml
+++ b/.github/workflows/PackageCompatibility.yml
@@ -100,7 +100,3 @@ jobs:
           else
             ${{ matrix.package-manager }} run build
           fi
-
-      - name: Send Slack notification on failure
-        if: failure() || cancelled()
-        run: yarn workflow-failure "PackageCompatibility"

--- a/.github/workflows/SelfTest.yml
+++ b/.github/workflows/SelfTest.yml
@@ -47,7 +47,3 @@ jobs:
         with:
           test-name: ${{ matrix.test }}
           environment: ${{ matrix.environment }}
-
-      - name: Send Slack notification on failure
-        if: failure() || cancelled()
-        run: yarn workflow-failure "SelfTest"


### PR DESCRIPTION
### Remove Slack notification steps from GitHub workflow files to eliminate automated failure alerts
Removes the `Send Slack notification on failure` step from three GitHub workflow files that previously sent automated alerts when workflows failed or were cancelled. The changes affect:

- [.github/workflows/AgentExamplesRepo.yml](https://github.com/xmtp/xmtp-qa-tools/pull/765/files#diff-d959c01804b01732c2a157b427cde461debc516b6f7b20265e03c7343e1bf525) - removes step executing `yarn workflow-failure "AgentExamplesRepo"`
- [.github/workflows/PackageCompatibility.yml](https://github.com/xmtp/xmtp-qa-tools/pull/765/files#diff-fe7489f5eec49201cdf2f8a45e43fda8adff7d7ab335e520ab37700dda4ff148) - removes step executing `yarn workflow-failure "PackageCompatibility"`  
- [.github/workflows/SelfTest.yml](https://github.com/xmtp/xmtp-qa-tools/pull/765/files#diff-8ba64d06bcf71f14c4f78aaa19ad49db6dd670c2dc3488feea9cb5108c484bf3) - removes step executing `yarn workflow-failure "SelfTest"`

#### 📍Where to Start
Start with any of the three modified workflow files, such as [.github/workflows/AgentExamplesRepo.yml](https://github.com/xmtp/xmtp-qa-tools/pull/765/files#diff-d959c01804b01732c2a157b427cde461debc516b6f7b20265e03c7343e1bf525), to see the removal of the Slack notification step.

----

_[Macroscope](https://app.macroscope.com) summarized fce137c._