### PR TITLE
Refactor test run logic to handle no-fail option

### DIFF
--- a/scripts/cli.ts
+++ b/scripts/cli.ts
@@ -685,9 +685,7 @@ async function main(): Promise<void> {
 
         // Check if this is a simple test run (no retry options)
         const isSimpleRun =
-          options.maxAttempts === 1 &&
-          !options.explicitLogFlag &&
-          !options.noFail;
+          options.maxAttempts === 1 && !options.explicitLogFlag;
 
         if (isSimpleRun) {
           // Process environment variables for simple runs too
@@ -772,7 +770,18 @@ async function main(): Promise<void> {
           );
           console.debug(`Running test: ${testName}`);
           console.debug(`Executing: ${command}`);
-          execSync(command, { stdio: "inherit", env });
+          try {
+            execSync(command, { stdio: "inherit", env });
+          } catch (error) {
+            if (options.noFail) {
+              console.debug(
+                "Test failed but --no-fail was specified, exiting with code 0",
+              );
+              process.exit(0);
+            } else {
+              throw error;
+            }
+          }
         } else {
           // Use retry mechanism with logger
           await runVitestTest(testName, options);


### PR DESCRIPTION
### Modify test command execution to allow no-fail option in simple run mode and exit with success code when tests fail with no-fail flag
The test command logic in [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/982/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) is modified to handle the `--no-fail` option differently. The simple run condition check removes the `!options.noFail` requirement, allowing tests with the no-fail flag to execute in simple mode with direct terminal output. When tests fail in simple mode with the no-fail option enabled, the process wraps the `execSync` call in a try-catch block and exits with code 0 instead of propagating the error.

#### 📍Where to Start
Start with the test command logic in [scripts/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/982/files#diff-19c23bf197b13b229598fd56a3fca6c83f2e7464ee85ccd5b1eaefdc607e3810) where the simple run condition is evaluated and the `execSync` execution is handled.

----

_[Macroscope](https://app.macroscope.com) summarized cfde431._