### PR TITLE
Refactor metric sending to use gauge and histogram consistently

### DIFF
--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -190,12 +190,8 @@ export function sendMetric(
       );
     }
 
-    //metrics.gauge(fullMetricName, Math.round(metricValue), formattedTags);
-    metrics.histogram(
-      `${fullMetricName}.histogram`,
-      Math.round(metricValue),
-      formattedTags,
-    );
+    metrics.gauge(fullMetricName, Math.round(metricValue), formattedTags);
+    metrics.histogram(fullMetricName, Math.round(metricValue), formattedTags);
   } catch (error) {
     console.error(
       `❌ Error sending metric '${metricName}':`,


### PR DESCRIPTION
### Enable gauge metrics and remove histogram suffix from metric names in DataDog sendMetric function
The `sendMetric` function in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/975/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) now sends both gauge and histogram metrics to DataDog with consistent naming. The function enables gauge metrics by uncommenting the `metrics.gauge()` call and removes the `.histogram` suffix from histogram metric names, causing both metric types to use the same base metric name.

#### 📍Where to Start
Start with the `sendMetric` function in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/975/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3).

----

_[Macroscope](https://app.macroscope.com) summarized 8a16e07._