### PR TITLE
Update to latest release candidates for node bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@xmtp/node-bindings-1.2.5": "npm:@xmtp/node-bindings@1.2.5",
     "@xmtp/node-bindings-1.2.7": "npm:@xmtp/node-bindings@1.2.7",
     "@xmtp/node-bindings-1.2.8": "npm:@xmtp/node-bindings@1.2.8",
-    "@xmtp/node-bindings-1.3.0rc1": "npm:@xmtp/node-bindings@1.3.0-rc1",
+    "@xmtp/node-bindings-1.3.0rc2": "npm:@xmtp/node-bindings@1.3.0-rc2",
     "@xmtp/node-sdk": "3.1.2",
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13",
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47",
@@ -62,7 +62,7 @@
     "@xmtp/node-sdk-3.0.1": "npm:@xmtp/node-sdk@3.0.1",
     "@xmtp/node-sdk-3.1.1": "npm:@xmtp/node-sdk@3.1.1",
     "@xmtp/node-sdk-3.1.2": "npm:@xmtp/node-sdk@3.1.2",
-    "@xmtp/node-sdk-3.2.0rc1": "npm:@xmtp/node-sdk@3.2.0-rc1",
+    "@xmtp/node-sdk-3.2.0rc2": "npm:@xmtp/node-sdk@3.2.0-rc2",
     "axios": "^1.8.2",
     "datadog-metrics": "^0.12.1",
     "dotenv": "^16.5.0",
@@ -148,9 +148,9 @@
         "@xmtp/node-bindings": "1.2.8"
       }
     },
-    "@xmtp/node-sdk@3.2.0-rc1": {
+    "@xmtp/node-sdk@3.2.0-rc2": {
       "dependencies": {
-        "@xmtp/node-bindings": "1.3.0-rc1"
+        "@xmtp/node-bindings": "1.3.0-rc2"
       }
     }
   }

--- a/workers/versions.ts
+++ b/workers/versions.ts
@@ -59,7 +59,7 @@ import {
   Conversation as Conversation320,
   Dm as Dm320,
   Group as Group320,
-} from "@xmtp/node-sdk-3.2.0rc1";
+} from "@xmtp/node-sdk-3.2.0rc2";
 
 // SDK version mappings
 export const VersionList = [
@@ -68,8 +68,8 @@ export const VersionList = [
     Conversation: Conversation320,
     Dm: Dm320,
     Group: Group320,
-    nodeVersion: "3.2.0rc1",
-    bindingsPackage: "1.3.0rc1",
+    nodeVersion: "3.2.0rc2",
+    bindingsPackage: "1.3.0rc2",
     auto: true,
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,10 +1512,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings-1.3.0rc1@npm:@xmtp/node-bindings@1.3.0-rc1, @xmtp/node-bindings@npm:1.3.0-rc1":
-  version: 1.3.0-rc1
-  resolution: "@xmtp/node-bindings@npm:1.3.0-rc1"
-  checksum: 10/3ba98529f27d8054cb9875fb2284a2c1722309530c8841ebdb629ff48d578d8467dc34631b0e69942628853c75e63a2b9d29c4eb6ec1f06ddc7326114726910b
+"@xmtp/node-bindings-1.3.0rc2@npm:@xmtp/node-bindings@1.3.0-rc2, @xmtp/node-bindings@npm:1.3.0-rc2":
+  version: 1.3.0-rc2
+  resolution: "@xmtp/node-bindings@npm:1.3.0-rc2"
+  checksum: 10/13920112ca1bb338bf4a960cc17768f6d613b40943c28ca46c33cb1a84335fe746f77c182be3d2ab109c8f431ca18b36d2759f2c14cf855daa4498ccf28eb108
   languageName: node
   linkType: hard
 
@@ -1630,15 +1630,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-3.2.0rc1@npm:@xmtp/node-sdk@3.2.0-rc1":
-  version: 3.2.0-rc1
-  resolution: "@xmtp/node-sdk@npm:3.2.0-rc1"
+"@xmtp/node-sdk-3.2.0rc2@npm:@xmtp/node-sdk@3.2.0-rc2":
+  version: 3.2.0-rc2
+  resolution: "@xmtp/node-sdk@npm:3.2.0-rc2"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.3.0-rc1"
-  checksum: 10/e65f4c4b667674efa4b43779beb36706c5a72874411d71e928d7cf2f1da87e68736bbacf35cc6b917549e8aa70548716789cdedf03373717b2e3063b54d358c5
+    "@xmtp/node-bindings": "npm:1.3.0-rc2"
+  checksum: 10/b5d33e93d12664ef1960b7916341c1a3c41abf665330191812880081cc25c94716eeb4924e5aa566e5188fa87bd095a0ae0aaa1647a70f910475783d600c403d
   languageName: node
   linkType: hard
 
@@ -4742,7 +4742,7 @@ __metadata:
     "@xmtp/node-bindings-1.2.5": "npm:@xmtp/node-bindings@1.2.5"
     "@xmtp/node-bindings-1.2.7": "npm:@xmtp/node-bindings@1.2.7"
     "@xmtp/node-bindings-1.2.8": "npm:@xmtp/node-bindings@1.2.8"
-    "@xmtp/node-bindings-1.3.0rc1": "npm:@xmtp/node-bindings@1.3.0-rc1"
+    "@xmtp/node-bindings-1.3.0rc2": "npm:@xmtp/node-bindings@1.3.0-rc2"
     "@xmtp/node-sdk": "npm:3.1.2"
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13"
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47"
@@ -4753,7 +4753,7 @@ __metadata:
     "@xmtp/node-sdk-3.0.1": "npm:@xmtp/node-sdk@3.0.1"
     "@xmtp/node-sdk-3.1.1": "npm:@xmtp/node-sdk@3.1.1"
     "@xmtp/node-sdk-3.1.2": "npm:@xmtp/node-sdk@3.1.2"
-    "@xmtp/node-sdk-3.2.0rc1": "npm:@xmtp/node-sdk@3.2.0-rc1"
+    "@xmtp/node-sdk-3.2.0rc2": "npm:@xmtp/node-sdk@3.2.0-rc2"
     axios: "npm:^1.8.2"
     datadog-metrics: "npm:^0.12.1"
     dotenv: "npm:^16.5.0"


### PR DESCRIPTION
### Update XMTP node bindings and SDK dependencies from version 1.3.0-rc1 to 1.3.0-rc2 and 3.2.0-rc1 to 3.2.0-rc2
Updates XMTP dependency versions across the project configuration files. The changes modify `@xmtp/node-bindings` from version 1.3.0-rc1 to 1.3.0-rc2 and `@xmtp/node-sdk` from version 3.2.0-rc1 to 3.2.0-rc2 in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/898/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519). The [workers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/898/files#diff-910db3846cf9a0d5fc1c527bde6d944858ffb53a43a6717ee43018e0ba23e793) file updates the import statement and VersionList array to reference the new release candidate versions. The [yarn.lock](https://github.com/xmtp/xmtp-qa-tools/pull/898/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) file reflects the dependency tree changes for the updated package versions.

#### 📍Where to Start
Start with the dependency changes in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/898/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to understand the version updates, then review the import and configuration changes in [workers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/898/files#diff-910db3846cf9a0d5fc1c527bde6d944858ffb53a43a6717ee43018e0ba23e793).

----

_[Macroscope](https://app.macroscope.com) summarized 09e7dfc._