### PR TITLE
Add performance benchmarks for stress test clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,11 @@ yarn test functional --no-fail --debug
 - `--debug` - Enable debug logging and file output a saves logs to `logs/` directory (no terminal verbosity)
 - `--no-fail` - Exit successfully even on test failures
 
+### Rate limits
+
+- **Read operations**: 20,000 requests per 5-minute window
+- **Write operations**: 3,000 messages published per 5-minute window
+
 ### Resources
 
 - **Inboxes:** Inboxes for testing - [see section](/inboxes/)

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -157,9 +157,8 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
     ),
   );
   await sleep(streamColdStartTimeout); // wait for stream to start
-  console.debug("sleeping done");
+
   const sentEvents = await options.triggerEvents();
-  console.debug("triggerEvents done");
   const allReceived = await Promise.all(collectPromises);
   const eventTimings: Record<string, Record<number, number>> = {};
   let timingSum = 0;

--- a/suites/agents/stress-test.test.ts
+++ b/suites/agents/stress-test.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 */
 
 const testName = "rate-limited";
-const WORKER_COUNT = 100;
+const WORKER_COUNT = 500;
 const MESSAGES_PER_WORKER = 1;
 const SUCCESS_THRESHOLD = 99;
 const BATCH_SIZE = 50;

--- a/suites/agents/stress-test.test.ts
+++ b/suites/agents/stress-test.test.ts
@@ -3,6 +3,11 @@ import { getWorkers } from "@workers/manager";
 import { IdentifierKind, type Conversation } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
+/*
+- **Read operations**: 20,000 requests per 5-minute window
+- **Write operations**: 3,000 messages published per 5-minute window
+*/
+
 const testName = "rate-limited";
 const WORKER_COUNT = 100;
 const MESSAGES_PER_WORKER = 1;


### PR DESCRIPTION
### Increase stress test worker count from 100 to 500 and document API rate limits for performance benchmarks
- Increases `WORKER_COUNT` constant from 100 to 500 in [suites/agents/stress-test.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/839/files#diff-793fbc660e580d91972704e08a1b5ef8382c1b0c42e1fb57134d0f592da198ee), scaling the stress test by 5x
- Documents API rate limits in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/839/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with read operations at 20,000 requests per 5-minute window and write operations at 3,000 messages per 5-minute window
- Removes debug console log statements from stream event collection process in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/839/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a)

#### 📍Where to Start
Start with the `WORKER_COUNT` constant change in [suites/agents/stress-test.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/839/files#diff-793fbc660e580d91972704e08a1b5ef8382c1b0c42e1fb57134d0f592da198ee) to understand the scale increase of the stress test.

----

_[Macroscope](https://app.macroscope.com) summarized 12990df._