### PR TITLE
Improve error logging and extract event timestamps

### DIFF
--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -158,7 +158,7 @@ export function sendMetric(
 ): void {
   try {
     if (metricValue <= 0) {
-      console.warn(`❌ Metric value is 0 or negative: ${metricName}`);
+      console.error(`❌ Metric value is 0 or negative: ${metricName}`);
       return;
     }
     const enrichedTags = enrichTags(tags);


### PR DESCRIPTION
### Improve error logging and extract event timestamps from stream processing events in helpers/datadog.ts and helpers/streams.ts
- Changes log level from `console.warn` to `console.error` for negative or zero metric values in the `sendMetric` function in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1032/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3)
- Adds `extractTimestamp` function to [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1032/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) that extracts timestamps from event objects by checking receivedAt, timestamp, sentAt, and createdAt fields
- Modifies `collectAndTimeEventsWithStats` to use extracted event timestamps instead of `Date.now()` when available
- Changes key generation in `verifyAgentMessageStream` from random sessionId to conversation ID (`group.id`)
- Updates `triggerEvents` function return structure to use `conversationId` instead of `sessionId`

#### 📍Where to Start
Start with the `extractTimestamp` function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1032/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to understand the new timestamp extraction logic, then review how it's used in `collectAndTimeEventsWithStats`.

----

_[Macroscope](https://app.macroscope.com) summarized 850c201._