### PR TITLE
Remove redundant test for group creation with 50 members

### DIFF
--- a/suites/bugs/failtowait/test.test.ts
+++ b/suites/bugs/failtowait/test.test.ts
@@ -11,20 +11,6 @@ describe(testName, async () => {
   });
   const creator = workers.getAll()[0];
 
-  it("should create a group with 50 members", async () => {
-    // Get 100 inbox IDs for group members
-    const memberInboxIds = getInboxIds(50);
-    console.log(`Creating group with ${memberInboxIds.length} members`);
-
-    // Create the group
-    const group = (await creator.client.conversations.newGroup(
-      memberInboxIds,
-    )) as Group;
-    await group.sync();
-
-    console.log(`Group created with ID: ${group.id}`);
-  });
-
   it("should create a group with 100 members", async () => {
     // Get 100 inbox IDs for group members
     const memberInboxIds = getInboxIds(100);


### PR DESCRIPTION
### Remove redundant test case for group creation with 50 members from test suite in suites/bugs/failtowait/test.test.ts
The test file [suites/bugs/failtowait/test.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/781/files#diff-fa2a9860c81adc3dd6b21bd0e57ccb263868d0a60c945134a6f14bd9618f1545) removes the test case `should create a group with 50 members` while retaining the test case `should create a group with 100 members`. The removed test included functionality to retrieve 50 inbox IDs, create a group with those members, and sync the group.

#### 📍Where to Start
Start with the remaining test case in [suites/bugs/failtowait/test.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/781/files#diff-fa2a9860c81adc3dd6b21bd0e57ccb263868d0a60c945134a6f14bd9618f1545) to understand the test structure and verify the removal of the 50-member test case.

----

_[Macroscope](https://app.macroscope.com) summarized 423d06d._