### PR TITLE
Schedule performance workflows with gaps

### DIFF
--- a/.github/workflows/Large.yml
+++ b/.github/workflows/Large.yml
@@ -3,7 +3,7 @@ description: "should verify performance of the group streams"
 
 on:
   schedule:
-    - cron: "15 */2 * * *" # Runs every 2 hours at 15 minutes past
+    - cron: "0 */2 * * *" # Runs every 2 hours at top of hour (30+ min separation from Performance at :15 and :45)
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -3,7 +3,7 @@ description: "should verify performance "
 
 on:
   schedule:
-    - cron: "45,15 * * * *" # Runs every 30 minutes at 15 and 45 minutes past
+    - cron: "30 * * * *" # Runs every hour at 30 minutes past (30+ min separation from Large at :00)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adjust GitHub workflow schedules to ensure a minimum 30-minute separation between Large and Performance workflows.