### PR TITLE
Refactor worker retrieval to use index for clarity

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cli": "tsx scripts/cli.ts",
     "dms": "yarn test functional/dms.test.ts",
     "format": "prettier -w .",
-    "functional": "yarn test suites/functional",
+    "functional": "yarn test suites/functional --sync all",
     "gen": "tsx inboxes/gen.ts",
     "large": "yarn test suites/metrics/large",
     "lint": "eslint .",

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -541,6 +541,21 @@ async function runVitestTest(
     );
   }
 
+  // Extract --sync parameter and set as environment variable
+  const syncArg = options.vitestArgs.find((arg) => arg.startsWith("--sync="));
+  if (syncArg) {
+    const syncValue = syncArg.split("=")[1];
+    env.SYNC_STRATEGY = syncValue;
+    console.debug(
+      `Setting SYNC_STRATEGY environment variable to: ${syncValue}`,
+    );
+
+    // Remove from vitestArgs since it's not a vitest parameter
+    options.vitestArgs = options.vitestArgs.filter(
+      (arg) => !arg.startsWith("--sync="),
+    );
+  }
+
   // Set logging level
   env.LOGGING_LEVEL = options.logLevel || "error";
 
@@ -706,6 +721,23 @@ async function main(): Promise<void> {
             // Remove from vitestArgs since it's not a vitest parameter
             options.vitestArgs = options.vitestArgs.filter(
               (arg) => !arg.startsWith("--env="),
+            );
+          }
+
+          // Extract --sync parameter and set as environment variable
+          const syncArg = options.vitestArgs.find((arg) =>
+            arg.startsWith("--sync="),
+          );
+          if (syncArg) {
+            const syncValue = syncArg.split("=")[1];
+            env.SYNC_STRATEGY = syncValue;
+            console.debug(
+              `Setting SYNC_STRATEGY environment variable to: ${syncValue}`,
+            );
+
+            // Remove from vitestArgs since it's not a vitest parameter
+            options.vitestArgs = options.vitestArgs.filter(
+              (arg) => !arg.startsWith("--sync="),
             );
           }
 

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -171,6 +171,9 @@ function showUsageAndExit(): never {
     "      --log-level <level> Set logging level (debug, info, error) (default: debug)",
   );
   console.error(
+    "      --sync <strategy>   Set sync strategy (e.g., --sync all,conversations)",
+  );
+  console.error(
     "      [vitest_options...] Other options passed directly to vitest",
   );
   console.error("");
@@ -363,6 +366,16 @@ function parseTestArgs(args: string[]): {
         } else {
           console.warn(
             "--log-level flag requires a value (e.g., --log-level debug)",
+          );
+        }
+        break;
+      case "--sync":
+        if (nextArg) {
+          options.vitestArgs.push(`--sync=${nextArg}`);
+          i++;
+        } else {
+          console.warn(
+            "--sync flag requires a value (e.g., --sync all,conversations)",
           );
         }
         break;

--- a/scripts/versions.ts
+++ b/scripts/versions.ts
@@ -384,7 +384,8 @@ function main() {
   }
 
   // Check for --help flag
-  const shouldShowHelp = process.argv.includes("--help") || process.argv.includes("-h");
+  const shouldShowHelp =
+    process.argv.includes("--help") || process.argv.includes("-h");
   if (shouldShowHelp) {
     showHelp();
     return;

--- a/suites/browser/browser.test.ts
+++ b/suites/browser/browser.test.ts
@@ -19,7 +19,6 @@ describe(testName, () => {
 
   beforeAll(async () => {
     const convoStreamBot = await getWorkers(2);
-    const names = convoStreamBot.getAll().map((w) => w.name);
     // Start conversation streams for group event detection
     convoStreamBot.startStream(typeofStream.Conversation);
 
@@ -27,8 +26,8 @@ describe(testName, () => {
     // Start message and response streams for gm bot
     gmBotWorker.startStream(typeofStream.MessageandResponse);
 
-    creator = convoStreamBot.get(names[0]) as Worker;
-    xmtpChat = convoStreamBot.get(names[1]) as Worker;
+    creator = convoStreamBot.get(0)!;
+    xmtpChat = convoStreamBot.get(1)!;
     receiver = gmBotWorker.getCreator();
     xmtpTester = new playwright({
       headless,

--- a/suites/bugs/conv-stream-fails.test.ts/conv-stream-fails.test.ts
+++ b/suites/bugs/conv-stream-fails.test.ts/conv-stream-fails.test.ts
@@ -15,12 +15,11 @@ describe(testName, () => {
 
   beforeAll(async () => {
     const convoStreamBot = await getWorkers(["randomgroup", "randommember"]);
-    const names = convoStreamBot.getAll().map((w) => w.name);
     // Start conversation streams for group event detection
     convoStreamBot.startStream(typeofStream.Conversation);
 
-    creator = convoStreamBot.get(names[0]) as Worker;
-    xmtpChat = convoStreamBot.get(names[1]) as Worker;
+    creator = convoStreamBot.get(0)!;
+    xmtpChat = convoStreamBot.get(1)!;
     xmtpTester = new playwright({
       headless,
       defaultUser: {

--- a/suites/functional/callbacks.test.ts
+++ b/suites/functional/callbacks.test.ts
@@ -8,11 +8,9 @@ describe(testName, async () => {
   setupTestLifecycle({ testName });
   const workers = await getWorkers(5);
 
-  const names = workers.getAll().map((w) => w.name);
-
   it("should receive messages using await async", async () => {
-    const sender = workers.get(names[0])!;
-    const receiver = workers.get(names[1])!;
+    const sender = workers.get(0)!;
+    const receiver = workers.get(1)!;
 
     // Set up stream first
     const receiverConversation =
@@ -50,8 +48,8 @@ describe(testName, async () => {
   });
 
   it("should receive messages using callback", async () => {
-    const sender = workers.get(names[2])!;
-    const receiver = workers.get(names[1])!;
+    const sender = workers.get(2)!;
+    const receiver = workers.get(1)!;
 
     // Set up stream first
     const messagePromise = new Promise<DecodedMessage>((resolve, reject) => {
@@ -85,7 +83,7 @@ describe(testName, async () => {
   });
 
   // it("should receive conversation with async", async () => {
-  //   const receiver = workers.get(names[1])!;
+  //   const receiver = workers.get(1])!;
 
   //   // Set up stream first
   //   const stream = await receiver.client.conversations.stream();
@@ -118,7 +116,7 @@ describe(testName, async () => {
   // });
 
   // it("should receive conversation with callback", async () => {
-  //   const receiver = workers.get(names[1])!;
+  //   const receiver = workers.get(1])!;
 
   //   // Set up stream first
   //   const conversationPromise = new Promise<Dm>((resolve, reject) => {

--- a/suites/functional/playwright.test.ts
+++ b/suites/functional/playwright.test.ts
@@ -19,7 +19,6 @@ describe(testName, () => {
 
   beforeAll(async () => {
     const convoStreamBot = await getWorkers(2);
-    const names = convoStreamBot.getAll().map((w) => w.name);
     // Start conversation streams for group event detection
     convoStreamBot.startStream(typeofStream.Conversation);
 
@@ -27,8 +26,8 @@ describe(testName, () => {
     // Start message and response streams for gm bot
     gmBotWorker.startStream(typeofStream.MessageandResponse);
 
-    creator = convoStreamBot.get(names[0]) as Worker;
-    xmtpChat = convoStreamBot.get(names[1]) as Worker;
+    creator = convoStreamBot.get(0)!;
+    xmtpChat = convoStreamBot.get(1)!;
     receiver = gmBotWorker.getCreator();
     xmtpTester = new playwright({
       headless,

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -463,9 +463,6 @@ export class WorkerClient extends Worker {
     this.client = client as Client;
     this.address = address;
 
-    this.startInitialStream();
-    this.startSyncs();
-
     const installationId = this.client.installationId;
 
     return {
@@ -474,23 +471,6 @@ export class WorkerClient extends Worker {
       address: address,
       installationId,
     };
-  }
-
-  /**
-   * Starts a periodic sync of all conversations
-   * @param interval - The interval in milliseconds to sync
-   */
-  private startSyncs() {
-    // No automatic syncs - everything is on-demand now
-    // Use startSync() method to start syncs manually
-  }
-
-  /**
-   * Unified method to start the appropriate stream based on configuration
-   */
-  private startInitialStream() {
-    // No automatic streams - everything is on-demand now
-    // Use startStream() method to start streams manually
   }
 
   /**
@@ -1198,10 +1178,6 @@ export class WorkerClient extends Worker {
     this.client = client as Client;
     this.address = address;
     this.folder = newFolder; // Update folder reference
-
-    // Restart streams and syncs with new installation
-    this.startInitialStream();
-    this.startSyncs();
 
     const newInstallationId = this.client.installationId;
 

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -256,6 +256,7 @@ export class WorkerClient extends Worker {
     void (async () => {
       while (true) {
         if (syncType === typeOfSync.SyncAll) {
+          console.debug(`[${this.nameId}] Starting ${syncType} sync`);
           await this.client.conversations.syncAll();
         } else if (syncType === typeOfSync.Sync) {
           await this.client.conversations.sync();

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -256,7 +256,6 @@ export class WorkerClient extends Worker {
     void (async () => {
       while (true) {
         if (syncType === typeOfSync.SyncAll) {
-          console.debug(`[${this.nameId}] Starting ${syncType} sync`);
           await this.client.conversations.syncAll();
         } else if (syncType === typeOfSync.Sync) {
           await this.client.conversations.sync();

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -221,28 +221,6 @@ export class WorkerClient extends Worker {
   }
 
   /**
-   * Apply sync strategy by starting sync and streams
-   * @param strategy - The sync strategy to apply
-   */
-  public applySyncStrategy(strategy: SyncStrategy): void {
-    console.debug(
-      `[${this.nameId}] Applying sync strategy: ${JSON.stringify(strategy)}`,
-    );
-
-    // Start sync if specified
-    if (strategy.syncType !== typeOfSync.None) {
-      this.startSync(strategy.syncType, strategy.syncInterval);
-    }
-
-    // Start streams if specified
-    for (const streamType of strategy.streamTypes) {
-      if (streamType !== typeofStream.None) {
-        this.startStream(streamType);
-      }
-    }
-  }
-
-  /**
    * Starts a specific sync type
    * @param syncType - The type of sync to start
    * @param interval - The interval in milliseconds to sync

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -5,6 +5,7 @@ import { formatBytes, generateEncryptionKeyHex, sleep } from "@helpers/client";
 import { getAutoVersions, VersionList } from "@workers/versions";
 import { type Client, type Group, type XmtpEnv } from "@xmtp/node-sdk";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
 import { installationThreshold, WorkerClient, type typeofStream } from "./main";
 
 // Deprecated: Use getWorkers with count and options instead
@@ -277,16 +278,24 @@ export class WorkerManager {
    * Gets a specific worker by name and optional installation ID
    */
   public get(
-    baseName: string,
+    baseName: string | number,
     installationId: string = "a",
   ): Worker | undefined {
-    if (baseName.includes("-")) {
-      const parts = baseName.split("-");
-      const name = parts[0];
-      const id = parts[1];
-      return this.workers[name]?.[id];
+    if (typeof baseName === "number") {
+      let index = baseName;
+      if (index >= this.getAll().length) {
+        throw new Error(`Worker index ${index} out of bounds`);
+      }
+      return this.getAll()[index];
+    } else {
+      if (baseName.includes("-")) {
+        const parts = baseName.split("-");
+        const name = parts[0];
+        const id = parts[1];
+        return this.workers[name]?.[id];
+      }
+      return this.workers[baseName]?.[installationId];
     }
-    return this.workers[baseName]?.[installationId];
   }
 
   /**


### PR DESCRIPTION
### Refactor worker retrieval to use index-based access and add sync strategy configuration through CLI parameters
- Adds `--sync` CLI parameter support in [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/847/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) that sets the `SYNC_STRATEGY` environment variable for configuring synchronization behavior
- Modifies worker access pattern across test files to use numeric indices instead of name-based lookup, removing intermediate name extraction steps
- Removes automatic syncing and streaming initialization from [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/847/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1), replacing it with explicit `applySyncStrategy` method
- Updates [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/847/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) to support both string and numeric worker access through modified `get` method and adds `checkCLI` method for applying sync strategies from environment variables

#### 📍Where to Start
Start with the `checkCLI` method in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/847/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) to understand how sync strategies are applied from environment variables.

----

_[Macroscope](https://app.macroscope.com) summarized 39319ef._