### PR TITLE
Update node version filtering and add versioning option

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -71,7 +71,9 @@ import { initDataDog } from "./datadog";
 import { addFileLogging, setupPrettyLogs } from "./logger";
 
 export function nodeVersionOptions() {
-  return VersionList.map((v) => v.nodeVersion).reverse();
+  return VersionList.filter((v) => v.auto)
+    .map((v) => v.nodeVersion)
+    .reverse();
 }
 
 // SDK version mappings
@@ -84,6 +86,7 @@ export const VersionList = [
     nodeVersion: "0.0.13",
     bindingsPackage: "0.0.9",
     libXmtpVersion: "0.0.9",
+    auto: true,
   },
   {
     Client: Client47,
@@ -93,6 +96,7 @@ export const VersionList = [
     nodeVersion: "0.0.47",
     bindingsPackage: "0.4.1",
     libXmtpVersion: "6bd613d",
+    auto: true,
   },
   {
     Client: Client105,
@@ -102,6 +106,7 @@ export const VersionList = [
     nodeVersion: "1.0.5",
     bindingsPackage: "1.1.3",
     libXmtpVersion: "6eb1ce4",
+    auto: true,
   },
   {
     Client: Client209,
@@ -111,6 +116,7 @@ export const VersionList = [
     nodeVersion: "2.0.9",
     bindingsPackage: "1.1.8",
     libXmtpVersion: "bfadb76",
+    auto: true,
   },
   {
     Client: Client210,
@@ -120,6 +126,7 @@ export const VersionList = [
     nodeVersion: "2.1.0",
     bindingsPackage: "1.2.0",
     libXmtpVersion: "7b9b4d0",
+    auto: true,
   },
   {
     Client: Client220,
@@ -129,6 +136,7 @@ export const VersionList = [
     nodeVersion: "2.2.1",
     bindingsPackage: "1.2.2",
     libXmtpVersion: "d0f0b67",
+    auto: true,
   },
   {
     Client: Client300,
@@ -138,16 +146,18 @@ export const VersionList = [
     nodeVersion: "3.0.1",
     bindingsPackage: "1.2.5",
     libXmtpVersion: "dc3e8c8",
+    auto: true,
   },
-  // {
-  //   Client: Client310,
-  //   Conversation: Conversation310,
-  //   Dm: Dm310,
-  //   Group: Group310,
-  //   nodeVersion: "3.1.0",
-  //   bindingsPackage: "1.2.6",
-  //   libXmtpVersion: "bfeba9f",
-  // },
+  {
+    Client: Client310,
+    Conversation: Conversation310,
+    Dm: Dm310,
+    Group: Group310,
+    nodeVersion: "3.1.0",
+    bindingsPackage: "1.2.6",
+    libXmtpVersion: "bfeba9f",
+    auto: false,
+  },
 ];
 
 export type GroupMetadataContent = {

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -453,11 +453,12 @@ export async function getWorkers(
   descriptorsOrMap: string[] | Record<string, string> | number,
   options: {
     env?: XmtpEnv;
+    nodeVersion?: string;
     useVersions?: boolean;
     randomNames?: boolean;
   } = {},
 ): Promise<WorkerManager> {
-  const { useVersions = true, randomNames = true } = options;
+  const { useVersions = true, randomNames = true, nodeVersion } = options;
   const env = options.env || (process.env.XMTP_ENV as XmtpEnv) || "dev";
   const manager = new WorkerManager(env);
 
@@ -476,8 +477,12 @@ export async function getWorkers(
     }
 
     // Apply versioning if requested
-    const descriptors = useVersions ? getWorkersWithVersions(names) : names;
-
+    let descriptors = useVersions ? getWorkersWithVersions(names) : names;
+    if (nodeVersion) {
+      descriptors = descriptors.map((descriptor) =>
+        descriptor.replace(/-[a-z]$/, `-${nodeVersion}`),
+      );
+    }
     workerPromises = descriptors.map((descriptor) =>
       manager.createWorker(descriptor),
     );


### PR DESCRIPTION
### Update node version filtering to filter `nodeVersionOptions()` function to only include versions where `auto` is true and add versioning option to `getWorkers` function in workers/manager.ts
- Modifies the `nodeVersionOptions()` function in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/776/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to filter the VersionList to only include versions where `auto` is true before mapping and reversing node versions, adds `auto` property to all version objects in VersionList array, and uncomments Client310 version with `auto: false`
- Adds optional `nodeVersion` parameter to `getWorkers` function in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/776/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) that allows overriding version suffix in worker descriptors when provided

#### 📍Where to Start
Start with the `nodeVersionOptions()` function in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/776/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to understand the version filtering changes.

----

_[Macroscope](https://app.macroscope.com) summarized b3eaa5b._