### PR TITLE
Reduce error threshold and adjust logging levels

### DIFF
--- a/.github/workflows/Delivery.yml
+++ b/.github/workflows/Delivery.yml
@@ -20,7 +20,7 @@ jobs:
       XMTP_ENV: ${{ matrix.env }}
       REGION: ${{ vars.REGION }}
       DELIVERY_AMOUNT: 100
-      ERROR_TRESHOLD: 90
+      ERROR_TRESHOLD: 10
       LOGGING_LEVEL: error
       LOG_LEVEL: info
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: Run tests
-        run: yarn test ${{ matrix.test }} --no-fail
+        run: yarn test ${{ matrix.test }} --no-fail --log-level off
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -570,7 +570,7 @@ async function runVitestTest(
   }
 
   // Set logging level
-  env.LOGGING_LEVEL = options.logLevel || "error";
+  env.LOGGING_LEVEL = options.logLevel || "off";
 
   for (let attempt = 1; attempt <= options.maxAttempts; attempt++) {
     console.debug(`Attempt ${attempt} of ${options.maxAttempts}...`);


### PR DESCRIPTION
### Reduce error threshold from 90 to 10 and adjust logging levels to 'off' in GitHub workflow and CLI test runner
- Changes `ERROR_TRESHOLD` from 90 to 10 in [.github/workflows/Delivery.yml](https://github.com/xmtp/xmtp-qa-tools/pull/981/files#diff-1e5205e84716125f9b82bfa417467835d3dd392fb6eb68224e0aadcb5e629ecb) and adds `--log-level off` parameter to the yarn test command
- Modifies default `LOGGING_LEVEL` environment variable from 'error' to 'off' in the `runVitestTest` function within [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/981/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810)

#### 📍Where to Start
Start with the GitHub workflow configuration in [.github/workflows/Delivery.yml](https://github.com/xmtp/xmtp-qa-tools/pull/981/files#diff-1e5205e84716125f9b82bfa417467835d3dd392fb6eb68224e0aadcb5e629ecb) to understand the error threshold change and test command modifications.

----

_[Macroscope](https://app.macroscope.com) summarized 1684c5b._