### PR TITLE
Enable caching for test environment setup and results

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Setup test environment
         uses: ./.github/actions/xmtp-test-setup
+        with:
+          cache-data: true
 
       - name: Run tests ${{ matrix.BATCH_SIZE }}
         run: yarn test ${{ matrix.test }} --no-fail --debug
@@ -38,6 +40,7 @@ jobs:
         with:
           test-name: ${{ matrix.test }}
           environment: ${{ matrix.environment }}
+          save-to-cache: true
 
       - name: Send Slack notification on failure
         if: failure() || cancelled()


### PR DESCRIPTION
### Enable caching for test environment setup and results in Performance workflow
This pull request modifies the [.github/workflows/Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/932/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) workflow file to add caching functionality. The changes configure the `xmtp-test-setup` action to use cached data by setting `cache-data: true` and enable the `xmtp-performance-report` action to save results to cache by adding `save-to-cache: true`.

#### 📍Where to Start
Start with the modifications to the `xmtp-test-setup` and `xmtp-performance-report` actions in [.github/workflows/Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/932/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3).

----

_[Macroscope](https://app.macroscope.com) summarized 6d007e4._