### PR TITLE
Update default test type to 'dms' for health checks

### DIFF
--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -5,18 +5,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      test_type:
-        description: "Type of test to run (functional or performance)"
-        required: false
-        default: "functional"
-        type: choice
-        options:
-          - functional # full functional test
-          - performance #  performarce test with more large groups
-          - regression # regression test with more large groups
-          - dms # health check
 
 jobs:
   test:
@@ -25,8 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ${{ github.event.inputs.test_type || 'functional' }}
-        environment: [production]
+        test: [performance] # performance test with more large groups
+        # test: [functional] # full functional test
+        # test: [regression] # regression test with more large groups
+        # test: [dms] # health check
+        environment: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.environment }}

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -7,10 +7,11 @@ on:
       - main
   workflow_dispatch:
     inputs:
-      test_type:
+      test_type:source ~/.bashrc;pr_push
+      
         description: "Type of test to run (functional or performance)"
         required: false
-        default: "dms"
+        default: "functional"
         type: choice
         options:
           - functional # full functional test
@@ -25,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ${{ github.event.inputs.test_type || 'functional' }}
+        test: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_type || 'functional' }}
         environment: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -7,8 +7,7 @@ on:
       - main
   workflow_dispatch:
     inputs:
-      test_type:source ~/.bashrc;pr_push
-      
+      test_type:
         description: "Type of test to run (functional or performance)"
         required: false
         default: "functional"
@@ -26,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_type || 'functional' }}
+        test: ${{ github.event.inputs.test_type || 'functional' }}
         environment: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -10,11 +10,13 @@ on:
       test_type:
         description: "Type of test to run (functional or performance)"
         required: false
-        default: "functional"
+        default: "dms"
         type: choice
         options:
-          - functional
-          - performance
+          - functional # full functional test
+          - performance #  performarce test with more large groups
+          - regression # regression test with more large groups
+          - dms # health check
 
 jobs:
   test:


### PR DESCRIPTION
### Add 'regression' and 'dms' test type options to GitHub workflow configuration for health checks
The GitHub workflow configuration in [Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/801/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085) adds two new test type options to the `type` choice parameter: `regression` for regression tests with more large groups and `dms` for health checks. The existing `functional` and `performance` options receive descriptive comments clarifying their purposes as full functional tests and performance tests with more large groups respectively.

#### 📍Where to Start
Start with the `type` choice parameter configuration in [Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/801/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085) to review the new test type options.

----

_[Macroscope](https://app.macroscope.com) summarized 7d8cc8c._