### PR TITLE
Rename internal to production for clarity and accuracy

### DIFF
--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -54,7 +54,7 @@ export interface NetworkMetricTags extends MetricTags {
 export interface ResponseMetricTags extends MetricTags {
   agent?: string;
   address?: string;
-  internal?: boolean;
+  production?: boolean;
 }
 
 // Legacy interface exports for backward compatibility

--- a/suites/agents/agents-dms.test.ts
+++ b/suites/agents/agents-dms.test.ts
@@ -66,7 +66,7 @@ describe(testName, async () => {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",
-        production: agent.production || false,
+        production: agent.production === true ? true : false,
         agent: agent.name,
         address: agent.address,
         sdk: workers.getCreator().sdk,

--- a/suites/agents/agents-dms.test.ts
+++ b/suites/agents/agents-dms.test.ts
@@ -66,7 +66,7 @@ describe(testName, async () => {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",
-        internal: agent.internal || false,
+        production: agent.production || false,
         agent: agent.name,
         address: agent.address,
         sdk: workers.getCreator().sdk,

--- a/suites/agents/agents-tagged.test.ts
+++ b/suites/agents/agents-tagged.test.ts
@@ -73,7 +73,7 @@ describe(testName, async () => {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",
-        production: agent.production || false,
+        production: agent.production === true ? true : false,
         agent: agent.name,
         address: agent.address,
         sdk: workers.getCreator().sdk,

--- a/suites/agents/agents-tagged.test.ts
+++ b/suites/agents/agents-tagged.test.ts
@@ -73,7 +73,7 @@ describe(testName, async () => {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",
-        internal: agent.internal || false,
+        production: agent.production || false,
         agent: agent.name,
         address: agent.address,
         sdk: workers.getCreator().sdk,

--- a/suites/agents/agents-untagged.test.ts
+++ b/suites/agents/agents-untagged.test.ts
@@ -70,7 +70,7 @@ describe(testName, async () => {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",
-        production: agent.production || false,
+        production: agent.production === true ? true : false,
         agent: agent.name,
         address: agent.address,
         sdk: workers.getCreator().sdk,

--- a/suites/agents/agents-untagged.test.ts
+++ b/suites/agents/agents-untagged.test.ts
@@ -70,7 +70,7 @@ describe(testName, async () => {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",
-        internal: agent.internal || false,
+        production: agent.production || false,
         agent: agent.name,
         address: agent.address,
         sdk: workers.getCreator().sdk,

--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -6,7 +6,7 @@
     "sendMessage": "/help",
     "networks": ["production"],
     "slackChannel": "#tbachat-alerts",
-    "internal": true,
+    "production": true,
     "shouldRespondOnTagged": true
   },
   {
@@ -15,7 +15,7 @@
     "address": "0xe15aa1ba585aea8a4639331ce5f9aec86f8c4541",
     "sendMessage": "hi",
     "networks": ["production"],
-    "internal": false,
+    "production": false,
     "slackChannel": "#elsa-alerts",
     "shouldRespondOnTagged": true
   },
@@ -26,7 +26,7 @@
     "sendMessage": "hola",
     "expectedMessage": ["chat", "invalid"],
     "networks": ["dev", "production"],
-    "internal": true,
+    "production": true,
     "slackChannel": "#csx-alerts",
     "shouldRespondOnTagged": false
   },
@@ -38,7 +38,7 @@
     "sendMessage": "hola",
     "expectedMessage": ["chat", "invalid"],
     "networks": ["dev", "production"],
-    "internal": true,
+    "production": true,
     "slackChannel": "#gang-alerts",
     "shouldRespondOnTagged": false
   },
@@ -47,7 +47,7 @@
     "baseName": "flaunchy",
     "address": "0x557463B158F70e4E269bB7BCcF6C587e3BC878F4",
     "sendMessage": "hi",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#flaunchy-alerts",
     "shouldRespondOnTagged": true
@@ -57,7 +57,7 @@
     "baseName": "mamo.base.eth",
     "address": "0x99B10779557cc52c6E3a97C9A6C3446f021290cc",
     "sendMessage": "hi",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#mamo-alerts",
     "shouldRespondOnTagged": true
@@ -67,7 +67,7 @@
     "baseName": "squabble.base.eth",
     "address": "0xD60d560c9Ae4ad9b7C252FacE7B664A8d7A426da",
     "sendMessage": "@squabble.base.eth",
-    "internal": true,
+    "production": true,
     "networks": ["production"],
     "slackChannel": "#squabble-alerts",
     "shouldRespondOnTagged": true
@@ -77,7 +77,7 @@
     "baseName": "arma.base.eth",
     "address": "0x1456350CD79c51814567b0c1E767d3032dBD1647",
     "sendMessage": "hi",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#arma-alerts",
     "shouldRespondOnTagged": false
@@ -87,7 +87,7 @@
     "baseName": "onit.base.eth",
     "address": "0xE9C89b50f3b947125FdBCdF8FBff35b9f38fB0C4",
     "sendMessage": "hi",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#onit-alerts",
     "shouldRespondOnTagged": true
@@ -97,7 +97,7 @@
     "baseName": "byte.base.eth",
     "address": "0xdfc00a0B28Df3c07b0942300E896C97d62014499",
     "sendMessage": "hi",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#byte-alerts",
     "shouldRespondOnTagged": false
@@ -107,7 +107,7 @@
     "baseName": "gm.base.eth",
     "address": "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0",
     "sendMessage": "hola",
-    "internal": true,
+    "production": true,
     "networks": ["dev", "production"],
     "slackChannel": "#gm-alerts",
     "shouldRespondOnTagged": false
@@ -117,7 +117,7 @@
     "baseName": "local.base.eth",
     "address": "0xb6469a25ba51c59303eb24c04dad0e0ee1127d5b",
     "sendMessage": "hola",
-    "internal": true,
+    "production": true,
     "networks": ["local"],
     "slackChannel": "#local-alerts",
     "shouldRespondOnTagged": false
@@ -127,7 +127,7 @@
     "baseName": "bankr.base.eth",
     "address": "0x7f1c0d2955f873fc91f1728c19b2ed7be7a9684d",
     "sendMessage": "hey there how are you?",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#bankr-alerts",
     "shouldRespondOnTagged": true
@@ -137,7 +137,7 @@
     "baseName": "key-check.base.eth",
     "address": "0x235017975ed5F55e23a71979697Cd67DcAE614Fa",
     "sendMessage": "/kc help",
-    "internal": true,
+    "production": true,
     "networks": ["dev", "production"],
     "slackChannel": "#key-check-alerts",
     "shouldRespondOnTagged": true
@@ -147,7 +147,7 @@
     "baseName": "bitte.base.eth",
     "address": "0xb177e33734e982828eBb5993627ebcD7C8A9106a",
     "sendMessage": "hi",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#bitte-alerts",
     "shouldRespondOnTagged": true
@@ -157,7 +157,7 @@
     "baseName": "0x9e73…3466",
     "address": "0x9E73e4126bb22f79f89b6281352d01dd3d203466",
     "sendMessage": "@tokenbot",
-    "internal": false,
+    "production": false,
     "networks": ["production"],
     "slackChannel": "#tokenbot-alerts",
     "shouldRespondOnTagged": true

--- a/suites/agents/helper.ts
+++ b/suites/agents/helper.ts
@@ -22,8 +22,8 @@ export interface AgentConfig {
   slackChannel?: string;
   /** Whether to test this agent in groups (default: false) */
   groupTesting?: boolean;
-  /** Whether the agent is internal */
-  internal?: boolean;
+  /** Whether the agent is production */
+  production?: boolean;
 }
 
 /**

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -433,7 +433,7 @@ export class WorkerClient extends Worker {
     installationId: string;
     address: `0x${string}`;
   }> {
-    // Tell the Worker to do any internal initialization
+    // Tell the Worker to do any production initialization
     this.postMessage({
       type: "initialize",
       data: {

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -424,7 +424,7 @@ export class WorkerManager {
       }
     }
 
-    // Check if the worker already exists in our internal storage
+    // Check if the worker already exists in our production storage
     if (providedInstallId && this.workers[baseName]?.[providedInstallId]) {
       console.debug(`Reusing existing worker for ${descriptor}`);
       return this.workers[baseName][providedInstallId];
@@ -466,7 +466,7 @@ export class WorkerManager {
     // Store the new worker for potential cleanup later
     this.activeWorkers.push(workerClient);
 
-    // Add to our internal storage
+    // Add to our production storage
     this.addWorker(baseName, folder, worker);
 
     return worker;


### PR DESCRIPTION
### Rename internal property to production in agent configurations and datadog metrics for clarity and accuracy
This pull request renames the `internal` property to `production` across agent configurations and datadog metric tagging to improve clarity and accuracy of the naming convention:

- Updates the `ResponseMetricTags` interface in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/970/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to use `production` instead of `internal`
- Modifies the `AgentConfig` interface in [suites/agents/helper.ts](https://github.com/xmtp/xmtp-qa-tools/pull/970/files#diff-49b6b20cd3a52c55adea3d142d0de7b32fb94ad3d49d369c278c109e34aaa9c7) to use `production` property with updated documentation
- Changes all agent test files to use `production: agent.production === true ? true : false` instead of `internal: agent.internal || false` for metric tagging
- Updates all agent configurations in [suites/agents/agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/970/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) to use the `production` property name
- Revises comments in worker files to reference "production" instead of "internal"

#### 📍Where to Start
Start with the `ResponseMetricTags` interface in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/970/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to understand the core type definition change, then review the `AgentConfig` interface in [suites/agents/helper.ts](https://github.com/xmtp/xmtp-qa-tools/pull/970/files#diff-49b6b20cd3a52c55adea3d142d0de7b32fb94ad3d49d369c278c109e34aaa9c7).

----

_[Macroscope](https://app.macroscope.com) summarized 6dba12e._