### PR TITLE
Update performance metrics for clarity and accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,12 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
 
 ### Large Inbox Sync Performance Summary
 
-| Inbox Size | Sync Time (s) | DB Size (MB) | Query Count |
-| ---------- | ------------- | ------------ | ----------- |
-| Small      | 0.452         | 13           | 19          |
-| Medium     | 0.47          | 100          | 139         |
-| Large      | 0.505         | 201          | 279         |
-| XL         | 0.505         | 404          | 559         |
+| Inbox Size | Sync Time | DB Size (MB) | queryGroupMessages |
+| ---------- | --------- | ------------ | ------------------ |
+| Small      | 452       | 13           | 19                 |
+| Medium     | 47        | 100          | 139                |
+| Large      | 505       | 201          | 279                |
+| XL         | 505       | 404          | 559                |
 
 ## Success criteria summary
 


### PR DESCRIPTION
### Update performance metrics table headers and time value formatting for clarity and accuracy in README.md
The changes modify the Large Inbox Sync Performance Summary table in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/768/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) by renaming column headers from `Sync Time (s)` to `Sync Time` and `Query Count` to `queryGroupMessages`, and reformatting time values by removing decimal points and the `(s)` suffix (converting values like `0.452` to `452`).

#### 📍Where to Start
Start with the Large Inbox Sync Performance Summary table in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/768/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

----

_[Macroscope](https://app.macroscope.com) summarized f606122._