### PR TITLE
Add step to print workflow IP region information

### DIFF
--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -3,7 +3,7 @@ description: "should verify performance of the library in the production network
 
 on:
   schedule:
-    - cron: "*/5 * * * *" # Runs every 5 minutes for agents-dms
+    - cron: "*/10 * * * *" # Runs every 5 minutes for agents-dms
     - cron: "*/30 * * * *" # Runs every 30 minutes for agents-tagged
     - cron: "0 * * * *" # Runs every hour for agents-untagged
   workflow_dispatch:

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -29,6 +29,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Print workflow region
+        run: |
+          echo "Workflow IP region:"
+          curl -s https://ipinfo.io/region
+          echo ""
+          echo "Full IP info:"
+          curl -s https://ipinfo.io/json | jq .
+
       - name: Setup test env
         uses: ./.github/actions/xmtp-test-setup
         with:

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -2,7 +2,7 @@ name: Wildcard
 description: "Manual PR verification workflow - supports functional and performance tests"
 
 on:
-  #pull_request:
+  pull_request:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -301,6 +301,15 @@ yarn test functional --debug
 
 > This will save logs to `logs/` directory and will not print to the terminal.
 
+#### Resources
+
+- **Inboxes:** Inboxes for testing - [see section](/inboxes/)
+- **Local:** Work in local network - [see section](/dev/)
+- **Workers:** Worker for testing - [see section](/workers/)
+- **Helpers:** Coding helpers - [see section](/helpers/)
+- **Scripts:** Monorepo scripts - [see section](/scripts/)
+- **Introduction:** Walkthrough of the monorepo - [see video](https://www.loom.com/share/f447b9a602e44093bce5412243e53664)
+
 #### Rate limits
 
 - **Read operations**: 20,000 requests per 5-minute window
@@ -311,12 +320,3 @@ yarn test functional --debug
 - `local`: `http://localhost:5556`
 - `dev`: `https://grpc.dev.xmtp.network:443`
 - `production`: `https://grpc.production.xmtp.network:443`
-
-#### Resources
-
-- **Inboxes:** Inboxes for testing - [see section](/inboxes/)
-- **Local:** Work in local network - [see section](/dev/)
-- **Workers:** Worker for testing - [see section](/workers/)
-- **Helpers:** Coding helpers - [see section](/helpers/)
-- **Scripts:** Monorepo scripts - [see section](/scripts/)
-- **Introduction:** Walkthrough of the monorepo - [see video](https://www.loom.com/share/f447b9a602e44093bce5412243e53664)

--- a/README.md
+++ b/README.md
@@ -310,12 +310,12 @@ yarn test functional --debug
 - **Scripts:** Monorepo scripts - [see section](/scripts/)
 - **Introduction:** Walkthrough of the monorepo - [see video](https://www.loom.com/share/f447b9a602e44093bce5412243e53664)
 
-#### Rate limits
+##### Rate limits
 
 - **Read operations**: 20,000 requests per 5-minute window
 - **Write operations**: 3,000 messages published per 5-minute window
 
-#### Endpoints
+##### Endpoints
 
 - `local`: `http://localhost:5556`
 - `dev`: `https://grpc.dev.xmtp.network:443`

--- a/README.md
+++ b/README.md
@@ -306,6 +306,12 @@ yarn test functional --debug
 - **Read operations**: 20,000 requests per 5-minute window
 - **Write operations**: 3,000 messages published per 5-minute window
 
+#### Endpoints
+
+- `local`: `http://localhost:5556`
+- `dev`: `https://grpc.dev.xmtp.network:443`
+- `production`: `https://grpc.production.xmtp.network:443`
+
 #### Resources
 
 - **Inboxes:** Inboxes for testing - [see section](/inboxes/)

--- a/suites/metrics/delivery.test.ts
+++ b/suites/metrics/delivery.test.ts
@@ -1,3 +1,4 @@
+import { sleep } from "@helpers/client";
 import {
   sendMetric,
   type DeliveryMetricTags,
@@ -24,6 +25,10 @@ describe(testName, async () => {
   const group = await workers.createGroupBetweenAll();
 
   it("stream: should verify message delivery and order accuracy using streams", async () => {
+    workers.getAllButCreator().forEach((worker) => {
+      worker.worker.startStream(typeofStream.Message);
+    });
+    await sleep(2000);
     const stats = await verifyMessageStream(
       group,
       workers.getAllButCreator(),


### PR DESCRIPTION
### Add step to print workflow IP region information in GitHub Actions Wildcard workflow
- Enables the Wildcard workflow to trigger on pull requests by uncommenting the `pull_request:` trigger in [.github/workflows/Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/997/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085)
- Adds a new step that uses `curl` to fetch and display IP region information of the workflow runner
- Changes the `agents-dms` cron schedule from every 5 minutes to every 10 minutes in [.github/workflows/Agents.yml](https://github.com/xmtp/xmtp-qa-tools/pull/997/files#diff-667c0afa1369370bd08a51b31aeb54b4cd0b8f4a040c00bc9a6819bb9ae71c91)
- Modifies the message delivery test in [suites/metrics/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/997/files#diff-0f3c55dc6d900d23666ba9ab8188b79381f1d16170c4c07a38fc2ea412ffa916) to start message streams for all workers except the creator and adds a 2-second delay before verification
- Reorganizes documentation in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/997/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) by moving the Rate limits section and adding an Endpoints section with local, dev, and production URLs

#### 📍Where to Start
Start with the new "Print workflow region" step in [.github/workflows/Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/997/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085) to understand the IP region information functionality being added.

----

_[Macroscope](https://app.macroscope.com) summarized 3dcc148._