### PR TITLE
Parameterize test selection for Datadog

### DIFF
--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -206,8 +206,8 @@ export function parseTestName(testName: string): ParsedTestName {
   const operationParts = metricName.split(".");
 
   let testNameExtracted = operationParts[0];
-  if (testNameExtracted.includes("m_large")) {
-    testNameExtracted = "m_large";
+  if (testNameExtracted.includes("large_")) {
+    testNameExtracted = "large";
   }
 
   let operationName = "";

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -15,11 +15,13 @@ export const setupTestLifecycle = ({
   sdk,
   getCustomDuration,
   setCustomDuration,
+  metrics = false,
 }: {
   testName: string;
   sdk?: string;
   getCustomDuration?: () => number | undefined;
   setCustomDuration?: (v: number | undefined) => void;
+  metrics?: boolean;
 }) => {
   beforeAll(() => {
     loadEnv(testName);
@@ -55,12 +57,12 @@ export const setupTestLifecycle = ({
       members,
     };
 
-    if (testName.includes("m_") || process.env.XMTP_ENV === "local") {
+    if (metrics || process.env.XMTP_ENV === "local") {
       sendMetric("duration", duration, values);
     }
 
     // Network stats handling for performance tests
-    if (testName.includes("m_performance") && !skipNetworkStats) {
+    if (metrics && testName.includes("performance") && !skipNetworkStats) {
       const networkStats = await getNetworkStats();
 
       for (const [statName, statValue] of Object.entries(networkStats)) {

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -5,9 +5,9 @@ import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import type { Group } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
-const testName = "m_delivery";
+const testName = "delivery";
 describe(testName, async () => {
-  setupTestLifecycle({ testName });
+  setupTestLifecycle({ testName, metrics: true });
   const amountofMessages = parseInt(process.env.DELIVERY_AMOUNT ?? "10");
   const receiverAmount = parseInt(process.env.DELIVERY_RECEIVERS ?? "4");
 

--- a/suites/metrics/large/conversations.test.ts
+++ b/suites/metrics/large/conversations.test.ts
@@ -11,7 +11,7 @@ import {
   saveLog,
 } from "./helpers";
 
-const testName = "m_large_conversations";
+const testName = "large_conversations";
 describe(testName, async () => {
   let workers = await getWorkers(m_large_WORKER_COUNT);
 
@@ -30,6 +30,7 @@ describe(testName, async () => {
     setCustomDuration: (v) => {
       customDuration = v;
     },
+    metrics: true,
   });
 
   for (

--- a/suites/metrics/large/cumulative_syncs.test.ts
+++ b/suites/metrics/large/cumulative_syncs.test.ts
@@ -4,10 +4,11 @@ import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import { afterAll, describe, it } from "vitest";
 import { m_large_BATCH_SIZE, m_large_TOTAL, saveLog } from "./helpers";
 
-const testName = "m_large_cumulative_syncs";
+const testName = "large_cumulative_syncs";
 describe(testName, async () => {
   setupTestLifecycle({
     testName,
+    metrics: true,
   });
   let workers: WorkerManager;
 

--- a/suites/metrics/large/membership.test.ts
+++ b/suites/metrics/large/membership.test.ts
@@ -11,7 +11,7 @@ import {
   saveLog,
 } from "./helpers";
 
-const testName = "m_large_membership";
+const testName = "large_membership";
 describe(testName, async () => {
   let newGroup: Group;
 
@@ -30,6 +30,7 @@ describe(testName, async () => {
     setCustomDuration: (v) => {
       customDuration = v;
     },
+    metrics: true,
   });
 
   for (

--- a/suites/metrics/large/messages.test.ts
+++ b/suites/metrics/large/messages.test.ts
@@ -11,7 +11,7 @@ import {
   saveLog,
 } from "./helpers";
 
-const testName = "m_large_messages";
+const testName = "large_messages";
 describe(testName, async () => {
   let workers = await getWorkers(m_large_WORKER_COUNT);
 
@@ -30,6 +30,7 @@ describe(testName, async () => {
     setCustomDuration: (v) => {
       customDuration = v;
     },
+    metrics: true,
   });
 
   for (

--- a/suites/metrics/large/metadata.test.ts
+++ b/suites/metrics/large/metadata.test.ts
@@ -11,7 +11,7 @@ import {
   saveLog,
 } from "./helpers";
 
-const testName = "m_large_metadata";
+const testName = "large_metadata";
 describe(testName, async () => {
   let workers = await getWorkers(m_large_WORKER_COUNT);
 
@@ -30,6 +30,7 @@ describe(testName, async () => {
     setCustomDuration: (v) => {
       customDuration = v;
     },
+    metrics: true,
   });
   for (
     let i = m_large_BATCH_SIZE;

--- a/suites/metrics/large/syncs.test.ts
+++ b/suites/metrics/large/syncs.test.ts
@@ -4,10 +4,11 @@ import { getWorkers, type Worker } from "@workers/manager";
 import { afterAll, describe, it } from "vitest";
 import { m_large_BATCH_SIZE, m_large_TOTAL, saveLog } from "./helpers";
 
-const testName = "m_large_syncs";
+const testName = "large_syncs";
 describe(testName, async () => {
   setupTestLifecycle({
     testName,
+    metrics: true,
   });
   const summaryMap: Record<number, any> = {};
 

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -5,7 +5,7 @@ import { getWorkers } from "@workers/manager";
 import { Client, IdentifierKind, type Dm, type Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "m_performance";
+const testName = "performance";
 describe(testName, async () => {
   const batchSize = parseInt(process.env.BATCH_SIZE ?? "5");
   const total = parseInt(process.env.MAX_GROUP_SIZE ?? "10");
@@ -25,6 +25,7 @@ describe(testName, async () => {
     setCustomDuration: (v) => {
       customDuration = v;
     },
+    metrics: true,
   });
 
   it("clientCreate: should measure creating a client", async () => {

--- a/suites/other/large-inbox.test.ts
+++ b/suites/other/large-inbox.test.ts
@@ -1,10 +1,12 @@
 import { getMessageByMb } from "@helpers/client";
+import { setupTestLifecycle } from "@helpers/vitest";
 import { getInboxIds } from "@inboxes/utils";
 import { getWorkers, type Worker } from "@workers/manager";
 import { afterAll, beforeAll, describe, it } from "vitest";
 
-const testName = "m_large_installations";
+const testName = "large_installations";
 describe(testName, async () => {
+  setupTestLifecycle({ testName, metrics: true });
   let workers = await getWorkers(["creator", "small", "medium", "large", "xl"]);
 
   let smallInbox: Worker;


### PR DESCRIPTION
Refactor Datadog test metric filtering to use an explicit `metrics` parameter instead of string pattern matching.