### PR TITLE
Update test name for clarity in agent responses

### DIFF
--- a/suites/agents/agents-dms.test.ts
+++ b/suites/agents/agents-dms.test.ts
@@ -28,7 +28,7 @@ describe(testName, async () => {
 
   // Handle case where no agents are configured for the current environment
   if (filteredAgents.length === 0) {
-    it(`${env}: No agents configured for this environment`, () => {
+    it(`${testName}: No agents configured for this environment`, () => {
       console.log(`No agents found for env: ${env}`);
       expect(true).toBe(true); // Pass the test
     });
@@ -37,7 +37,7 @@ describe(testName, async () => {
 
   // Test each agent in DMs
   for (const agent of filteredAgents) {
-    it(`${env}: ${agent.name} DM : ${agent.address}`, async () => {
+    it(`${testName}: ${agent.name} DM : ${agent.address}`, async () => {
       console.log(
         `sending ${agent.sendMessage} to agent`,
         agent.name,

--- a/suites/agents/agents-tagged.test.ts
+++ b/suites/agents/agents-tagged.test.ts
@@ -38,7 +38,7 @@ describe(testName, async () => {
   }
 
   for (const agent of filteredAgents) {
-    it(`${env}: ${agent.name} should respond to tagged/command message : ${agent.address}`, async () => {
+    it(`${testName}: ${agent.name} should respond to tagged/command message : ${agent.address}`, async () => {
       const isSlashCommand = agent.sendMessage.startsWith("/");
       const testMessage = isSlashCommand
         ? agent.sendMessage

--- a/suites/agents/agents-untagged.test.ts
+++ b/suites/agents/agents-untagged.test.ts
@@ -34,7 +34,7 @@ describe(testName, async () => {
   }
 
   for (const agent of filteredAgents) {
-    it(`${env}: ${agent.name} should not respond to untagged hi : ${agent.address}`, async () => {
+    it(`${testName}: ${agent.name} should not respond to untagged hi : ${agent.address}`, async () => {
       console.log("sending message to agent", agent.name, agent.address);
       const conversation = await workers
         .getCreator()


### PR DESCRIPTION
### Update test descriptions in agent test suites to use testName variable instead of env variable for clarity
Changes test description formatting across three agent test files to replace `${env}` variable references with `${testName}` variable references in test case descriptions:

- [agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/984/files#diff-bb8296cd180fddaeacac442a33c7b8eb00c648f56e8b17041a0a3994dc85a569) - Updates two test descriptions for DM agent tests
- [agents-tagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/984/files#diff-27341650cd787e4903ca1cc50b151d4032b7a33fb36694108a846a96a88237ab) - Updates test description for tagged message agent tests  
- [agents-untagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/984/files#diff-8a849c6d5ab8542b6c3442755495d273106e12136edc7afb303c7863c1b11b72) - Updates test description for untagged message agent tests

The changes affect only test report labeling and do not modify test functionality or behavior.

#### 📍Where to Start
Start with the test description changes in [agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/984/files#diff-bb8296cd180fddaeacac442a33c7b8eb00c648f56e8b17041a0a3994dc85a569) as it contains the most changes with two updated test descriptions.

----

_[Macroscope](https://app.macroscope.com) summarized 1630204._