### PR TITLE
Remove pull request trigger for performance workflow

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -2,9 +2,6 @@ name: Performance
 description: "should verify performance "
 
 on:
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "30 * * * *" # Runs every 30 minutes
   workflow_dispatch:


### PR DESCRIPTION
### Remove pull request trigger for performance workflow to prevent automatic execution on main branch pull requests
The Performance workflow configuration in [.github/workflows/Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/796/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) removes the `pull_request` trigger that previously caused the workflow to run automatically on pull requests targeting the main branch. The workflow retains its scheduled execution every 30 minutes and manual `workflow_dispatch` trigger capability.

#### 📍Where to Start
Start with the workflow triggers section in [.github/workflows/Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/796/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) to see the removal of the `pull_request` trigger.

----

_[Macroscope](https://app.macroscope.com) summarized 5c296b8._