### PR TITLE
Refactor worker retrieval for improved clarity and efficiency

### DIFF
--- a/suites/agents/agents-dms.test.ts
+++ b/suites/agents/agents-dms.test.ts
@@ -14,7 +14,11 @@ import { type AgentConfig } from "./helper";
 
 const testName = "agents-dms";
 describe(testName, async () => {
-  setupTestLifecycle({ testName, sendMetrics: true });
+  setupTestLifecycle({
+    testName,
+    sendMetrics: true,
+    sendDurationMetrics: true,
+  });
   const env = process.env.XMTP_ENV as XmtpEnv;
   const workers = await getWorkers(["randomguy"]);
 

--- a/suites/agents/agents-tagged.test.ts
+++ b/suites/agents/agents-tagged.test.ts
@@ -16,7 +16,11 @@ import { type AgentConfig } from "./helper";
 const testName = "agents-tagged";
 
 describe(testName, async () => {
-  setupTestLifecycle({ testName, sendMetrics: true });
+  setupTestLifecycle({
+    testName,
+    sendMetrics: true,
+    sendDurationMetrics: true,
+  });
   const env = process.env.XMTP_ENV as XmtpEnv;
   const workers = await getWorkers(["randomguy"]);
 

--- a/suites/metrics/large.test.ts
+++ b/suites/metrics/large.test.ts
@@ -11,11 +11,6 @@ import { describe, expect, it } from "vitest";
 
 const testName = "large";
 describe(testName, async () => {
-  setupTestLifecycle({
-    testName,
-    sendMetrics: true,
-    sendDurationMetrics: true,
-  });
   const BATCH_SIZE = process.env.BATCH_SIZE
     ? process.env.BATCH_SIZE.split("-").map((v) => Number(v))
     : [5, 10];
@@ -38,6 +33,7 @@ describe(testName, async () => {
       customDuration = v;
     },
     sendMetrics: true,
+    sendDurationMetrics: true,
   });
 
   for (const groupSize of BATCH_SIZE) {


### PR DESCRIPTION
### Refactor message recovery testing in delivery test suite to use stream control instead of worker termination for improved clarity and efficiency
- Refactors [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/920/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916) to use stream stopping/resuming with `typeofStream.Message` from `@workers/main` instead of worker termination for message recovery testing, renames variables `amountofMessages` to `MESSAGE_COUNT` and `receiverAmount` to `WORKER_COUNT`, and removes the `getWorkersFromGroup` helper function
- Adds `sendDurationMetrics: true` parameter to `setupTestLifecycle` function calls in [suites/agents/agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/920/files#diff-bb8296cd180fddaeacac442a33c7b8eb00c648f56e8b17041a0a3994dc85a569), [suites/agents/agents-tagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/920/files#diff-27341650cd787e4903ca1cc50b151d4032b7a33fb36694108a846a96a88237ab), and [suites/metrics/large.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/920/files#diff-35b7d3aab1f9a9df212c9c00e57ea87f688fdf7c4fecbbb6b0e0d2cceb9edafb)

#### 📍Where to Start
Start with the message recovery test implementation in [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/920/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916) to understand the core refactoring from worker termination to stream control.

----

_[Macroscope](https://app.macroscope.com) summarized dbe5531._