### PR TITLE
Remove emojis and set readme style

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,73 @@
+# README Style Guide
+
+## README Writing Standards
+
+When creating or editing README files, follow these strict guidelines:
+
+### Content Style
+- **No emojis**: Never use emojis in READMEs
+- **Concise**: Be brief and to the point
+- **No redundancy**: Avoid repeating information
+- **Code-heavy**: Prioritize code examples and snippets over lengthy explanations
+
+### Structure
+- Use clear, direct headers without decorative elements
+- Lead with practical examples rather than theory
+- Include minimal explanatory text - let code speak for itself
+- Focus on "how" rather than "why"
+
+### Format Requirements
+- Use plain text headers (no emoji prefixes)
+- Include more code blocks than paragraphs
+- Keep descriptions brief - one sentence when possible
+- Use tables for structured data without emoji indicators
+
+### Code Examples
+- Always include working code examples
+- Show real command line usage
+- Provide copy-paste ready snippets
+- Include minimal setup instructions
+
+### Performance Tables
+- Use text instead of emoji status indicators:
+  - "On Target" instead of ✅
+  - "Concern" instead of ⚠️
+  - "Failed" instead of ❌
+- Keep table data clean and readable
+
+### Anti-patterns to Avoid
+- Emoji decorations in headers or content
+- Long explanatory paragraphs
+- Redundant information across sections
+- Flowery or marketing language
+- Over-explanation of simple concepts
+
+### Example Format
+```markdown
+# Tool Name
+
+Brief one-line description.
+
+## Quick Start
+
+```bash
+npm install tool
+npm run start
+```
+
+## Commands
+
+```bash
+tool command --option value
+tool other-command
+```
+
+## Configuration
+
+```yaml
+config:
+  setting: value
+```
+```
+
+This style prioritizes developer efficiency and reduces visual noise while maintaining essential information.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,4 +1,4 @@
-# 🔄 GitHub Workflows
+# GitHub Workflows
 
 This directory contains GitHub Actions workflows for automating testing, deployment, and maintenance processes for the XMTP testing framework. These workflows provide continuous monitoring, performance testing, and quality assurance for XMTP protocol functionality.
 
@@ -30,7 +30,7 @@ gh workflow run workflow-name.yml
 gh workflow run Agents.yml
 ```
 
-## 🤖 Agent Health Monitoring
+## Agent Health Monitoring
 
 The `Agents.yml` workflow monitors the health and responsiveness of XMTP agents in production.
 
@@ -57,7 +57,7 @@ jobs:
 - Test reporting via Datadog metrics
 - Response time tracking
 
-## 🚂 Deployment Automation
+## Deployment Automation
 
 The `Deploy.yml` workflow automates Railway deployments when version bumps are detected.
 
@@ -92,7 +92,7 @@ jobs:
 - Auto-merge capability
 - Deployment metadata tracking
 
-## 💾 Installation Data Backup
+## Installation Data Backup
 
 The `upload-installations.yml` workflow backs up installation data and keys.
 
@@ -111,7 +111,7 @@ on:
 - Long-term artifact retention (365 days)
 - Environment variable capture
 
-## 📝 Configuration
+## Configuration
 
 Workflows are configured using GitHub repository secrets and variables:
 
@@ -131,7 +131,7 @@ Workflows are configured using GitHub repository secrets and variables:
 - `BATCH_SIZE`: Number of participants per batch
 - `MAX_GROUP_SIZE`: Maximum group size for testing
 
-## 📊 Monitoring and Reporting
+## Monitoring and Reporting
 
 Workflow results are accessible through multiple channels:
 
@@ -145,12 +145,12 @@ Workflow results are accessible through multiple channels:
 
 The workflows are organized into logical categories:
 
-- **🤖 Automated Tests**: `Agents.yml`, `Gm.yml` - Continuous monitoring
-- **📊 Metrics Tests**: `Delivery.yml`, `Large.yml`, `Performance.yml` - Performance measurement
-- **🚨 Stress Tests**: `GroupStress.yml` - High-load scenario testing
-- **🔧 Infrastructure**: `Deploy.yml`, `PackageCompatibility.yml` - Deployment and compatibility
+- **Automated Tests**: `Agents.yml`, `Gm.yml` - Continuous monitoring
+- **Metrics Tests**: `Delivery.yml`, `Large.yml`, `Performance.yml` - Performance measurement
+- **Stress Tests**: `GroupStress.yml` - High-load scenario testing
+- **Infrastructure**: `Deploy.yml`, `PackageCompatibility.yml` - Deployment and compatibility
 
-## 📝 Best practices
+## Best practices
 
 When working with these workflows, consider the following best practices:
 
@@ -160,7 +160,7 @@ When working with these workflows, consider the following best practices:
 4. **Concurrency limits**: Avoid excessive parallel executions
 5. **Timeout configuration**: Set appropriate timeouts to prevent hung jobs
 
-## 🔄 Recent Changes
+## Recent Changes
 
 The workflows have been updated to use standardized naming conventions:
 

--- a/README.md
+++ b/README.md
@@ -90,19 +90,19 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 | Operation                | Description                            | Avg | Target | Performance  |
 | ------------------------ | -------------------------------------- | --- | ------ | ------------ |
-| clientCreate             | Creating a client                      | 588 | <350   | ⚠️ Concern   |
-| inboxState               | Checking inbox state                   | 41  | <350   | ✅ On Target |
-| newDm                    | Creating a direct message conversation | 258 | <350   | ✅ On Target |
-| newDmWithIdentifiers     | Creating a dm by address               | 294 | <350   | ✅ On Target |
-| sendGM                   | Sending a group message                | 126 | <200   | ✅ On Target |
-| receiveGM                | Receiving a group message              | 87  | <200   | ✅ On Target |
-| createGroup              | Creating a group                       | 315 | <350   | ✅ On Target |
-| createGroupByIdentifiers | Creating a group by address            | 313 | <350   | ✅ On Target |
-| syncGroup                | Syncing group state                    | 76  | <200   | ✅ On Target |
-| updateGroupName          | Updating group metadata                | 129 | <200   | ✅ On Target |
-| removeMembers            | Removing participants from a group     | 127 | <250   | ✅ On Target |
-| sendGroupMessage         | Sending a group message                | 85  | <200   | ✅ On Target |
-| receiveGroupMessage      | Processing group message strea         | 124 | <200   | ✅ On Target |
+| clientCreate             | Creating a client                      | 588 | <350   | Concern     |
+| inboxState               | Checking inbox state                   | 41  | <350   | On Target   |
+| newDm                    | Creating a direct message conversation | 258 | <350   | On Target   |
+| newDmWithIdentifiers     | Creating a dm by address               | 294 | <350   | On Target   |
+| sendGM                   | Sending a group message                | 126 | <200   | On Target   |
+| receiveGM                | Receiving a group message              | 87  | <200   | On Target   |
+| createGroup              | Creating a group                       | 315 | <350   | On Target   |
+| createGroupByIdentifiers | Creating a group by address            | 313 | <350   | On Target   |
+| syncGroup                | Syncing group state                    | 76  | <200   | On Target   |
+| updateGroupName          | Updating group metadata                | 129 | <200   | On Target   |
+| removeMembers            | Removing participants from a group     | 127 | <250   | On Target   |
+| sendGroupMessage         | Sending a group message                | 85  | <200   | On Target   |
+| receiveGroupMessage      | Processing group message strea         | 124 | <200   | On Target   |
 
 ### Group operations performance
 
@@ -110,14 +110,14 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 | Size | Send message | Update name | Remove members | Create  | Performance  |
 | ---- | ------------ | ----------- | -------------- | ------- | ------------ |
-| 50   | 86           | 135         | 139            | 1329    | ✅ On Target |
-| 100  | 88           | 145         | 157            | 1522    | ✅ On Target |
-| 150  | 95           | 203         | 190            | 2306    | ✅ On Target |
-| 200  | 93           | 193         | 205            | ⚠️ 3344 | ✅ On Target |
-| 250  | 108          | 219         | 237            | ⚠️ 4276 | ✅ On Target |
-| 300  | 97           | 244         | 247            | ⚠️ 5463 | ✅ On Target |
-| 350  | 101          | 264         | 308            | ⚠️ 6641 | ✅ On Target |
-| 400  | 111          | 280         | 320            | ⚠️ 7641 | ✅ On Target |
+| 50   | 86           | 135         | 139            | 1329    | On Target |
+| 100  | 88           | 145         | 157            | 1522    | On Target |
+| 150  | 95           | 203         | 190            | 2306    | On Target |
+| 200  | 93           | 193         | 205            | 3344    | On Target |
+| 250  | 108          | 219         | 237            | 4276    | On Target |
+| 300  | 97           | 244         | 247            | 5463    | On Target |
+| 350  | 101          | 264         | 308            | 6641    | On Target |
+| 400  | 111          | 280         | 320            | 7641    | On Target |
 
 _Note: This measurments are taken only from the sender side and after the group is created._
 
@@ -125,14 +125,14 @@ _Note: This measurments are taken only from the sender side and after the group 
 
 | Group Size | New conversation | Metadata | Messages | Add Members | Performance  |
 | ---------- | ---------------- | -------- | -------- | ----------- | ------------ |
-| 50         | 687              | 141      | 131      | 401         | ✅ On Target |
-| 100        | 746              | 155      | 117      | 420         | ✅ On Target |
-| 150        | 833              | 163      | 147      | 435         | ✅ On Target |
-| 200        | 953              | 179      | 173      | 499         | ✅ On Target |
-| 250        | 1007             | 187      | 161      | 526         | ⚠️ Concern   |
-| 300        | 1040             | 195      | 167      | 543         | ⚠️ Concern   |
-| 350        | 1042             | 198      | 178      | 581         | ⚠️ Concern   |
-| 400        | 1192             | 214      | 173      | 609         | ⚠️ Concern   |
+| 50         | 687              | 141      | 131      | 401         | On Target |
+| 100        | 746              | 155      | 117      | 420         | On Target |
+| 150        | 833              | 163      | 147      | 435         | On Target |
+| 200        | 953              | 179      | 173      | 499         | On Target |
+| 250        | 1007             | 187      | 161      | 526         | Concern   |
+| 300        | 1040             | 195      | 167      | 543         | Concern   |
+| 350        | 1042             | 198      | 178      | 581         | Concern   |
+| 400        | 1192             | 214      | 173      | 609         | Concern   |
 
 _Note: This measurments are taken only from the receiver side and after the group is created._
 
@@ -140,14 +140,14 @@ _Note: This measurments are taken only from the receiver side and after the grou
 
 | Size | syncAll |      | sync |      | Performance  |
 | ---- | ------- | ---- | ---- | ---- | ------------ |
-| 50   | 366     | ...  | 291  | ...  | ✅ On Target |
-| 100  | 503     | 521  | 424  | 372  | ✅ On Target |
-| 150  | 665     | 727  | 522  | 622  | ✅ On Target |
-| 200  | 854     | 1066 | 653  | 936  | ✅ On Target |
-| 250  | 966     | 1582 | 768  | 1148 | ⚠️ Concern   |
-| 300  | 1225    | 1619 | 861  | 1362 | ⚠️ Concern   |
-| 350  | 1322    | 1846 | 1218 | 2017 | ⚠️ Concern   |
-| 400  | 1292    | 2082 | 1325 | 1792 | ⚠️ Concern   |
+| 50   | 366     | ...  | 291  | ...  | On Target |
+| 100  | 503     | 521  | 424  | 372  | On Target |
+| 150  | 665     | 727  | 522  | 622  | On Target |
+| 200  | 854     | 1066 | 653  | 936  | On Target |
+| 250  | 966     | 1582 | 768  | 1148 | Concern   |
+| 300  | 1225    | 1619 | 861  | 1362 | Concern   |
+| 350  | 1322    | 1846 | 1218 | 2017 | Concern   |
+| 400  | 1292    | 2082 | 1325 | 1792 | Concern   |
 
 _Note: `syncAll` is measured only as the first cold start of the client (fresh inbox). Cumulative sync is measured as the first time all the groups are sync for the first time._
 
@@ -157,21 +157,21 @@ _Note: `syncAll` is measured only as the first cold start of the client (fresh i
 
 | Performance Metric | Average | Target | Performance  |
 | ------------------ | ------- | ------ | ------------ |
-| DNS Lookup         | 13      | <50    | ✅ On Target |
-| TCP Connection     | 48      | <70    | ✅ On Target |
-| TLS Handshake      | 124     | <150   | ✅ On Target |
-| Processing         | 35      | <100   | ✅ On Target |
-| Server Call        | 159     | <250   | ✅ On Target |
+| DNS Lookup         | 13      | <50    | On Target |
+| TCP Connection     | 48      | <70    | On Target |
+| TLS Handshake      | 124     | <150   | On Target |
+| Processing         | 35      | <100   | On Target |
+| Server Call        | 159     | <250   | On Target |
 
 ### Regional Network Performance
 
 | Region        | Server Call | TLS | ~ us-east | Performance  |
 | ------------- | ----------- | --- | --------- | ------------ |
-| us-east       | 140         | 123 | Baseline  | ✅ On Target |
-| us-west       | 151         | 118 | <20% ~    | ✅ On Target |
-| europe        | 230         | 180 | <40% ~    | ✅ On Target |
-| asia          | 450         | 350 | >100% ~   | ⚠️ Concern   |
-| south-america | 734         | 573 | >200% ~   | ⚠️ Concern   |
+| us-east       | 140         | 123 | Baseline  | On Target |
+| us-west       | 151         | 118 | <20% ~    | On Target |
+| europe        | 230         | 180 | <40% ~    | On Target |
+| asia          | 450         | 350 | >100% ~   | Concern   |
+| south-america | 734         | 573 | >200% ~   | Concern   |
 
 _Note: Baseline is `us-east` region and `production` network._
 
@@ -183,12 +183,12 @@ _Note: `Production` network consistently shows better network performance across
 
 | Test Area            | Average         | Target         | Performance  |
 | -------------------- | --------------- | -------------- | ------------ |
-| Stream Delivery Rate | 100% successful | 99.9% minimum  | ✅ On Target |
-| Poll Delivery Rate   | 100% successful | 99.9% minimum  | ✅ On Target |
-| Recovery Rate        | 100% successful | 99.9% minimum  | ✅ On Target |
-| Stream Order         | 100% in order   | 99.9% in order | ✅ On Target |
-| Poll Order           | 100% in order   | 99.9% in order | ✅ On Target |
-| Recovery Order       | 100% in order   | 99.9% in order | ✅ On Target |
+| Stream Delivery Rate | 100% successful | 99.9% minimum  | On Target |
+| Poll Delivery Rate   | 100% successful | 99.9% minimum  | On Target |
+| Recovery Rate        | 100% successful | 99.9% minimum  | On Target |
+| Stream Order         | 100% in order   | 99.9% in order | On Target |
+| Poll Order           | 100% in order   | 99.9% in order | On Target |
+| Recovery Order       | 100% in order   | 99.9% in order | On Target |
 
 _Note: Testing regularly in groups of `40` active members listening to one user sending 100 messages_
 
@@ -218,17 +218,17 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
 
 | Metric                  | Current Performance         | Target                 | Performance  |
 | ----------------------- | --------------------------- | ---------------------- | ------------ |
-| Core SDK Operations     | All within targets          | Meet defined targets   | ✅ On Target |
-| Small Group Operations  | ≤300                        | ≤300 for <50 members   | ✅ On Target |
-| Medium Group Operations | ≤1000                       | ≤1000 for <400 members | ⚠️ Concern   |
-| Network Performance     | All metrics within target   | Meet defined targets   | ✅ On Target |
-| Message Delivery        | 100%                        | 99.9% minimum          | ✅ On Target |
-| Stream Message Loss     | 100%                        | 99.9% minimum          | ✅ On Target |
-| Poll Message Loss       | 100%                        | 99.9% minimum          | ✅ On Target |
-| Message Order           | 100%                        | 100% in order          | ✅ On Target |
-| South-america & Asia    | more than 40%               | <20% difference        | ⚠️ Concern   |
-| US & Europe             | less than 20% variance      | <20% difference        | ✅ On Target |
-| Dev vs Production       | Production 4.5-16.1% better | Production ≥ Dev       | ✅ On Target |
+| Core SDK Operations     | All within targets          | Meet defined targets   | On Target |
+| Small Group Operations  | ≤300                        | ≤300 for <50 members   | On Target |
+| Medium Group Operations | ≤1000                       | ≤1000 for <400 members | Concern   |
+| Network Performance     | All metrics within target   | Meet defined targets   | On Target |
+| Message Delivery        | 100%                        | 99.9% minimum          | On Target |
+| Stream Message Loss     | 100%                        | 99.9% minimum          | On Target |
+| Poll Message Loss       | 100%                        | 99.9% minimum          | On Target |
+| Message Order           | 100%                        | 100% in order          | On Target |
+| South-america & Asia    | more than 40%               | <20% difference        | Concern   |
+| US & Europe             | less than 20% variance      | <20% difference        | On Target |
+| Dev vs Production       | Production 4.5-16.1% better | Production ≥ Dev       | On Target |
 
 ## Tools & utilities
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -1,4 +1,4 @@
-# 🤖 XMTP Test Bots
+# XMTP Test Bots
 
 This directory contains test bots for the XMTP protocol. These bots help validate the functionality of XMTP, automate testing scenarios, and provide interactive agents for development purposes.
 
@@ -131,7 +131,7 @@ const stressTest = async (count) => {
 - Large group scale testing
 - Performance benchmarking
 
-## 🧪 Test Bot
+## Test Bot
 
 The `test` bot provides a command interface for testing XMTP features.
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -139,7 +139,7 @@ await cleanAllRawLogs();
 - **Log processing**: Utilities for cleaning and processing large log files
 - **Winston integration**: Professional logging with multiple transports
 
-## 🧪 Vitest Module (`vitest.ts`)
+## Vitest Module (`vitest.ts`)
 
 The `vitest.ts` module provides test lifecycle management and performance tracking integration.
 
@@ -262,7 +262,7 @@ interface NetworkStats {
 }
 ```
 
-## 🔄 Streams Module (`streams.ts`)
+## Streams Module (`streams.ts`)
 
 The `streams.ts` module provides utilities for testing message delivery and conversation streams.
 
@@ -322,7 +322,7 @@ const stats = calculateMessageStats(
 - Membership streams (member additions/removals)
 - Consent streams (contact approvals)
 
-## 🔧 Environment Configuration
+## Environment Configuration
 
 All helper modules work together through environment configuration:
 
@@ -346,7 +346,7 @@ The helpers reference data files in other directories:
 - **`@inboxes/*.json`**: Generated test identities and wallet data
 - **Environment variables**: Loaded from `.env` files
 
-## 🚀 Getting Started
+## Getting Started
 
 To use the helpers in your tests:
 

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -28,7 +28,7 @@ A Slack bot that integrates with Anthropic's Claude SDK for AI responses and pro
 
 ## Features
 
-### 🤖 AI Chat with Claude
+### AI Chat with Claude
 
 - Direct message support
 - @mention support in channels

--- a/suites/README.md
+++ b/suites/README.md
@@ -1,4 +1,4 @@
-# 🧪 Test Suites
+# Test Suites
 
 Comprehensive end-to-end test suites for validating XMTP protocol functionality, performance, and reliability across different scenarios and environments.
 
@@ -6,18 +6,18 @@ Comprehensive end-to-end test suites for validating XMTP protocol functionality,
 
 | Test Suite                      | Purpose                            | Key Features                                 | Documentation                       |
 | ------------------------------- | ---------------------------------- | -------------------------------------------- | ----------------------------------- |
-| **[agents](./agents/)**         | Production agent health monitoring | Live agent testing, response validation      | [📖 README](./agents/README.md)     |
-| **[bench](./bench/)**           | Performance benchmarking           | Throughput measurement, latency analysis     | [📖 README](./bench/README.md)      |
-| **[browser](./browser/)**       | Browser integration validation     | Playwright automation, cross-browser testing | [📖 README](./browser/README.md)    |
-| **[bugs](./bugs/)**             | Bug reproduction and tracking      | Historical issues, regression prevention     | [📖 README](./bugs/README.md)       |
-| **[functional](./functional/)** | Core protocol functionality        | Complete feature coverage, integration tests | [📖 README](./functional/README.md) |
-| **[group](./group/)**           | Group conversation testing         | Stress testing, multi-version compatibility  | [📖 README](./group/README.md)      |
-| **[large](./large/)**           | Large-scale performance testing    | Scalability validation, resource monitoring  | [📖 README](./large/README.md)      |
-| **[metrics](./metrics/)**       | Performance metrics collection     | Delivery reliability, operational metrics    | [📖 README](./metrics/README.md)    |
-| **[mobile](./mobile/)**         | Mobile performance testing         | Load testing, responsiveness validation      | [📖 README](./mobile/README.md)     |
+| **[agents](./agents/)**         | Production agent health monitoring | Live agent testing, response validation      | [README](./agents/README.md)     |
+| **[bench](./bench/)**           | Performance benchmarking           | Throughput measurement, latency analysis     | [README](./bench/README.md)      |
+| **[browser](./browser/)**       | Browser integration validation     | Playwright automation, cross-browser testing | [README](./browser/README.md)    |
+| **[bugs](./bugs/)**             | Bug reproduction and tracking      | Historical issues, regression prevention     | [README](./bugs/README.md)       |
+| **[functional](./functional/)** | Core protocol functionality        | Complete feature coverage, integration tests | [README](./functional/README.md) |
+| **[group](./group/)**           | Group conversation testing         | Stress testing, multi-version compatibility  | [README](./group/README.md)      |
+| **[large](./large/)**           | Large-scale performance testing    | Scalability validation, resource monitoring  | [README](./large/README.md)      |
+| **[metrics](./metrics/)**       | Performance metrics collection     | Delivery reliability, operational metrics    | [README](./metrics/README.md)    |
+| **[mobile](./mobile/)**         | Mobile performance testing         | Load testing, responsiveness validation      | [README](./mobile/README.md)     |
 | **[other](./other/)**           | Specialized edge case testing      | Rate limiting, storage, notifications, etc   | [View tests →](./other/)            |
 
-## 🤖 Production & Monitoring
+## Production & Monitoring
 
 ### Agent Health Testing
 
@@ -49,7 +49,7 @@ yarn test bench
 - Performance regression detection
 - CSV data export for analysis
 
-## ⚙️ Core Functionality Testing
+## Core Functionality Testing
 
 ### Functional Test Suite
 
@@ -97,7 +97,7 @@ yarn test browser
 - Web integration scenarios
 - UI/UX validation
 
-## 🔄 Group & Conversation Testing
+## Group & Conversation Testing
 
 ### Group Stress Testing
 
@@ -116,7 +116,7 @@ yarn test group
 - Message stream performance
 - Concurrent worker scenarios
 
-## 🚀 Performance & Scale Testing
+## Performance & Scale Testing
 
 ### Large-Scale Testing
 
@@ -196,7 +196,7 @@ yarn test storage
 - Space utilization optimization
 - Performance vs. storage trade-offs
 
-## 🔒 Security & Quality Assurance
+## Security & Quality Assurance
 
 ### Spam & Security Testing
 
@@ -228,7 +228,7 @@ yarn test notifications
 - Delivery reliability validation
 - Multi-platform support
 
-## 🐛 Bug Documentation & Regression
+## Bug Documentation & Regression
 
 ### Bug Reproduction Testing
 
@@ -254,7 +254,7 @@ yarn test bugs
 - Log files and error traces
 - Resolution documentation
 
-## 🔧 Specialized Testing
+## Specialized Testing
 
 ### Rate Limiting & Edge Cases
 
@@ -271,7 +271,7 @@ yarn test other/rate-limited.test.ts
 - Boundary condition validation
 - Error handling verification
 
-## 🏃‍♂️ Running Tests
+## Running Tests
 
 ### Basic Test Execution
 

--- a/suites/bugs/BUG_TEMPLATE.md
+++ b/suites/bugs/BUG_TEMPLATE.md
@@ -1,4 +1,4 @@
-# 🐛 Bug Report
+# Bug Report
 
 ## Description
 

--- a/suites/bugs/README.md
+++ b/suites/bugs/README.md
@@ -1,3 +1,3 @@
-# Bug logs 🐛
+# Bug logs
 
 This repository contains documentation for known bugs and their solutions. Use this folder to share clear repros

--- a/suites/bugs/addmember/README.md
+++ b/suites/bugs/addmember/README.md
@@ -1,4 +1,4 @@
-## 🐛 Group Member Addition Bug
+## Group Member Addition Bug
 
 • **Repro**:
 

--- a/suites/datadog/README.md
+++ b/suites/datadog/README.md
@@ -116,9 +116,9 @@ This test suite replaces the previous Slack bot functionality:
 🚨 Found 23 test failures
 ⏰ Query period: 2024-01-15T10:00:00.000Z to 2024-01-15T14:00:00.000Z
 📄 Found 23 processed issue entries
-🤖 Claude analysis length: 847 characters
+Claude analysis length: 847 characters
 📝 Analysis preview: *Critical Test Failures Analysis*
 
 The most significant issues in the last 4 hours involve...
-🔄 Data refresh completed in 3,421ms
+Data refresh completed in 3,421ms
 ```

--- a/suites/functional/README.md
+++ b/suites/functional/README.md
@@ -290,7 +290,7 @@ it("should deliver messages in the correct order", async () => {
 - Timestamp ordering
 - Delivery confirmation
 
-## 🐛 Regression Testing
+## Regression Testing
 
 The `regression.test.ts` module verifies fixes for historical issues.
 
@@ -307,7 +307,7 @@ it("should handle edge case that previously caused issues", async () => {
 - Edge case testing
 - Version compatibility
 
-## 🔄 Stream Testing
+## Stream Testing
 
 The `streams.test.ts` module tests message streaming functionality.
 
@@ -325,7 +325,7 @@ it("receiveGM: should receive a message via stream", async () => {
 - Delivery verification
 - Stream performance
 
-## 🔄 Sync Comparison
+## Sync Comparison
 
 The `sync.test.ts` module compares different synchronization approaches.
 

--- a/suites/other/README.md
+++ b/suites/other/README.md
@@ -1,4 +1,4 @@
-# 🔧 Other Test Suite
+# Other Test Suite
 
 Specialized edge case testing and miscellaneous scenarios for validating XMTP protocol resilience, performance limits, and system behavior under unusual conditions.
 
@@ -156,7 +156,7 @@ yarn test other/storage
 | 50 members | 200    | 5.0 MB        | 0.025 MB       | 2.1 MB          | 2.5× better     |
 ```
 
-## 🚀 Running Specialized Tests
+## Running Specialized Tests
 
 ### Individual Test Execution
 
@@ -207,9 +207,9 @@ Worker Statistics: forks=0, errors=0, messages=500
 
 ```
 ## Detailed Analysis
-✅ 2-member groups: 1000 groups, 5.00 MB total
-✅ 50-member groups: 200 groups, 5.00 MB total
-✅ 200-member groups: 50 groups, 5.00 MB total
+2-member groups: 1000 groups, 5.00 MB total
+50-member groups: 200 groups, 5.00 MB total
+200-member groups: 50 groups, 5.00 MB total
 
 Efficiency Gain: 4× better storage efficiency with larger groups
 ```
@@ -217,13 +217,13 @@ Efficiency Gain: 4× better storage efficiency with larger groups
 ### Rate Limiting Output
 
 ```
-🚀 LAUNCHING 8 WORKER THREADS EACH SENDING 5000 MESSAGES!
+LAUNCHING 8 WORKER THREADS EACH SENDING 5000 MESSAGES!
 🧵 Each worker runs in its own thread for TRUE parallelism
 🔥 Worker thread henry starting burst...
 Rate limiting engaged after 1,000 messages per thread
 ```
 
-## 🔧 Configuration & Customization
+## Configuration & Customization
 
 ### Environment Variables
 


### PR DESCRIPTION
Remove all emojis from README files and establish a `.cursorrules` file for a consistent, concise, and code-focused documentation style.