### PR TITLE
Add support for new XMTP node-sdk version 3.2.0rc3

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@xmtp/node-bindings-1.2.7": "npm:@xmtp/node-bindings@1.2.7",
     "@xmtp/node-bindings-1.2.8": "npm:@xmtp/node-bindings@1.2.8",
     "@xmtp/node-bindings-1.3.0rc2": "npm:@xmtp/node-bindings@1.3.0-rc2",
+    "@xmtp/node-bindings-1.3.0rc3": "npm:@xmtp/node-bindings@1.4.0-dev.ad95443",
     "@xmtp/node-sdk": "3.1.2",
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13",
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47",
@@ -62,6 +63,7 @@
     "@xmtp/node-sdk-3.1.1": "npm:@xmtp/node-sdk@3.1.1",
     "@xmtp/node-sdk-3.1.2": "npm:@xmtp/node-sdk@3.1.2",
     "@xmtp/node-sdk-3.2.0rc2": "npm:@xmtp/node-sdk@3.2.0-rc2",
+    "@xmtp/node-sdk-3.2.0rc3": "npm:@xmtp/node-sdk@3.2.0-rc2",
     "axios": "^1.8.2",
     "datadog-metrics": "^0.12.1",
     "dotenv": "^16.5.0",
@@ -95,62 +97,5 @@
   "packageManager": "yarn@4.6.0",
   "engines": {
     "node": ">=20"
-  },
-  "packageExtensions": {
-    "@xmtp/mls-client@0.0.9": {
-      "dependencies": {
-        "@xmtp/mls-client-bindings-node": "0.0.9"
-      }
-    },
-    "@xmtp/node-sdk@0.0.47": {
-      "dependencies": {
-        "@xmtp/node-bindings": "0.0.41"
-      }
-    },
-    "@xmtp/node-sdk@1.0.0": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.0.0"
-      }
-    },
-    "@xmtp/node-sdk@1.0.5": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.1.3"
-      }
-    },
-    "@xmtp/node-sdk@2.0.9": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.1.8"
-      }
-    },
-    "@xmtp/node-sdk@2.1.0": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.2.0"
-      }
-    },
-    "@xmtp/node-sdk@2.2.0": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.2.2"
-      }
-    },
-    "@xmtp/node-sdk@3.0.1": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.2.5"
-      }
-    },
-    "@xmtp/node-sdk@3.1.1": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.2.7"
-      }
-    },
-    "@xmtp/node-sdk@3.1.2": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.2.8"
-      }
-    },
-    "@xmtp/node-sdk@3.2.0-rc2": {
-      "dependencies": {
-        "@xmtp/node-bindings": "1.3.0-rc2"
-      }
-    }
   }
 }

--- a/workers/versions.ts
+++ b/workers/versions.ts
@@ -60,9 +60,24 @@ import {
   Dm as Dm320,
   Group as Group320,
 } from "@xmtp/node-sdk-3.2.0rc2";
+import {
+  Client as Client320rc3,
+  Conversation as Conversation320rc3,
+  Dm as Dm320rc3,
+  Group as Group320rc3,
+} from "@xmtp/node-sdk-3.2.0rc3";
 
 // SDK version mappings
 export const VersionList = [
+  {
+    Client: Client320rc3,
+    Conversation: Conversation320rc3,
+    Dm: Dm320rc3,
+    Group: Group320rc3,
+    nodeVersion: "3.2.0rc3",
+    bindingsPackage: "1.3.0rc3",
+    auto: false,
+  },
   {
     Client: Client320,
     Conversation: Conversation320,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,6 +1519,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/node-bindings-1.3.0rc3@npm:@xmtp/node-bindings@1.4.0-dev.ad95443":
+  version: 1.4.0-dev.ad95443
+  resolution: "@xmtp/node-bindings@npm:1.4.0-dev.ad95443"
+  checksum: 10/1734fb6e4d03b77292ef6299e3da094664466ae4d0a1f1ac4b24c6c3bd4963dc79218cdfe6c714301847a2c123809fb684b434d36ab9fad446091872fa6fe51e
+  languageName: node
+  linkType: hard
+
 "@xmtp/node-sdk-0.0.13@npm:@xmtp/mls-client@0.0.13":
   version: 0.0.13
   resolution: "@xmtp/mls-client@npm:0.0.13"
@@ -1630,7 +1637,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-3.2.0rc2@npm:@xmtp/node-sdk@3.2.0-rc2":
+"@xmtp/node-sdk-3.2.0rc2@npm:@xmtp/node-sdk@3.2.0-rc2, @xmtp/node-sdk-3.2.0rc3@npm:@xmtp/node-sdk@3.2.0-rc2":
   version: 3.2.0-rc2
   resolution: "@xmtp/node-sdk@npm:3.2.0-rc2"
   dependencies:
@@ -4743,6 +4750,7 @@ __metadata:
     "@xmtp/node-bindings-1.2.7": "npm:@xmtp/node-bindings@1.2.7"
     "@xmtp/node-bindings-1.2.8": "npm:@xmtp/node-bindings@1.2.8"
     "@xmtp/node-bindings-1.3.0rc2": "npm:@xmtp/node-bindings@1.3.0-rc2"
+    "@xmtp/node-bindings-1.3.0rc3": "npm:@xmtp/node-bindings@1.4.0-dev.ad95443"
     "@xmtp/node-sdk": "npm:3.1.2"
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13"
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47"
@@ -4754,6 +4762,7 @@ __metadata:
     "@xmtp/node-sdk-3.1.1": "npm:@xmtp/node-sdk@3.1.1"
     "@xmtp/node-sdk-3.1.2": "npm:@xmtp/node-sdk@3.1.2"
     "@xmtp/node-sdk-3.2.0rc2": "npm:@xmtp/node-sdk@3.2.0-rc2"
+    "@xmtp/node-sdk-3.2.0rc3": "npm:@xmtp/node-sdk@3.2.0-rc2"
     axios: "npm:^1.8.2"
     datadog-metrics: "npm:^0.12.1"
     dotenv: "npm:^16.5.0"


### PR DESCRIPTION
### Add support for new XMTP node-sdk version 3.2.0rc3 by updating package dependencies and version configuration
- Updates [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/915/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to add new dependency aliases for `@xmtp/node-bindings-1.3.0rc3` and `@xmtp/node-sdk-3.2.0rc3` while removing the `packageExtensions` section that previously managed dependency mappings between XMTP SDK and bindings versions
- Modifies [workers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/915/files#diff-910db3846cf9a0d5fc1c527bde6d944858ffb53a43a6717ee43018e0ba23e793) to import and register the new XMTP client library version 3.2.0rc3 components (`Client320rc3`, `Conversation320rc3`, `Dm320rc3`, `Group320rc3`) in the `VersionList` array with `auto` flag set to false
- Updates [yarn.lock](https://github.com/xmtp/xmtp-qa-tools/pull/915/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect the new dependency changes

#### 📍Where to Start
Start with the `VersionList` array in [workers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/915/files#diff-910db3846cf9a0d5fc1c527bde6d944858ffb53a43a6717ee43018e0ba23e793) to understand how the new XMTP SDK version 3.2.0rc3 is registered and configured.

----

_[Macroscope](https://app.macroscope.com) summarized 30c0285._