### PR TITLE
Refactor metric sending to include histogram functionality

### DIFF
--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -190,7 +190,7 @@ export function sendMetric(
       );
     }
 
-    metrics.gauge(fullMetricName, Math.round(metricValue), formattedTags);
+    //metrics.gauge(fullMetricName, Math.round(metricValue), formattedTags);
     metrics.histogram(
       `${fullMetricName}.histogram`,
       Math.round(metricValue),

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -191,7 +191,11 @@ export function sendMetric(
     }
 
     metrics.gauge(fullMetricName, Math.round(metricValue), formattedTags);
-    metrics.histogram(fullMetricName, Math.round(metricValue), formattedTags);
+    metrics.histogram(
+      `${fullMetricName}.histogram`,
+      Math.round(metricValue),
+      formattedTags,
+    );
   } catch (error) {
     console.error(
       `❌ Error sending metric '${metricName}':`,

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -1,4 +1,8 @@
-import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
+import {
+  sendHistogramMetric,
+  sendMetric,
+  type ResponseMetricTags,
+} from "@helpers/datadog";
 import { verifyMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getAddresses, getInboxIds } from "@inboxes/utils";
@@ -101,6 +105,11 @@ describe(testName, async () => {
       sdk: workers.getCreator().sdk,
     };
     sendMetric("response", verifyResult.averageEventTiming, responseMetricTags);
+    sendHistogramMetric(
+      "response",
+      verifyResult.averageEventTiming,
+      responseMetricTags,
+    );
 
     setCustomDuration(verifyResult.averageEventTiming);
     expect(verifyResult.almostAllReceived).toBe(true);
@@ -150,6 +159,14 @@ describe(testName, async () => {
         workers.getAllButCreator(),
       );
       sendMetric("response", verifyResult.averageEventTiming, {
+        test: testName,
+        metric_type: "stream",
+        metric_subtype: "message",
+        sdk: workers.getCreator().sdk,
+        members: i.toString(),
+        installations: i.toString(),
+      } as ResponseMetricTags);
+      sendHistogramMetric("response", verifyResult.averageEventTiming, {
         test: testName,
         metric_type: "stream",
         metric_subtype: "message",

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -1,8 +1,4 @@
-import {
-  sendHistogramMetric,
-  sendMetric,
-  type ResponseMetricTags,
-} from "@helpers/datadog";
+import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
 import { verifyMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getAddresses, getInboxIds } from "@inboxes/utils";
@@ -105,11 +101,6 @@ describe(testName, async () => {
       sdk: workers.getCreator().sdk,
     };
     sendMetric("response", verifyResult.averageEventTiming, responseMetricTags);
-    sendHistogramMetric(
-      "response",
-      verifyResult.averageEventTiming,
-      responseMetricTags,
-    );
 
     setCustomDuration(verifyResult.averageEventTiming);
     expect(verifyResult.almostAllReceived).toBe(true);
@@ -159,14 +150,6 @@ describe(testName, async () => {
         workers.getAllButCreator(),
       );
       sendMetric("response", verifyResult.averageEventTiming, {
-        test: testName,
-        metric_type: "stream",
-        metric_subtype: "message",
-        sdk: workers.getCreator().sdk,
-        members: i.toString(),
-        installations: i.toString(),
-      } as ResponseMetricTags);
-      sendHistogramMetric("response", verifyResult.averageEventTiming, {
         test: testName,
         metric_type: "stream",
         metric_subtype: "message",


### PR DESCRIPTION
### Modify DataDog histogram metric naming in `sendMetric` function to append '.histogram' suffix
The `sendMetric` function in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/974/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) now appends '.histogram' to the full metric name when sending histogram metrics to DataDog, creating distinct naming between gauge and histogram metrics that previously used identical names.

#### 📍Where to Start
Start with the `sendMetric` function in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/974/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3).

----

_[Macroscope](https://app.macroscope.com) summarized 77107d2._