### PR TITLE
Update cron schedule and add separate agent tests

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -3,17 +3,18 @@ description: "should verify performance of the library in the production network
 
 on:
   schedule:
-    - cron: "*/15 * * * *" # Runs every 15 minutes
+    - cron: "*/5 * * * *" # Runs every 5 minutes for agents-dms
+    - cron: "*/30 * * * *" # Runs every 30 minutes for agents-tagged
+    - cron: "0 * * * *" # Runs every hour for agents-untagged
   workflow_dispatch:
 
 jobs:
-  test:
+  agents-dms:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        test: [agents-dms, agents-tagged, agents-untagged]
         env: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
@@ -27,16 +28,82 @@ jobs:
       - name: Setup test env
         uses: ./.github/actions/xmtp-test-setup
 
-      - name: Run tests
-        run: yarn test ${{ matrix.test }} --no-fail --debug
+      - name: Run agents-dms tests
+        run: yarn test agents-dms --no-fail --debug
 
       - name: Cleanup and upload artifacts
         if: always()
         uses: ./.github/actions/xmtp-test-cleanup
         with:
-          test-name: ${{ matrix.test }}
+          test-name: agents-dms
           env: ${{ matrix.env }}
 
       - name: Send Slack notification on failure
         if: failure() || cancelled()
-        run: yarn workflow-failure "${{ matrix.test }}"
+        run: yarn workflow-failure "agents-dms"
+
+  agents-tagged:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, production]
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      XMTP_ENV: ${{ matrix.env }}
+      REGION: ${{ vars.REGION }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup test env
+        uses: ./.github/actions/xmtp-test-setup
+
+      - name: Run agents-tagged tests
+        run: yarn test agents-tagged --no-fail --debug
+
+      - name: Cleanup and upload artifacts
+        if: always()
+        uses: ./.github/actions/xmtp-test-cleanup
+        with:
+          test-name: agents-tagged
+          env: ${{ matrix.env }}
+
+      - name: Send Slack notification on failure
+        if: failure() || cancelled()
+        run: yarn workflow-failure "agents-tagged"
+
+  agents-untagged:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, production]
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      XMTP_ENV: ${{ matrix.env }}
+      REGION: ${{ vars.REGION }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup test env
+        uses: ./.github/actions/xmtp-test-setup
+
+      - name: Run agents-untagged tests
+        run: yarn test agents-untagged --no-fail --debug
+
+      - name: Cleanup and upload artifacts
+        if: always()
+        uses: ./.github/actions/xmtp-test-cleanup
+        with:
+          test-name: agents-untagged
+          env: ${{ matrix.env }}
+
+      - name: Send Slack notification on failure
+        if: failure() || cancelled()
+        run: yarn workflow-failure "agents-untagged"


### PR DESCRIPTION
### Update cron schedule frequencies for agent tests and restructure GitHub workflow from single job to three separate jobs in Agents.yml
The GitHub workflow [Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/965/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) restructures from a single job with matrix configuration to three separate jobs, each running different agent test types at different frequencies:

- Changes `agents-dms` cron schedule from every 15 minutes to every 5 minutes
- Adds `agents-tagged` job running every 30 minutes  
- Adds `agents-untagged` job running every hour
- Removes matrix.test configuration and replaces with dedicated jobs containing specific test commands
- Maintains identical environment matrix (dev, production) across all three jobs

#### 📍Where to Start
Start with the cron schedule definitions and job structure changes in [Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/965/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91).

----

_[Macroscope](https://app.macroscope.com) summarized 7d749d6._