### PR TITLE
Update onit agent with address and network details

### DIFF
--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -77,9 +77,9 @@
   {
     "name": "onit",
     "baseName": "onit.base.eth",
-    "address": "",
+    "address": "0xE9C89b50f3b947125FdBCdF8FBff35b9f38fB0C4",
     "sendMessage": "hi",
-    "networks": [],
+    "networks": ["production"],
     "slackChannel": "#onit-alerts",
     "shouldRespondOnTagged": true
   },


### PR DESCRIPTION
### Update onit agent configuration with Ethereum address 0xE9C89b50f3b947125FdBCdF8FBff35b9f38fB0C4 and production network deployment in agents.json
The agent configuration in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/892/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) is modified to populate the `address` field with the Ethereum address `0xE9C89b50f3b947125FdBCdF8FBff35b9f38fB0C4` and the `networks` field with the `production` network, changing the agent from having no address and no network assignments to being configured for production deployment.

#### 📍Where to Start
Start with the agent configuration changes in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/892/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5).

----

_[Macroscope](https://app.macroscope.com) summarized 45c52c9._