### PR TITLE
Reduce stream timeout for improved performance stability

### DIFF
--- a/scripts/stress.ts
+++ b/scripts/stress.ts
@@ -21,7 +21,7 @@ function parseArgs(): StressTestConfig {
   const config: StressTestConfig = {
     userCount: 1000,
     successThreshold: 99,
-    streamTimeoutInSeconds: 200,
+    streamTimeoutInSeconds: 120,
     env: "production",
     botAddress: "0x7f1c0d2955f873fc91f1728c19b2ed7be7a9684d",
     agentName: "",


### PR DESCRIPTION
### Reduce stream timeout from 200 seconds to 120 seconds in StressTestConfig for improved performance stability
This change modifies the default `streamTimeoutInSeconds` parameter value in the `StressTestConfig` object within [scripts/stress.ts](https://github.com/xmtp/xmtp-qa-tools/pull/865/files#diff-22a8763f1206747559c66b2643d2260459fbc7ae8ddd0733c418791b77ebf4ab), reducing the timeout from 200 seconds to 120 seconds.

#### 📍Where to Start
Start with the `StressTestConfig` object in [scripts/stress.ts](https://github.com/xmtp/xmtp-qa-tools/pull/865/files#diff-22a8763f1206747559c66b2643d2260459fbc7ae8ddd0733c418791b77ebf4ab) where the `streamTimeoutInSeconds` parameter has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized a518962._