### PR TITLE
Update agent networks to reflect production environment

### DIFF
--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -78,7 +78,7 @@
     "name": "gm-restarts",
     "address": "0xB45DAC55eE7F7598868b270783EBC7CF157A2c55",
     "sendMessage": "hi",
-    "networks": ["dev"],
+    "networks": ["production"],
     "slackChannel": "#gm-restarts-alerts",
     "shouldRespondOnTagged": false
   },
@@ -87,7 +87,7 @@
     "baseName": "gm.base.eth",
     "address": "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0",
     "sendMessage": "hola",
-    "networks": ["dev"],
+    "networks": ["production"],
     "slackChannel": "#gm-alerts",
     "shouldRespondOnTagged": false
   },


### PR DESCRIPTION
### Update agent network configuration from dev to production environment in agents.json
The network configuration for agents changes from "dev" to "production" in two locations within [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/805/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5). This modification updates the environment where agents operate from development to production infrastructure.

#### 📍Where to Start
Start by reviewing the network configuration changes in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/805/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) to see the two locations where the network setting has been updated from "dev" to "production".

----

_[Macroscope](https://app.macroscope.com) summarized 89e1f24._