### PR TITLE
Clarify monitoring setup description in documentation

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring system
 
-We've built a monitoring setup that tells us when things are working well and alerts us immediately when they're not.
+Monitoring setup that tells us when things are working well and alerts us immediately when they're not.
 
 ## Automated workflows
 


### PR DESCRIPTION
### Remove "We've built a" phrase from monitoring setup description in documentation
Removes the phrase "We've built a" from the first line of [docs/monitoring.md](https://github.com/xmtp/xmtp-qa-tools/pull/1037/files#diff-5451393354374ef994bc816d1c0a86459be726bd231dc37b4385707be6b56921), making the monitoring setup description more concise by changing it from "We've built a monitoring setup that tells us when things are working well and alerts us immediately when they're not." to "Monitoring setup that tells us when things are working well and alerts us immediately when they're not."

#### 📍Where to Start
Start with the first line of [docs/monitoring.md](https://github.com/xmtp/xmtp-qa-tools/pull/1037/files#diff-5451393354374ef994bc816d1c0a86459be726bd231dc37b4385707be6b56921) where the text modification was made.

----

_[Macroscope](https://app.macroscope.com) summarized 17d8407._