### PR TITLE
Refactor operation names for consistency and clarity

### DIFF
--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -81,29 +81,27 @@ flowchart LR
 
 We can test all XMTP bindings using three main applications. We use [xmtp.chat](https://xmtp.chat/) to test the Browser SDK's Wasm binding in actual web environments. We use [Convos](https://github.com/ephemeraHQ/converse-app) to test the React Native SDK, which uses both Swift and Kotlin FFI bindings for mobile devices. We use [agents](https://github.com/ephemeraHQ/xmtp-agent-examples) to test the Node SDK's Napi binding for server functions. This testing method checks the entire protocol across all binding types, making sure different clients work together, messages are saved, and users have the same experience across the XMTP system.
 
-## Operation performance
+## Operations
 
-### Core SDK Operations Performance
+### Core SDK operations
 
-| Operation                | Description                            | Avg | Target | Performance |
-| ------------------------ | -------------------------------------- | --- | ------ | ----------- |
-| clientCreate             | Creating a client                      | 588 | <350   | Concern     |
-| inboxState               | Checking inbox state                   | 41  | <350   | On Target   |
-| newDm                    | Creating a direct message conversation | 258 | <350   | On Target   |
-| newDmWithIdentifiers     | Creating a dm by address               | 294 | <350   | On Target   |
-| sendGM                   | Sending a group message                | 126 | <200   | On Target   |
-| receiveGM                | Receiving a group message              | 87  | <200   | On Target   |
-| createGroup              | Creating a group                       | 315 | <350   | On Target   |
-| createGroupByIdentifiers | Creating a group by address            | 313 | <350   | On Target   |
-| syncGroup                | Syncing group state                    | 76  | <200   | On Target   |
-| updateGroupName          | Updating group metadata                | 129 | <200   | On Target   |
-| removeMembers            | Removing participants from a group     | 127 | <250   | On Target   |
-| sendGroupMessage         | Sending a group message                | 85  | <200   | On Target   |
-| receiveGroupMessage      | Processing group message strea         | 124 | <200   | On Target   |
+| Operation            | Description                            | Avg | Target | Performance |
+| -------------------- | -------------------------------------- | --- | ------ | ----------- |
+| clientCreate         | Creating a client                      | 588 | <350   | Concern     |
+| inboxState           | Checking inbox state                   | 41  | <350   | On Target   |
+| newDm                | Creating a direct message conversation | 258 | <350   | On Target   |
+| newDmWithIdentifiers | Creating a dm by address               | 294 | <350   | On Target   |
+| send                 | Sending a group message                | 126 | <200   | On Target   |
+| stream               | Receiving a group message              | 87  | <200   | On Target   |
+| newGroup             | Creating a group                       | 315 | <350   | On Target   |
+| newGroupByAddress    | Creating a group by address            | 313 | <350   | On Target   |
+| sync                 | Syncing group state                    | 76  | <200   | On Target   |
+| updateName           | Updating group metadata                | 129 | <200   | On Target   |
+| removeMembers        | Removing participants from a group     | 127 | <250   | On Target   |
 
-### Group operations performance
+### Group operations
 
-#### Sender-Side average performance
+#### Sender-side average
 
 | Size | Send message | Update name | Remove members | Create | Performance |
 | ---- | ------------ | ----------- | -------------- | ------ | ----------- |
@@ -118,7 +116,7 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 _Note: This measurments are taken only from the sender side and after the group is created._
 
-#### Receiver-Side stream performance
+#### Receiver-side stream
 
 | Group Size | New conversation | Metadata | Messages | Add Members | Performance |
 | ---------- | ---------------- | -------- | -------- | ----------- | ----------- |
@@ -133,7 +131,7 @@ _Note: This measurments are taken only from the sender side and after the group 
 
 _Note: This measurments are taken only from the receiver side and after the group is created._
 
-#### Receiver-Side sync performance
+#### Receiver-side sync
 
 | Size | syncAll |      | sync |      | Performance |
 | ---- | ------- | ---- | ---- | ---- | ----------- |
@@ -148,7 +146,7 @@ _Note: This measurments are taken only from the receiver side and after the grou
 
 _Note: `syncAll` is measured only as the first cold start of the client (fresh inbox). Cumulative sync is measured as the first time all the groups are sync for the first time._
 
-## Networks performance
+## Networks
 
 ### Network performance
 
@@ -160,7 +158,7 @@ _Note: `syncAll` is measured only as the first cold start of the client (fresh i
 | Processing         | 35      | <100   | On Target   |
 | Server Call        | 159     | <250   | On Target   |
 
-### Regional Network Performance
+### Regional network performance
 
 | Region        | Server Call | TLS | ~ us-east | Performance |
 | ------------- | ----------- | --- | --------- | ----------- |
@@ -191,7 +189,7 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
 
 ## Storage
 
-### Storage by Group Size
+### Storage by group size
 
 | Group Size  | Groups | Sender storage | Avg Group Size | Receiver storage | Efficiency Gain |
 | ----------- | ------ | -------------- | -------------- | ---------------- | --------------- |
@@ -202,7 +200,7 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
 | 150 members | 12     | 5.6 MB         | 0.465 MB       | 6.797 MB         | 3.2× better     |
 | 200 members | 10     | 6.2 MB         | 0.618 MB       | 8.090 MB         | 3.2× better     |
 
-### Large Inbox Sync Performance Summary
+### Large inbox syncs
 
 | Inbox Size | Sync Time (ms) | DB Size (MB) | Existing Groups | queryGroupMessages |
 | ---------- | -------------- | ------------ | --------------- | ------------------ |
@@ -223,9 +221,9 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
   - [`hi.xmtp.eth`](https://xmtp.chat/dm/0x937C0d4a6294cdfa575de17382c7076b579DC176): A bot that replies "hi" to all messages
 - **Test suites:** Test suites directory - [see section](https://github.com/xmtp/xmtp-qa-tools/tree/main/suites/)
 
-## Testing Summary
+## Testing summary
 
-### Test coverage
+#### Test coverage
 
 - Functional: Core protocol (DMs, groups, streams, sync, consent, codecs, installations)
 - Metrics: Performance benchmarking, delivery reliability, large-scale testing (up to 400 members)
@@ -237,7 +235,7 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
 - Bugs: Historical issue reproduction and regression prevention
 - Other: Security, spam detection, rate limiting, storage efficiency
 
-### Testing framework
+#### Testing framework
 
 - Multi-version SDKs: Compatibility testing across versions 0.0.47 → 2.2.0+
 - Stream verification: Message delivery, conversation streams, metadata updates
@@ -251,7 +249,7 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
 - Slack Bot: AI-powered responses, history fetching, log management
 - Geographic testing: Multi-region performance across US, Europe, Asia, South America
 
-### Metrics tracked
+#### Metrics tracked
 
 - Delivery: 100% success rate (target: 99.9%)
 - Performance: <350ms core operations, <200ms messaging, <150ms TLS
@@ -261,12 +259,12 @@ _Note: Testing regularly in groups of `40` active members listening to one user 
 
 ## Development
 
-### Prerequisites
+#### Prerequisites
 
 - Node.js (>20.18.0)
 - Yarn 4.6.0
 
-### Installation
+#### Installation
 
 ```bash
 # Installation For a faster download with just the latest code
@@ -275,7 +273,7 @@ cd xmtp-qa-tools
 yarn install
 ```
 
-### Environment variables
+#### Environment variables
 
 ```bash
 XMTP_ENV="dev" #  environment (dev, production, local, multinode)
@@ -296,7 +294,7 @@ yarn test functional
 yarn test performance
 ```
 
-### Debug mode
+#### Debug mode
 
 ```bash
 yarn test functional --debug
@@ -304,12 +302,12 @@ yarn test functional --debug
 
 > This will save logs to `logs/` directory and will not print to the terminal.
 
-### Rate limits
+#### Rate limits
 
 - **Read operations**: 20,000 requests per 5-minute window
 - **Write operations**: 3,000 messages published per 5-minute window
 
-### Resources
+#### Resources
 
 - **Inboxes:** Inboxes for testing - [see section](/inboxes/)
 - **Local:** Work in local network - [see section](/dev/)

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -85,19 +85,19 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 ### Core SDK operations
 
-| Operation            | Description                            | Avg | Target | Performance |
-| -------------------- | -------------------------------------- | --- | ------ | ----------- |
-| clientCreate         | Creating a client                      | 588 | <350   | Concern     |
-| inboxState           | Checking inbox state                   | 41  | <350   | On Target   |
-| newDm                | Creating a direct message conversation | 258 | <350   | On Target   |
-| newDmWithIdentifiers | Creating a dm by address               | 294 | <350   | On Target   |
-| send                 | Sending a group message                | 126 | <200   | On Target   |
-| stream               | Receiving a group message              | 87  | <200   | On Target   |
-| newGroup             | Creating a group                       | 315 | <350   | On Target   |
-| newGroupByAddress    | Creating a group by address            | 313 | <350   | On Target   |
-| sync                 | Syncing group state                    | 76  | <200   | On Target   |
-| updateName           | Updating group metadata                | 129 | <200   | On Target   |
-| removeMembers        | Removing participants from a group     | 127 | <250   | On Target   |
+| Operation         | Description                            | Avg | Target | Performance |
+| ----------------- | -------------------------------------- | --- | ------ | ----------- |
+| clientCreate      | Creating a client                      | 588 | <350   | Concern     |
+| inboxState        | Checking inbox state                   | 41  | <350   | On Target   |
+| newDm             | Creating a direct message conversation | 258 | <350   | On Target   |
+| newDmByAddress    | Creating a dm by address               | 294 | <350   | On Target   |
+| send              | Sending a group message                | 126 | <200   | On Target   |
+| stream            | Receiving a group message              | 87  | <200   | On Target   |
+| newGroup          | Creating a group                       | 315 | <350   | On Target   |
+| newGroupByAddress | Creating a group by address            | 313 | <350   | On Target   |
+| sync              | Syncing group state                    | 76  | <200   | On Target   |
+| updateName        | Updating group metadata                | 129 | <200   | On Target   |
+| removeMembers     | Removing participants from a group     | 127 | <250   | On Target   |
 
 ### Group operations
 

--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 ### Core SDK operations
 
-| Operation            | Description                            | Avg | Target | Performance |
-| -------------------- | -------------------------------------- | --- | ------ | ----------- |
-| clientCreate         | Creating a client                      | 588 | <350   | Concern     |
-| inboxState           | Checking inbox state                   | 41  | <350   | On Target   |
-| newDm                | Creating a direct message conversation | 258 | <350   | On Target   |
-| newDmWithIdentifiers | Creating a dm by address               | 294 | <350   | On Target   |
-| send                 | Sending a group message                | 126 | <200   | On Target   |
-| stream               | Receiving a group message              | 87  | <200   | On Target   |
-| newGroup             | Creating a group                       | 315 | <350   | On Target   |
-| newGroupByAddress    | Creating a group by address            | 313 | <350   | On Target   |
-| sync                 | Syncing group state                    | 76  | <200   | On Target   |
-| updateName           | Updating group metadata                | 129 | <200   | On Target   |
-| removeMembers        | Removing participants from a group     | 127 | <250   | On Target   |
+| Operation         | Description                            | Avg | Target | Performance |
+| ----------------- | -------------------------------------- | --- | ------ | ----------- |
+| clientCreate      | Creating a client                      | 588 | <350   | Concern     |
+| inboxState        | Checking inbox state                   | 41  | <350   | On Target   |
+| newDm             | Creating a direct message conversation | 258 | <350   | On Target   |
+| newDmByAddress    | Creating a dm by address               | 294 | <350   | On Target   |
+| send              | Sending a group message                | 126 | <200   | On Target   |
+| stream            | Receiving a group message              | 87  | <200   | On Target   |
+| newGroup          | Creating a group                       | 315 | <350   | On Target   |
+| newGroupByAddress | Creating a group by address            | 313 | <350   | On Target   |
+| sync              | Syncing group state                    | 76  | <200   | On Target   |
+| updateName        | Updating group metadata                | 129 | <200   | On Target   |
+| removeMembers     | Removing participants from a group     | 127 | <250   | On Target   |
 
 ### Group operations
 

--- a/README.md
+++ b/README.md
@@ -85,21 +85,19 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 
 ### Core SDK operations
 
-| Operation                | Description                            | Avg | Target | Performance |
-| ------------------------ | -------------------------------------- | --- | ------ | ----------- |
-| clientCreate             | Creating a client                      | 588 | <350   | Concern     |
-| inboxState               | Checking inbox state                   | 41  | <350   | On Target   |
-| newDm                    | Creating a direct message conversation | 258 | <350   | On Target   |
-| newDmWithIdentifiers     | Creating a dm by address               | 294 | <350   | On Target   |
-| sendGM                   | Sending a group message                | 126 | <200   | On Target   |
-| receiveGM                | Receiving a group message              | 87  | <200   | On Target   |
-| createGroup              | Creating a group                       | 315 | <350   | On Target   |
-| createGroupByIdentifiers | Creating a group by address            | 313 | <350   | On Target   |
-| syncGroup                | Syncing group state                    | 76  | <200   | On Target   |
-| updateGroupName          | Updating group metadata                | 129 | <200   | On Target   |
-| removeMembers            | Removing participants from a group     | 127 | <250   | On Target   |
-| sendGroupMessage         | Sending a group message                | 85  | <200   | On Target   |
-| receiveGroupMessage      | Processing group message strea         | 124 | <200   | On Target   |
+| Operation            | Description                            | Avg | Target | Performance |
+| -------------------- | -------------------------------------- | --- | ------ | ----------- |
+| clientCreate         | Creating a client                      | 588 | <350   | Concern     |
+| inboxState           | Checking inbox state                   | 41  | <350   | On Target   |
+| newDm                | Creating a direct message conversation | 258 | <350   | On Target   |
+| newDmWithIdentifiers | Creating a dm by address               | 294 | <350   | On Target   |
+| send                 | Sending a group message                | 126 | <200   | On Target   |
+| stream               | Receiving a group message              | 87  | <200   | On Target   |
+| newGroup             | Creating a group                       | 315 | <350   | On Target   |
+| newGroupByAddress    | Creating a group by address            | 313 | <350   | On Target   |
+| sync                 | Syncing group state                    | 76  | <200   | On Target   |
+| updateName           | Updating group metadata                | 129 | <200   | On Target   |
+| removeMembers        | Removing participants from a group     | 127 | <250   | On Target   |
 
 ### Group operations
 

--- a/suites/functional/convos.test.ts
+++ b/suites/functional/convos.test.ts
@@ -38,7 +38,7 @@ describe(testName, async () => {
     expect(convo.id).toBeDefined();
   });
 
-  it("newDmWithIdentifier should create a new DM conversation using Ethereum address", async () => {
+  it("newDmByAddress: should create a new DM conversation using Ethereum address", async () => {
     const dm2 = await workers
       .get("henry")!
       .client.conversations.newDmWithIdentifier({
@@ -49,7 +49,7 @@ describe(testName, async () => {
     expect(dm2).toBeDefined();
     expect(dm2.id).toBeDefined();
   });
-  it("should send a message in DM conversation", async () => {
+  it("send: should send a message in DM conversation", async () => {
     const message = "gm-" + Math.random().toString(36).substring(2, 15);
 
     console.log(
@@ -61,7 +61,7 @@ describe(testName, async () => {
     expect(dmId).toBeDefined();
   });
 
-  it("should receive and verify message delivery in DM conversation", async () => {
+  it("stream: should receive and verify message delivery in DM conversation", async () => {
     const verifyResult = await verifyMessageStream(convo, [
       workers.get("randomguy")!,
     ]);

--- a/suites/functional/sync.test.ts
+++ b/suites/functional/sync.test.ts
@@ -4,7 +4,7 @@ import { getWorkers, type WorkerManager } from "@workers/manager";
 import { type Group } from "@xmtp/node-sdk";
 import { describe, expect, it } from "vitest";
 
-const testName = "sync-comparison";
+const testName = "sync";
 describe(testName, async () => {
   setupTestLifecycle({ testName });
   let workers: WorkerManager;

--- a/suites/metrics/large.test.ts
+++ b/suites/metrics/large.test.ts
@@ -48,7 +48,7 @@ describe(testName, async () => {
       );
     });
 
-    it(`syncGroup-${groupSize}: should sync a large group of ${groupSize} participants ${groupSize}`, async () => {
+    it(`groupsync-${groupSize}: should sync a large group of ${groupSize} participants ${groupSize}`, async () => {
       await newGroupBetweenAll.sync();
     });
     it(`addMember-${groupSize}: should notify all members of additions in ${groupSize} member group`, async () => {

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -126,12 +126,12 @@ describe(testName, async () => {
         );
       expect(newGroupByIdentifier.id).toBeDefined();
     });
-    it(`syncGroup-${i}: should sync a large group of ${i} participants ${i}`, async () => {
+    it(`sync-${i}: should sync a large group of ${i} participants ${i}`, async () => {
       await newGroup.sync();
       const members = await newGroup.members();
       expect(members.length).toBe(members.length);
     });
-    it(`updateGroupName-${i}: should update the group name`, async () => {
+    it(`updateName-${i}: should update the group name`, async () => {
       const newName = "Large Group";
       await newGroup.updateName(newName);
       await newGroup.sync();

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -82,7 +82,7 @@ describe(testName, async () => {
     expect(dm2.id).toBeDefined();
   });
 
-  it("sendGM: should measure sending a gm", async () => {
+  it("send: should measure sending a gm", async () => {
     // We'll expect this random message to appear in Joe's stream
     const message = "gm-" + Math.random().toString(36).substring(2, 15);
 
@@ -91,7 +91,7 @@ describe(testName, async () => {
     expect(dmId).toBeDefined();
   });
 
-  it("receiveGM: should measure receiving a gm", async () => {
+  it("stream: should measure receiving a gm", async () => {
     const verifyResult = await verifyMessageStream(dm!, [workers.getAll()[1]]);
 
     const responseMetricTags: ResponseMetricTags = {
@@ -126,7 +126,7 @@ describe(testName, async () => {
         );
       expect(newGroupByIdentifier.id).toBeDefined();
     });
-    it(`sync-${i}: should sync a large group of ${i} participants ${i}`, async () => {
+    it(`groupsync-${i}: should sync a large group of ${i} participants ${i}`, async () => {
       await newGroup.sync();
       const members = await newGroup.members();
       expect(members.length).toBe(members.length);

--- a/suites/metrics/performance.test.ts
+++ b/suites/metrics/performance.test.ts
@@ -72,7 +72,7 @@ describe(testName, async () => {
     expect(dm).toBeDefined();
     expect(dm.id).toBeDefined();
   });
-  it("newDmWithIdentifiers: should measure creating a DM", async () => {
+  it("newDmByAddress: should measure creating a DM", async () => {
     const dm2 = await creatorClient.conversations.newDmWithIdentifier({
       identifier: workers.getAll()[2].address,
       identifierKind: IdentifierKind.Ethereum,
@@ -115,7 +115,7 @@ describe(testName, async () => {
       ])) as Group;
       expect(newGroup.id).toBeDefined();
     });
-    it(`newGroupByIdentifiers-${i}: should create a large group of ${i} participants ${i}`, async () => {
+    it(`newGroupByAddress-${i}: should create a large group of ${i} participants ${i}`, async () => {
       const sliced = getAddresses(i);
       const newGroupByIdentifier =
         await creatorClient.conversations.newGroupWithIdentifiers(


### PR DESCRIPTION
### Refactor operation names for consistency and clarity in documentation and test files
Renames operation names across documentation and test files to improve consistency and clarity. The changes include:

- Renaming Core SDK operations in documentation tables: `newDmWithIdentifiers` to `newDmByAddress`, `sendGM` to `send`, `receiveGM` to `stream`, `createGroup` to `newGroup`, `createGroupByIdentifiers` to `newGroupByAddress`, `syncGroup` to `sync`, and `updateGroupName` to `updateName`
- Removing `sendGroupMessage` and `receiveGroupMessage` operations from Core SDK operations tables in [.cursor/rules/overview.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-2830aa6c1b4cbfd90f54215dc264609de649513642d75d96ef9fbc21e1781e6f) and [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
- Updating section titles in [.cursor/rules/overview.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-2830aa6c1b4cbfd90f54215dc264609de649513642d75d96ef9fbc21e1781e6f) to use consistent capitalization and formatting
- Modifying test descriptions in [suites/functional/convos.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-921d06b25076b4f509394b778b6f1a7cde9363faf7c6deabe686c5d6387db067), [suites/functional/sync.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-0bfd336e2f19157ab40251717ea5595ca52525fbdac5aca7ded3b4ab57b9f9fc), [suites/metrics/large.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-35b7d3aab1f9a9df212c9c00e57ea87f688fdf7c4fecbbb6b0e0d2cceb9edafb), and [suites/metrics/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-adb0590224053d7c760a746634c969979d21da0898d796688f24758b2d14f28d) to align with renamed operations

#### 📍Where to Start
Start with the Core SDK operations table in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to see the renamed operation names, then review the corresponding test description changes in [suites/metrics/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/976/files#diff-adb0590224053d7c760a746634c969979d21da0898d796688f24758b2d14f28d).

----

_[Macroscope](https://app.macroscope.com) summarized 7a98c54._