### PR TITLE
Set default stream timeout for workflow stability

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -19,6 +19,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.env }}
       REGION: ${{ vars.REGION }}
+      DEFAULT_STREAM_TIMEOUT_MS: 20000
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
     steps:


### PR DESCRIPTION
### Set default stream timeout of 20000ms for the Agents GitHub workflow to improve workflow stability
This change adds the `DEFAULT_STREAM_TIMEOUT_MS` environment variable with a value of 20000 to the [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/947/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) workflow configuration, making this timeout value available to all steps in the Agents workflow job.

#### 📍Where to Start
Start with the environment variables section in [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/947/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) where the new `DEFAULT_STREAM_TIMEOUT_MS` variable has been added.

----

_[Macroscope](https://app.macroscope.com) summarized 231e465._