### PR TITLE
Add support for node-sdk 3.1.0dev in tests and versions

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -2,6 +2,9 @@ name: Performance
 description: "should verify performance "
 
 on:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "30 * * * *" # Runs every 30 minutes
   workflow_dispatch:

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         test: [performance]
-        environment: [dev, production]
+        environment: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [bugs/failtowait]
+        test: [failtowait]
         environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -2,9 +2,9 @@ name: Wildcard
 description: "wildcard pull request"
 
 on:
-  # pull_request:
-  #   branches:
-  #     - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [dms]
-        environment: [dev, s]
+        test: [bugs/failtowait]
+        environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         test: [failtowait]
-        environment: [dev, production]
+        environment: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: Run script version
-        run: yarn script version
+        run: yarn script versions
 
       - name: Run tests
         run: yarn test ${{ matrix.test }}

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: Run tests
-        run: yarn test ${{ matrix.test }} --debug --no-fail
+        run: yarn test ${{ matrix.test }}
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Setup test environment
         uses: ./.github/actions/xmtp-test-setup
 
+      - name: Run script version
+        run: yarn script version
+
       - name: Run tests
         run: yarn test ${{ matrix.test }}
 

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -120,7 +120,7 @@ async function fileContainsString(
   });
 }
 
-export async function cleanAllRawLogs(): Promise<void> {
+export async function cleanAllRawLogs(pattern: string = ""): Promise<void> {
   const logsDir = path.join(process.cwd(), "logs");
   const outputDir = path.join(logsDir, "cleaned");
 
@@ -151,15 +151,15 @@ export async function cleanAllRawLogs(): Promise<void> {
     const inputPath = path.join(logsDir, file);
 
     try {
-      // Check if non-raw file contains "fork" using streaming
-      const containsTargetString = await fileContainsString(
-        inputPath,
-        "Fork detected",
-      );
-
-      if (!containsTargetString) {
-        console.log(`Skipping ${file} - does not contain "fork"`);
-        continue;
+      if (pattern) {
+        const containsTargetString = await fileContainsString(
+          inputPath,
+          pattern,
+        );
+        if (!containsTargetString) {
+          console.log(`Skipping ${file} - does not contain "${pattern}"`);
+          continue;
+        }
       }
 
       // Construct the corresponding raw filename

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "workers"
   ],
   "scripts": {
-    "ansi": "tsx -e \"(async () => { const { cleanAllRawLogs } = await import('./helpers/analyzer.js'); await cleanAllRawLogs(); })();\"",
+    "ansi:clean": "tsx -e \"(async () => { const { cleanAllRawLogs } = await import('./helpers/analyzer.js'); await cleanAllRawLogs(); })();\"",
+    "ansi:forks": "tsx -e \"(async () => { const { cleanAllRawLogs } = await import('./helpers/analyzer.js'); await cleanAllRawLogs(); })();\"",
     "bench": "yarn test suites/bench/bench.test.ts",
     "bot": "yarn cli bot",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@anthropic-ai/sdk": "^0.54.0",
     "@xmtp/content-type-reaction": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",
-    "@xmtp/node-bindings": "1.2.6",
+    "@xmtp/node-bindings": "1.2.6-dev.ef25041",
     "@xmtp/node-bindings-0.0.9": "npm:@xmtp/mls-client-bindings-node@0.0.9",
     "@xmtp/node-bindings-0.4.1": "npm:@xmtp/node-bindings@0.0.41",
     "@xmtp/node-bindings-1.0.0": "npm:@xmtp/node-bindings@1.0.0",
@@ -49,8 +49,7 @@
     "@xmtp/node-bindings-1.2.0": "npm:@xmtp/node-bindings@1.2.0",
     "@xmtp/node-bindings-1.2.2": "npm:@xmtp/node-bindings@1.2.2",
     "@xmtp/node-bindings-1.2.5": "npm:@xmtp/node-bindings@1.2.5",
-    "@xmtp/node-bindings-1.2.6": "npm:@xmtp/node-bindings@1.2.6",
-    "@xmtp/node-bindings-1.2.6dev": "npm:@xmtp/node-bindings@1.2.6-dev.ef25041",
+    "@xmtp/node-bindings-1.2.6": "npm:@xmtp/node-bindings@1.2.6-dev.ef25041",
     "@xmtp/node-sdk": "3.1.0",
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13",
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47",
@@ -137,11 +136,6 @@
       }
     },
     "@xmtp/node-sdk@3.1.0": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.2.6"
-      }
-    },
-    "@xmtp/node-sdk@3.1.0dev": {
       "dependencies": {
         "@xmtp/node-bindings": "1.2.6-dev.ef25041"
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@xmtp/node-bindings-1.2.2": "npm:@xmtp/node-bindings@1.2.2",
     "@xmtp/node-bindings-1.2.5": "npm:@xmtp/node-bindings@1.2.5",
     "@xmtp/node-bindings-1.2.6": "npm:@xmtp/node-bindings@1.2.6",
+    "@xmtp/node-bindings-1.2.6dev": "npm:@xmtp/node-bindings@1.2.6-dev.ef25041",
     "@xmtp/node-sdk": "3.1.0",
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13",
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47",
@@ -58,6 +59,7 @@
     "@xmtp/node-sdk-2.2.1": "npm:@xmtp/node-sdk@2.2.1",
     "@xmtp/node-sdk-3.0.1": "npm:@xmtp/node-sdk@3.0.1",
     "@xmtp/node-sdk-3.1.0": "npm:@xmtp/node-sdk@3.1.0",
+    "@xmtp/node-sdk-3.1.0dev": "npm:@xmtp/node-sdk@3.1.0",
     "axios": "^1.8.2",
     "datadog-metrics": "^0.12.1",
     "dotenv": "^16.5.0",
@@ -136,6 +138,11 @@
     "@xmtp/node-sdk@3.1.0": {
       "dependencies": {
         "@xmtp/node-bindings": "1.2.6"
+      }
+    },
+    "@xmtp/node-sdk@3.1.0dev": {
+      "dependencies": {
+        "@xmtp/node-bindings": "1.2.6-dev.ef25041"
       }
     }
   }

--- a/suites/bugs/failtowait/README.md
+++ b/suites/bugs/failtowait/README.md
@@ -1,0 +1,5 @@
+```bash
+yarn test bugs/failtowait --nodeVersion 2.0.9 --env production
+yarn test bugs/failtowait --debug --nodeVersion 3.1.0 --env production
+yarn test bugs/failtowait --debug --nodeVersion 3.1.0dev --env production
+```

--- a/suites/bugs/failtowait/test.test.ts
+++ b/suites/bugs/failtowait/test.test.ts
@@ -5,13 +5,44 @@ import { describe, it } from "vitest";
 
 const testName = "failtowait";
 
-describe(testName, async () => {
-  const workers = await getWorkers(1, {
-    nodeVersion: "3.1.0",
-  });
-  const creator = workers.getAll()[0];
+describe(testName, () => {
+  it("should create a group with 100 members in sdk 3.1.0dev", async () => {
+    const workers = await getWorkers(1, {
+      nodeVersion: "3.0.1",
+    });
+    const creator = workers.getAll()[0];
+    // Get 100 inbox IDs for group members
+    const memberInboxIds = getInboxIds(100);
+    console.log(`Creating group with ${memberInboxIds.length} members`);
 
-  it("should create a group with 100 members", async () => {
+    // Create the group
+    const group = (await creator.client.conversations.newGroup(
+      memberInboxIds,
+    )) as Group;
+    await group.sync();
+    console.log(`Group created with ID: ${group.id}`);
+  });
+  it("should create a group with 100 members in sdk 3.1.0", async () => {
+    const workers = await getWorkers(1, {
+      nodeVersion: "3.1.0",
+    });
+    const creator = workers.getAll()[0];
+    // Get 100 inbox IDs for group members
+    const memberInboxIds = getInboxIds(100);
+    console.log(`Creating group with ${memberInboxIds.length} members`);
+
+    // Create the group
+    const group = (await creator.client.conversations.newGroup(
+      memberInboxIds,
+    )) as Group;
+    await group.sync();
+    console.log(`Group created with ID: ${group.id}`);
+  });
+  it("should create a group with 100 members in sdk 3.1.0dev", async () => {
+    const workers = await getWorkers(1, {
+      nodeVersion: "3.1.0dev",
+    });
+    const creator = workers.getAll()[0];
     // Get 100 inbox IDs for group members
     const memberInboxIds = getInboxIds(100);
     console.log(`Creating group with ${memberInboxIds.length} members`);

--- a/suites/bugs/failtowait/test.test.ts
+++ b/suites/bugs/failtowait/test.test.ts
@@ -6,13 +6,13 @@ import { describe, it } from "vitest";
 const testName = "failtowait";
 
 describe(testName, () => {
+  // Get 100 inbox IDs for group members
+  const memberInboxIds = getInboxIds(100);
   it("should create a group with 100 members in sdk 3.1.0dev", async () => {
     const workers = await getWorkers(1, {
       nodeVersion: "3.0.1",
     });
     const creator = workers.getAll()[0];
-    // Get 100 inbox IDs for group members
-    const memberInboxIds = getInboxIds(100);
     console.log(`Creating group with ${memberInboxIds.length} members`);
 
     // Create the group
@@ -27,8 +27,6 @@ describe(testName, () => {
       nodeVersion: "3.1.0",
     });
     const creator = workers.getAll()[0];
-    // Get 100 inbox IDs for group members
-    const memberInboxIds = getInboxIds(100);
     console.log(`Creating group with ${memberInboxIds.length} members`);
 
     // Create the group
@@ -43,8 +41,6 @@ describe(testName, () => {
       nodeVersion: "3.1.0dev",
     });
     const creator = workers.getAll()[0];
-    // Get 100 inbox IDs for group members
-    const memberInboxIds = getInboxIds(100);
     console.log(`Creating group with ${memberInboxIds.length} members`);
 
     // Create the group

--- a/suites/bugs/failtowait/test.test.ts
+++ b/suites/bugs/failtowait/test.test.ts
@@ -36,23 +36,9 @@ describe(testName, () => {
     await group.sync();
     console.log(`Group created with ID: ${group.id}`);
   });
-  it("should create a group with 100 members in sdk 3.1.0", async () => {
+  it("should create a group with 100 members in sdk 3.1.0-dev", async () => {
     const workers = await getWorkers(1, {
       nodeVersion: "3.1.0",
-    });
-    const creator = workers.getAll()[0];
-    console.log(`Creating group with ${memberInboxIds.length} members`);
-
-    // Create the group
-    const group = (await creator.client.conversations.newGroup(
-      memberInboxIds,
-    )) as Group;
-    await group.sync();
-    console.log(`Group created with ID: ${group.id}`);
-  });
-  it("should create a group with 100 members in sdk 3.1.0dev", async () => {
-    const workers = await getWorkers(1, {
-      nodeVersion: "3.1.0dev",
     });
     const creator = workers.getAll()[0];
     console.log(`Creating group with ${memberInboxIds.length} members`);

--- a/suites/bugs/failtowait/test.test.ts
+++ b/suites/bugs/failtowait/test.test.ts
@@ -8,7 +8,21 @@ const testName = "failtowait";
 describe(testName, () => {
   // Get 100 inbox IDs for group members
   const memberInboxIds = getInboxIds(100);
-  it("should create a group with 100 members in sdk 3.1.0dev", async () => {
+  it("should create a group with 100 members in sdk 2.0.9", async () => {
+    const workers = await getWorkers(1, {
+      nodeVersion: "2.0.9",
+    });
+    const creator = workers.getAll()[0];
+    console.log(`Creating group with ${memberInboxIds.length} members`);
+
+    // Create the group
+    const group = (await creator.client.conversations.newGroup(
+      memberInboxIds,
+    )) as Group;
+    await group.sync();
+    console.log(`Group created with ID: ${group.id}`);
+  });
+  it("should create a group with 100 members in sdk 3.0.1", async () => {
     const workers = await getWorkers(1, {
       nodeVersion: "3.0.1",
     });

--- a/suites/commits/run.sh
+++ b/suites/commits/run.sh
@@ -22,7 +22,7 @@ echo "Completed $num_runs iterations. Waiting 1 minute before next cycle..."
 
 echo "Cleaning up..."
 
-yarn ansi
+yarn ansi:forks
 
 echo "Finished cleaning up"
 fork_count=$(find logs/cleaned -type f 2>/dev/null | wc -l)

--- a/suites/other/nodetest.test.ts
+++ b/suites/other/nodetest.test.ts
@@ -5,9 +5,9 @@ import {
   generatePrivateKey,
   getEncryptionKeyFromHex,
 } from "@helpers/client";
-import { LogLevel } from "@xmtp/node-bindings";
 import {
   Client,
+  LogLevel,
   type ClientOptions,
   type Group,
   type Signer,

--- a/workers/versions.ts
+++ b/workers/versions.ts
@@ -48,6 +48,12 @@ import {
   Dm as Dm310,
   Group as Group310,
 } from "@xmtp/node-sdk-3.1.0";
+import {
+  Client as Client310dev,
+  Conversation as Conversation310dev,
+  Dm as Dm310dev,
+  Group as Group310dev,
+} from "@xmtp/node-sdk-3.1.0dev";
 
 export const getAutoVersions = () => {
   return VersionList.filter((v) => v.auto);
@@ -55,6 +61,15 @@ export const getAutoVersions = () => {
 
 // SDK version mappings
 export const VersionList = [
+  {
+    Client: Client310dev,
+    Conversation: Conversation310dev,
+    Dm: Dm310dev,
+    Group: Group310dev,
+    nodeVersion: "3.1.0dev",
+    bindingsPackage: "1.2.6dev",
+    auto: false,
+  },
   {
     Client: Client310,
     Conversation: Conversation310,

--- a/workers/versions.ts
+++ b/workers/versions.ts
@@ -48,12 +48,6 @@ import {
   Dm as Dm310,
   Group as Group310,
 } from "@xmtp/node-sdk-3.1.0";
-import {
-  Client as Client310dev,
-  Conversation as Conversation310dev,
-  Dm as Dm310dev,
-  Group as Group310dev,
-} from "@xmtp/node-sdk-3.1.0dev";
 
 export const getAutoVersions = () => {
   return VersionList.filter((v) => v.auto);
@@ -61,15 +55,6 @@ export const getAutoVersions = () => {
 
 // SDK version mappings
 export const VersionList = [
-  {
-    Client: Client310dev,
-    Conversation: Conversation310dev,
-    Dm: Dm310dev,
-    Group: Group310dev,
-    nodeVersion: "3.1.0dev",
-    bindingsPackage: "1.2.6dev",
-    auto: false,
-  },
   {
     Client: Client310,
     Conversation: Conversation310,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1498,17 +1498,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings-1.2.6@npm:@xmtp/node-bindings@1.2.6, @xmtp/node-bindings@npm:1.2.6":
-  version: 1.2.6
-  resolution: "@xmtp/node-bindings@npm:1.2.6"
-  checksum: 10/34bc1988be3ffe0e1f4f9f82b65b9d914f9bd5d8d779522484b3f97c34fb1ee7f74d5a97a8512c6946dbf48ede3901d753cc8ae2cd1cba4857382f3aa1723df6
-  languageName: node
-  linkType: hard
-
-"@xmtp/node-bindings-1.2.6dev@npm:@xmtp/node-bindings@1.2.6-dev.ef25041":
+"@xmtp/node-bindings-1.2.6@npm:@xmtp/node-bindings@1.2.6-dev.ef25041, @xmtp/node-bindings@npm:1.2.6-dev.ef25041":
   version: 1.2.6-dev.ef25041
   resolution: "@xmtp/node-bindings@npm:1.2.6-dev.ef25041"
   checksum: 10/958090cad4665d3dd19ac86431b9bd497920865c519d764e64f04e613570b69ea3c1fbb8371a53c40f97e6833cf0ce837dac5c15f1fa89647364a3dc8f52545b
+  languageName: node
+  linkType: hard
+
+"@xmtp/node-bindings@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@xmtp/node-bindings@npm:1.2.6"
+  checksum: 10/34bc1988be3ffe0e1f4f9f82b65b9d914f9bd5d8d779522484b3f97c34fb1ee7f74d5a97a8512c6946dbf48ede3901d753cc8ae2cd1cba4857382f3aa1723df6
   languageName: node
   linkType: hard
 
@@ -4700,7 +4700,7 @@ __metadata:
     "@vitest/ui": "npm:^3.2.4"
     "@xmtp/content-type-reaction": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.6"
+    "@xmtp/node-bindings": "npm:1.2.6-dev.ef25041"
     "@xmtp/node-bindings-0.0.9": "npm:@xmtp/mls-client-bindings-node@0.0.9"
     "@xmtp/node-bindings-0.4.1": "npm:@xmtp/node-bindings@0.0.41"
     "@xmtp/node-bindings-1.0.0": "npm:@xmtp/node-bindings@1.0.0"
@@ -4709,8 +4709,7 @@ __metadata:
     "@xmtp/node-bindings-1.2.0": "npm:@xmtp/node-bindings@1.2.0"
     "@xmtp/node-bindings-1.2.2": "npm:@xmtp/node-bindings@1.2.2"
     "@xmtp/node-bindings-1.2.5": "npm:@xmtp/node-bindings@1.2.5"
-    "@xmtp/node-bindings-1.2.6": "npm:@xmtp/node-bindings@1.2.6"
-    "@xmtp/node-bindings-1.2.6dev": "npm:@xmtp/node-bindings@1.2.6-dev.ef25041"
+    "@xmtp/node-bindings-1.2.6": "npm:@xmtp/node-bindings@1.2.6-dev.ef25041"
     "@xmtp/node-sdk": "npm:3.1.0"
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13"
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,6 +1505,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/node-bindings-1.2.6dev@npm:@xmtp/node-bindings@1.2.6-dev.ef25041":
+  version: 1.2.6-dev.ef25041
+  resolution: "@xmtp/node-bindings@npm:1.2.6-dev.ef25041"
+  checksum: 10/958090cad4665d3dd19ac86431b9bd497920865c519d764e64f04e613570b69ea3c1fbb8371a53c40f97e6833cf0ce837dac5c15f1fa89647364a3dc8f52545b
+  languageName: node
+  linkType: hard
+
 "@xmtp/node-sdk-0.0.13@npm:@xmtp/mls-client@0.0.13":
   version: 0.0.13
   resolution: "@xmtp/mls-client@npm:0.0.13"
@@ -1592,7 +1599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-3.1.0@npm:@xmtp/node-sdk@3.1.0, @xmtp/node-sdk@npm:3.1.0":
+"@xmtp/node-sdk-3.1.0@npm:@xmtp/node-sdk@3.1.0, @xmtp/node-sdk-3.1.0dev@npm:@xmtp/node-sdk@3.1.0, @xmtp/node-sdk@npm:3.1.0":
   version: 3.1.0
   resolution: "@xmtp/node-sdk@npm:3.1.0"
   dependencies:
@@ -4703,6 +4710,7 @@ __metadata:
     "@xmtp/node-bindings-1.2.2": "npm:@xmtp/node-bindings@1.2.2"
     "@xmtp/node-bindings-1.2.5": "npm:@xmtp/node-bindings@1.2.5"
     "@xmtp/node-bindings-1.2.6": "npm:@xmtp/node-bindings@1.2.6"
+    "@xmtp/node-bindings-1.2.6dev": "npm:@xmtp/node-bindings@1.2.6-dev.ef25041"
     "@xmtp/node-sdk": "npm:3.1.0"
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13"
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47"
@@ -4712,6 +4720,7 @@ __metadata:
     "@xmtp/node-sdk-2.2.1": "npm:@xmtp/node-sdk@2.2.1"
     "@xmtp/node-sdk-3.0.1": "npm:@xmtp/node-sdk@3.0.1"
     "@xmtp/node-sdk-3.1.0": "npm:@xmtp/node-sdk@3.1.0"
+    "@xmtp/node-sdk-3.1.0dev": "npm:@xmtp/node-sdk@3.1.0"
     axios: "npm:^1.8.2"
     datadog-metrics: "npm:^0.12.1"
     dotenv: "npm:^16.5.0"


### PR DESCRIPTION
### Add support for node-sdk 3.1.0dev in tests and update failtowait test suite to test group creation across three SDK versions
- Updates package dependencies to use development version `@xmtp/node-bindings@1.2.6-dev.ef25041` and adds npm alias for `@xmtp/node-sdk-3.1.0dev`
- Restructures [failtowait/test.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/791/files#diff-fa2a9860c81adc3dd6b21bd0e57ccb263868d0a60c945134a6f14bd9618f1545) to run three separate tests for group creation with 100 members using SDK versions 2.0.9, 3.0.1, and 3.1.0
- Modifies GitHub Actions workflows to run on pull requests to main branch and changes test matrix from `dms` to `failtowait` in production environment only
- Updates `cleanAllRawLogs` function in [analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/791/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) to accept optional pattern parameter for flexible log filtering
- Renames `ansi` script to `ansi:clean` and adds `ansi:forks` script in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/791/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)

#### 📍Where to Start
Start with the restructured test suite in [failtowait/test.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/791/files#diff-fa2a9860c81adc3dd6b21bd0e57ccb263868d0a60c945134a6f14bd9618f1545) to understand how the tests now run across three different SDK versions.

----

_[Macroscope](https://app.macroscope.com) summarized 9b05867._