### PR TITLE
Refactor help command to include debug info and members

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: Run agents-dms tests
-        run: yarn test agents-dms --no-fail --debug
+        run: yarn test agents-dms --no-fail --debug --no-error-logs
 
       - name: Cleanup and upload artifacts
         if: always()
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: Run agents-tagged tests
-        run: yarn test agents-tagged --no-fail --debug
+        run: yarn test agents-tagged --no-fail --debug --no-error-logs
 
       - name: Cleanup and upload artifacts
         if: always()
@@ -95,7 +95,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: Run agents-untagged tests
-        run: yarn test agents-untagged --no-fail --debug
+        run: yarn test agents-untagged --no-fail --debug --no-error-logs
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/bots/gm-bot/helpers/client.ts
+++ b/bots/gm-bot/helpers/client.ts
@@ -114,7 +114,7 @@ export const logAgentDetails = async (
     console.log(`
     ✓ XMTP Client:
     • InboxId: ${inboxId}
-    • Version: ${Client.version}
+    • Bindings: ${Client.version}
     • Address: ${address}
     • Conversations: ${conversations.length}
     • Installations: ${inboxState.installations.length}

--- a/bots/simple/index.ts
+++ b/bots/simple/index.ts
@@ -15,21 +15,25 @@ const processMessage = async (
     `Received message: ${message.content as string} by ${message.senderInboxId}`,
   );
 
-  const senderAddress = await getSenderAddress(client, message.senderInboxId);
-  await conversation.send("address");
-  await conversation.send(senderAddress);
-  await conversation.send("inboxId");
-  await conversation.send(message.senderInboxId);
-  await conversation.send("conversationId");
-  await conversation.send(conversation.id);
+  const debugInfo = await conversation.debugInfo();
+  console.log("debugInfo", debugInfo);
 
-  const members = await conversation.members();
-  for (const member of members) {
-    const memberAddress = await getSenderAddress(client, member.inboxId);
-    console.log("member", memberAddress);
-    await conversation.send(memberAddress);
+  if ((message?.content as string)?.includes("/help")) {
+    const senderAddress = await getSenderAddress(client, message.senderInboxId);
+    await conversation.send("address");
+    await conversation.send(senderAddress);
+    await conversation.send("inboxId");
+    await conversation.send(message.senderInboxId);
+    await conversation.send("conversationId");
+    await conversation.send(conversation.id);
+    const members = await conversation.members();
+    for (const member of members) {
+      const memberAddress = await getSenderAddress(client, member.inboxId);
+      console.log("member", memberAddress);
+      await conversation.send(memberAddress);
+    }
+    console.log("Waiting for messages...");
   }
-  console.log("Waiting for messages...");
 };
 
 // Initialize the client with the message processor

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -5,8 +5,8 @@ import manualUsers from "@inboxes/manualusers.json";
 import type { Worker, WorkerManager } from "@workers/manager";
 import { regressionClient } from "@workers/versions";
 import {
+  Client,
   IdentifierKind,
-  type Client,
   type Conversation,
   type Signer,
   type XmtpEnv,
@@ -177,6 +177,7 @@ export const logAgentDetails = async (
     console.log(`
     ✓ XMTP Client:
     • InboxId: ${inboxId}
+    • Bindings: ${Client.version}
     • Address: ${address}
     • Conversations: ${conversations.length}
     • Installations: ${inboxState.installations.length}

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -291,7 +291,6 @@ export async function sendDatadogLog(
 ): Promise<void> {
   const apiKey = process.env.DATADOG_API_KEY;
   if (!apiKey) return;
-
   const errorLogs = extractErrorLogs(logFileName);
   const fail_lines = extractfail_lines(errorLogs);
   checkForCriticalErrors(testName, fail_lines);


### PR DESCRIPTION
### Refactor help command to include debug info and members by modifying the simple bot's `processMessage` function to only respond with debug information when messages contain '/help'
- Modifies the simple bot's `processMessage` function in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/966/files#diff-30ebb06ecdf573c7be880b009bde6672c5d27e16d9eff3db1d57c99aece12d2d) to only execute debug response logic when message content includes '/help', whereas previously it responded to all messages
- Adds a new `--no-error-logs` command line flag to [cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/966/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) that prevents sending error logs to Datadog during test execution
- Updates GitHub workflow commands in [Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/966/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91) to include the `--no-error-logs` flag for three agent test types
- Changes log output labels from 'Version' to 'Bindings' in client helper files while displaying the same `Client.version` value
- Modifies the Client import from type import to regular import in [client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/966/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to access static properties

#### 📍Where to Start
Start with the `processMessage` function in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/966/files#diff-30ebb06ecdf573c7be880b009bde6672c5d27e16d9eff3db1d57c99aece12d2d) to understand the core behavioral change where debug information is now only sent when messages contain '/help'.

----

_[Macroscope](https://app.macroscope.com) summarized 1691f9f._