### PR TITLE
Add runs parameter for multiple stress test executions

### DIFF
--- a/suites/agents/status.md
+++ b/suites/agents/status.md
@@ -1,39 +1,7 @@
 # LOCAL LOCAL
 
-| Agent               | Environment | Success Rate | Total Time | Avg Response | Median Response | 95th Percentile | M/s   | Status  |
-| ------------------- | ----------- | ------------ | ---------- | ------------ | --------------- | --------------- | ----- | ------- |
-| local               | dev         | 100.0%       | 3.2s       | 1.1s         | 1.1s            | 1.3s            | 93.0  | Success |
-| local               | local       | 100.0%       | 2.3s       | 0.4s         | 0.4s            | 0.7s            | 130.0 | Success |
-| local               | production  | 100.0%       | 3.6s       | 1.2s         | 1.2s            | 1.4s            | 84.3  | Success |
-| gm (first time)     | dev         | 66.7%        | 120.9s     | 7.5s         | 7.5s            | 14.0s           | 2.5   | Failure |
-| gm (optimistic)     | dev         | 99.7%        | 120.7s     | 16.8s        | 18.4s           | 30.4s           | 2.5   | Success |
-| gm (optimistic)     | production  | 100.0%       | 61.0s      | 42.6s        | 45.3s           | 57.2s           | 4.9   | Success |
-| gm (non-optimistic) | production  | 99.3%        | 120.7s     | 15.03s       | 15.24s          | 27.12s          | 2.5   | Success |
-
-# 📊 STRESS TEST RESULTS
-
-this was with 2nd time running the test
-
-Agent: gm
-Env: production
-Success Rate: 497/500 (99.4%)
-⏱️ Total Execution Time: 121.2s
-Average Response Time: 59.89s
-Median Response Time: 80.28s
-95th Percentile Response Time: 101.87s
-Messages per Second: 4.1
-✅ SUCCESS: 99.4% ≥ 99% threshold
-🏆 Test completed successfully!
-
-# 📊 STRESS TEST RESULTS
-
-Agent: gm
-Env: production
-Success Rate: 497/500 (99.4%)
-⏱️ Total Execution Time: 121.0s
-Average Response Time: 48.73s
-Median Response Time: 24.42s
-95th Percentile Response Time: 109.33s
-Messages per Second: 4.1
-✅ SUCCESS: 99.4% ≥ 99% threshold
-🏆 Test completed successfully!
+| Agent | Strategy | Environment | Success Rate | Total Time | Avg Response | Median Response | 95th Percentile | M/s  | Status  |
+| ----- | -------- | ----------- | ------------ | ---------- | ------------ | --------------- | --------------- | ---- | ------- |
+| local | normal   | production  | 100%         | 366.7s     | 16.78s       | 1.19s           | 57.44s          | 13.6 | Success |
+| local | async    | production  | 100%         | 364.4s     | 17.20s       | 1.13s           | 57.31s          | 13.7 | Success |
+| local | queue    | production  | 100%         | 365.2s     | 16.93s       | 1.27s           | 57.13s          | 13.7 | Success |

--- a/suites/agents/status.md
+++ b/suites/agents/status.md
@@ -3,5 +3,6 @@
 | Agent | Strategy | Environment | Success Rate | Total Time | Avg Response | Median Response | 95th Percentile | M/s  | Status  |
 | ----- | -------- | ----------- | ------------ | ---------- | ------------ | --------------- | --------------- | ---- | ------- |
 | local | normal   | production  | 100%         | 366.7s     | 16.78s       | 1.19s           | 57.44s          | 13.6 | Success |
-| local | async    | production  | 100%         | 364.4s     | 17.20s       | 1.13s           | 57.31s          | 13.7 | Success |
 | local | queue    | production  | 100%         | 365.2s     | 16.93s       | 1.27s           | 57.13s          | 13.7 | Success |
+| gm    | normal   | production  | 99.8%        | 636.0s     | 21.60s       | 14.32s          | 57.81s          | 7.9  | Success |
+| gm    | async    | production  | 98.3%        | 812.0s     | 25.23s       | 16.13s          | 98.71s          | 6.2  | Success |


### PR DESCRIPTION
### Add runs parameter to stress test script for multiple consecutive test executions
- The stress test script in [scripts/stress.ts](https://github.com/xmtp/xmtp-qa-tools/pull/869/files#diff-22a8763f1206747559c66b2643d2260459fbc7ae8ddd0733c418791b77ebf4ab) adds a `runs` parameter to the `StressTestConfig` interface with a default value of 1, enabling multiple consecutive test executions through a new `--runs` command-line argument
- The `runStressTest` function implements a for loop to execute tests multiple times, accumulates results across all runs, and displays progress reporting for each run
- The agent status documentation in [suites/agents/status.md](https://github.com/xmtp/xmtp-qa-tools/pull/869/files#diff-7866cbe72749c1131778d06f65cca541bcb90dcec00e53fc443ff684ff19c758) is restructured to compare different agent strategies (normal, queue, async) rather than environments, providing a more concise performance metrics overview

#### 📍Where to Start
Start with the `runStressTest` function in [scripts/stress.ts](https://github.com/xmtp/xmtp-qa-tools/pull/869/files#diff-22a8763f1206747559c66b2643d2260459fbc7ae8ddd0733c418791b77ebf4ab) to understand how the multiple runs functionality is implemented.

----

_[Macroscope](https://app.macroscope.com) summarized b896803._