### PR TITLE
Enable log cleaning option in CLI test commands

### DIFF
--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [failtowait]
+        test: [performance]
         environment: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
@@ -34,7 +34,7 @@ jobs:
         run: yarn script versions
 
       - name: Run tests
-        run: yarn test ${{ matrix.test }}
+        run: yarn test ${{ matrix.test }} --debug --no-fail
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/deploy-metadata.json
+++ b/deploy-metadata.json
@@ -1,1 +1,1 @@
-{"deployedAt": "2025-07-07T22:57:25Z", "version": "0.2.9"}
+{ "deployedAt": "2025-07-07T22:57:25Z", "version": "0.2.9" }

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -212,6 +212,7 @@ export interface TestLogOptions {
   testName: string;
   logFileName?: string;
   verboseLogging?: boolean;
+  logLevel?: string;
 }
 
 /**
@@ -245,6 +246,12 @@ export const createTestLogger = (options: TestLogOptions) => {
         ? "Verbose logging enabled: output will be shown in terminal AND logged to file."
         : "Test output will be hidden from terminal and logged to file only.",
     );
+
+    // Set logging level if provided
+    if (options.logLevel) {
+      process.env.LOGGING_LEVEL = options.logLevel;
+      console.log(`Log level set to: ${options.logLevel}`);
+    }
   } else {
     console.log(
       "Warning: Logging is disabled. Test output will not be visible anywhere.",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "ansi:clean": "tsx -e \"(async () => { const { cleanAllRawLogs } = await import('./helpers/analyzer.js'); await cleanAllRawLogs(); })();\"",
-    "ansi:forks": "tsx -e \"(async () => { const { cleanAllRawLogs } = await import('./helpers/analyzer.js'); await cleanAllRawLogs(); })();\"",
+    "ansi:forks": "tsx -e \"(async () => { const { cleanAllRawLogs } = await import('./helpers/analyzer.js'); await cleanAllRawLogs('Fork detected'); })();\"",
     "bench": "yarn test suites/bench/bench.test.ts",
     "bot": "yarn cli bot",
     "build": "tsc",


### PR DESCRIPTION
### Enable log cleaning option in CLI test commands by adding `--no-clean-logs` and `--log-level` flags to the test runner
- Adds automatic log cleaning functionality to CLI test commands with new `--no-clean-logs` and `--log-level` command-line options in [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/794/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810)
- Modifies `createTestLogger` function in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/794/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597) to accept optional `logLevel` parameter for setting `process.env.LOGGING_LEVEL`
- Updates GitHub workflow in [.github/workflows/Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/794/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085) to run performance tests with `--debug` and `--no-fail` flags
- Adds `cleanSpecificLogFile` function to handle ANSI code removal and pattern-based log cleaning
- Updates `cleanAllRawLogs` function call in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/794/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to include 'Fork detected' parameter

#### 📍Where to Start
Start with the `parseTestArgs` function in [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/794/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) to understand how the new command-line options are parsed and then review the `runVitestTest` function to see how log cleaning is implemented.

----

_[Macroscope](https://app.macroscope.com) summarized 5941ff9._