### PR TITLE
Remove error logging for timeout in stress test

### DIFF
--- a/scripts/stress.ts
+++ b/scripts/stress.ts
@@ -222,7 +222,7 @@ async function runStressTest(config: Config): Promise<void> {
       );
     }
   } catch (error) {
-    console.log(`❌ Test timed out - gathering partial results...`, error);
+    console.log(`❌ Test timed out - gathering partial results...`);
 
     // Collect partial results from completed workers
     const partialResults = await Promise.allSettled(promises);

--- a/scripts/stress.ts
+++ b/scripts/stress.ts
@@ -2,20 +2,19 @@ import {
   Client,
   IdentifierKind,
   type Conversation,
-  type LogLevel,
   type XmtpEnv,
 } from "@xmtp/node-sdk";
 import "dotenv/config";
 import fs from "node:fs";
 import path from "node:path";
-import { generatePrivateKey } from "viem/accounts";
 import {
   createSigner,
   generateEncryptionKeyHex,
   getDbPath,
   getEncryptionKeyFromHex,
   validateEnvironment,
-} from "../helpers/client";
+} from "@helpers/client";
+import { generatePrivateKey } from "viem/accounts";
 
 // yarn stress --address 0x362d666308d90e049404d361b29c41bda42dd38b --users 5
 // yarn stress --address 0x362d666308d90e049404d361b29c41bda42dd38b --users 5 --env production


### PR DESCRIPTION
### Remove error logging for timeout in stress test and replace environment variable configuration with command-line arguments and dynamic encryption key generation in scripts/stress.ts
The stress test script removes environment variable validation and replaces it with command-line argument parsing and hardcoded defaults in [scripts/stress.ts](https://github.com/xmtp/xmtp-qa-tools/pull/918/files#diff-22a8763f1206747559c66b2643d2260459fbc7ae8ddd0733c418791b77ebf4ab). The changes include:

- Remove `validateEnvironment` function usage and environment variable validation block for `ENCRYPTION_KEY`, `LOGGING_LEVEL`, `XMTP_ENV`, and `ADDRESS`
- Add command-line argument parsing for `--address` and `--env` with defaults of `"0x362d666308d90e049404d361b29c41bda42dd38b"` and `"production"`
- Replace static encryption key from environment variable with dynamic generation using `generateEncryptionKeyHex()`
- Remove error object from timeout catch block logging
- Add `address` field to Config interface and use `config.address` instead of hardcoded `ADDRESS` in `newDmWithIdentifier` call

#### 📍Where to Start
Start with the `parseArgs()` function in [scripts/stress.ts](https://github.com/xmtp/xmtp-qa-tools/pull/918/files#diff-22a8763f1206747559c66b2643d2260459fbc7ae8ddd0733c418791b77ebf4ab) to understand the new command-line argument configuration approach.

----

_[Macroscope](https://app.macroscope.com) summarized f06d1a1._