### PR TITLE
Refactor tests to improve clarity and structure

### DIFF
--- a/cli/send.ts
+++ b/cli/send.ts
@@ -15,7 +15,7 @@ import {
   getDbPath,
   getEncryptionKeyFromHex,
 } from "../helpers/client";
-import { getRandomAddress } from "../inboxes/utils";
+import { getRandomAddress, getRandomInboxIds } from "../inboxes/utils";
 
 // yarn send --address 0x362d666308d90e049404d361b29c41bda42dd38b --users 5
 // yarn send --address 0x362d666308d90e049404d361b29c41bda42dd38b --users 5 --env production
@@ -187,18 +187,12 @@ async function runsendTest(config: Config): Promise<void> {
           let conversation: Conversation;
 
           if (config.useGroups) {
-            // Create group with 5 people (including the target address)
-            const groupMembers = [config.address];
-            // Add 4 random addresses
-            for (let j = 0; j < 4; j++) {
-              groupMembers.push(getRandomAddress());
-            }
-
-            conversation = (await worker.conversations.newGroup(groupMembers, {
-              groupName: `test-group-${i}-${Date.now()}`,
-            })) as Conversation;
+            const groupMembers = getRandomInboxIds(4);
+            conversation = (await worker.conversations.newGroup(
+              groupMembers,
+            )) as Conversation;
             console.log(
-              `💬 ${i}: Group created in ${Date.now() - newDmStart}ms with ${groupMembers.length} members`,
+              `💬 ${i}: Group created in ${Date.now() - newDmStart}ms`,
             );
           } else {
             // Create DM

--- a/cli/send.ts
+++ b/cli/send.ts
@@ -129,6 +129,17 @@ async function runsendTest(config: Config): Promise<void> {
   // Initialize workers concurrently
   console.log(`📋 Initializing ${config.userCount} workers concurrently...`);
 
+  let initializedCount = 0;
+  const updateProgress = () => {
+    const percentage = Math.round((initializedCount / config.userCount) * 100);
+    const filled = Math.round((percentage / 100) * 20);
+    const empty = 20 - filled;
+    const bar = "█".repeat(filled) + "░".repeat(empty);
+    process.stdout.write(
+      `\r📋 [${bar}] ${percentage}% (${initializedCount}/${config.userCount} workers)`,
+    );
+  };
+
   const workerPromises = Array.from(
     { length: config.userCount },
     async (_, i) => {
@@ -148,13 +159,14 @@ async function runsendTest(config: Config): Promise<void> {
         loggingLevel: config.loggingLevel,
       });
 
-      console.log(`✅ ${i} initialized successfully`);
+      initializedCount++;
+      updateProgress();
       return client;
     },
   );
 
   const workers = await Promise.all(workerPromises);
-  console.log(`✅ All ${config.userCount} workers initialized successfully`);
+  console.log(`\n✅ All ${config.userCount} workers initialized successfully`);
 
   // Run all workers in parallel
   console.log(`🔄 Starting parallel execution...`);

--- a/cli/send.ts
+++ b/cli/send.ts
@@ -200,7 +200,7 @@ async function runsendTest(config: Config): Promise<void> {
             console.log(
               `💬 ${i}: Group created in ${Date.now() - newDmStart}ms with ${groupMembers.length} members`,
             );
-                    } else {
+          } else {
             // Create DM
             conversation = (await worker.conversations.newDmWithIdentifier({
               identifier: config.address,

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -14,7 +14,7 @@ import {
   type LogLevel,
   type Signer,
   type XmtpEnv,
-} from "@xmtp/node-sdk-3.2.1";
+} from "@xmtp/node-sdk";
 import dotenv from "dotenv";
 import { fromString, toString } from "uint8arrays";
 import { createWalletClient, http, toBytes } from "viem";

--- a/inboxes/utils.ts
+++ b/inboxes/utils.ts
@@ -54,14 +54,7 @@ export function getInboxByInstallationCount(
   }
   return typedInboxes2;
 }
-export function getRandomInbox() {
-  const pool = getInboxByInstallationCount(2);
-  return pool[Math.floor(Math.random() * pool.length)];
-}
-export function getRandomAddress() {
-  const pool = getInboxByInstallationCount(2);
-  return pool[Math.floor(Math.random() * pool.length)].accountAddress;
-}
+
 export function getRandomInboxIdsWithRandomInstallations(count: number) {
   let totalInboxes = [];
   const possibleInstallations = [2, 5, 10, 15, 20, 25, 30];
@@ -85,6 +78,13 @@ export function getRandomInboxIds(
     .sort(() => Math.random() - 0.5)
     .slice(0, count)
     .map((inbox) => inbox.inboxId);
+}
+export function getRandomAddress(count: number, installationCount: number = 2) {
+  const pool = getInboxByInstallationCount(installationCount);
+  return pool
+    .sort(() => Math.random() - 0.5)
+    .slice(0, count)
+    .map((inbox) => inbox.accountAddress);
 }
 
 export function getInboxIds(count: number) {

--- a/suites/bugs/slowsync/test.test.ts
+++ b/suites/bugs/slowsync/test.test.ts
@@ -1,5 +1,3 @@
-import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
-import { verifyMessageStream } from "@helpers/streams";
 import { typeOfSync } from "@workers/main";
 import { getWorkers } from "@workers/manager";
 import { ConsentEntityType, ConsentState, type Dm } from "@xmtp/node-sdk";
@@ -65,10 +63,12 @@ describe(testName, async () => {
             randomConversation?.id ?? "",
           );
         console.log("Found conversation", Date.now() - start);
+        const members = await conversation?.members();
+        console.log("Members", members?.length);
         await creator?.client.preferences.setConsentStates([
           {
-            entity: conversation!id,
-            entityType: ConsentEntityType.GroupId,
+            entity: members?.[0]?.inboxId ?? "",
+            entityType: ConsentEntityType.InboxId,
             state: ConsentState.Allowed,
           },
         ]);

--- a/suites/bugs/slowsync/test.test.ts
+++ b/suites/bugs/slowsync/test.test.ts
@@ -46,21 +46,37 @@ describe(testName, async () => {
       expect(dm.id).toBeDefined();
     });
     it("getConversationById:measure getting a conversation by id", async () => {
-      const conversation =
-        await creator?.client.conversations.getConversationById(dm!.id);
-      expect(conversation?.id).toBe(dm!.id);
-      console.log("Conversation", conversation?.id);
+      if (worker.name === "randomclient") {
+        expect(true).toBe(true);
+        return;
+      }
+      for (let i = 0; i < 500; i++) {
+        const start = Date.now();
+        const randomConversation = (
+          await creator?.client.conversations.list()
+        )?.[
+          Math.floor(
+            Math.random() *
+              ((await creator?.client.conversations.list())?.length ?? 0),
+          )
+        ];
+        const conversation =
+          await creator?.client.conversations.getConversationById(
+            randomConversation?.id ?? "",
+          );
+        console.log("Found conversation", conversation?.id, Date.now() - start);
+      }
     });
     it("send:measure sending a gm", async () => {
       const dmId = await dm!.send("gm");
       expect(dmId).toBeDefined();
     });
 
-    it("stream:measure receiving a gm", async () => {
-      const verifyResult = await verifyMessageStream(dm!, [receiver!]);
+    // it("stream:measure receiving a gm", async () => {
+    //   const verifyResult = await verifyMessageStream(dm!, [receiver!]);
 
-      expect(verifyResult.allReceived).toBe(true);
-    });
+    //   expect(verifyResult.allReceived).toBe(true);
+    // });
     it(`consent:verify group consent`, async () => {
       await creator?.client.preferences.setConsentStates([
         {

--- a/suites/bugs/slowsync/test.test.ts
+++ b/suites/bugs/slowsync/test.test.ts
@@ -64,33 +64,25 @@ describe(testName, async () => {
           await creator?.client.conversations.getConversationById(
             randomConversation?.id ?? "",
           );
-        console.log("Found conversation", conversation?.id, Date.now() - start);
+        console.log("Found conversation", Date.now() - start);
+        await creator?.client.preferences.setConsentStates([
+          {
+            entity: conversation!id,
+            entityType: ConsentEntityType.GroupId,
+            state: ConsentState.Allowed,
+          },
+        ]);
+        console.log("Set consent", Date.now() - start);
+        await creator?.client.preferences.getConsentState(
+          ConsentEntityType.GroupId,
+          conversation!.id,
+        );
+        console.log("Got consent", Date.now() - start);
       }
     });
     it("send:measure sending a gm", async () => {
       const dmId = await dm!.send("gm");
       expect(dmId).toBeDefined();
-    });
-
-    // it("stream:measure receiving a gm", async () => {
-    //   const verifyResult = await verifyMessageStream(dm!, [receiver!]);
-
-    //   expect(verifyResult.allReceived).toBe(true);
-    // });
-    it(`consent:verify group consent`, async () => {
-      await creator?.client.preferences.setConsentStates([
-        {
-          entity: receiver!.client.inboxId,
-          entityType: ConsentEntityType.InboxId,
-          state: ConsentState.Allowed,
-        },
-      ]);
-      const consentState = await creator?.client.preferences.getConsentState(
-        ConsentEntityType.InboxId,
-        receiver!.client.inboxId,
-      );
-      console.log("consentState", consentState);
-      expect(consentState).toBe(ConsentState.Allowed);
     });
   }
 });

--- a/suites/bugs/slowsync/test.test.ts
+++ b/suites/bugs/slowsync/test.test.ts
@@ -1,93 +1,80 @@
 import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
 import { verifyMessageStream } from "@helpers/streams";
-import { getRandomAddress } from "@inboxes/utils";
-import { getWorkers, type Worker } from "@workers/manager";
-import {
-  Client,
-  ConsentEntityType,
-  ConsentState,
-  IdentifierKind,
-  type Dm,
-} from "@xmtp/node-sdk";
+import { typeOfSync } from "@workers/main";
+import { getWorkers } from "@workers/manager";
+import { ConsentEntityType, ConsentState, type Dm } from "@xmtp/node-sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
 const testName = "slowsync";
 describe(testName, async () => {
   let dm: Dm | undefined;
-  let workers = await getWorkers(["bob", "edward"]);
-
-  const creator = workers.get("edward");
-  const receiver = workers.get("bob");
-  const creatorClient = creator!.client;
+  let workers = await getWorkers(["randomclient", "edward"]);
 
   beforeAll(async () => {
     for (const worker of workers.getAll()) {
-      await worker.client.conversations.syncAll();
+      worker.worker.startSync(typeOfSync.Both);
       console.log(
+        "started sync for",
         worker.name,
-        "has",
+        "with",
         (await worker.client.conversations.list()).length,
         "conversations",
       );
     }
   });
+  for (const worker of workers.getAll()) {
+    const creator = workers.get(
+      worker.name === "edward" ? "randomclient" : "edward",
+    );
+    const receiver = workers.get(
+      worker.name === "edward" ? "edward" : "randomclient",
+    );
 
-  it("inboxState:measure inboxState", async () => {
-    const inboxState = await creatorClient.preferences.inboxState(true);
-    expect(inboxState.installations.length).toBeGreaterThan(0);
-  });
-  it("newDm:measure creating a DM", async () => {
-    dm = (await creatorClient.conversations.newDm(
-      receiver!.client.inboxId,
-    )) as Dm;
-    expect(dm).toBeDefined();
-    expect(dm.id).toBeDefined();
-  });
-  it("newDmByAddress:measure creating a DM", async () => {
-    const dm2 = await receiver!.client.conversations.newDmWithIdentifier({
-      identifier: getRandomAddress(),
-      identifierKind: IdentifierKind.Ethereum,
+    it("inboxState:measure inboxState", async () => {
+      console.log("Creator", creator?.name);
+      console.log("Receiver", receiver?.name);
+      const inboxState = await creator?.client.preferences.inboxState(true);
+      expect(inboxState?.installations.length).toBeGreaterThan(0);
+    });
+    it("newDm:measure creating a DM", async () => {
+      dm = (await creator?.client.conversations.newDm(
+        receiver!.client.inboxId,
+      )) as Dm;
+      console.log("Created dm with id", dm?.id);
+      await dm.sync();
+      expect(dm).toBeDefined();
+      expect(dm.id).toBeDefined();
+    });
+    it("getConversationById:measure getting a conversation by id", async () => {
+      const conversation =
+        await creator?.client.conversations.getConversationById(dm!.id);
+      expect(conversation?.id).toBe(dm!.id);
+      console.log("Conversation", conversation?.id);
+    });
+    it("send:measure sending a gm", async () => {
+      const dmId = await dm!.send("gm");
+      expect(dmId).toBeDefined();
     });
 
-    expect(dm2).toBeDefined();
-    expect(dm2.id).toBeDefined();
-  });
-  it("getConversationById:measure getting a conversation by id", async () => {
-    const conversation = await creatorClient.conversations.getConversationById(
-      dm!.id,
-    );
-    expect(conversation!.id).toBe(dm!.id);
-  });
-  it("send:measure sending a gm", async () => {
-    const dmId = await dm!.send("gm");
-    expect(dmId).toBeDefined();
-  });
+    it("stream:measure receiving a gm", async () => {
+      const verifyResult = await verifyMessageStream(dm!, [receiver!]);
 
-  it(`consent:verify group consent`, async () => {
-    await creatorClient.preferences.setConsentStates([
-      {
-        entity: receiver!.client.inboxId,
-        entityType: ConsentEntityType.InboxId,
-        state: ConsentState.Allowed,
-      },
-    ]);
-    const consentState = await creatorClient.preferences.getConsentState(
-      ConsentEntityType.InboxId,
-      receiver!.client.inboxId,
-    );
-    console.log("consentState", consentState);
-    expect(consentState).toBe(ConsentState.Allowed);
-  });
-  it("stream:measure receiving a gm", async () => {
-    const verifyResult = await verifyMessageStream(dm!, [receiver!]);
-
-    sendMetric("response", verifyResult.averageEventTiming, {
-      test: testName,
-      metric_type: "stream",
-      metric_subtype: "message",
-      sdk: receiver!.sdk,
-    } as ResponseMetricTags);
-
-    expect(verifyResult.allReceived).toBe(true);
-  });
+      expect(verifyResult.allReceived).toBe(true);
+    });
+    it(`consent:verify group consent`, async () => {
+      await creator?.client.preferences.setConsentStates([
+        {
+          entity: receiver!.client.inboxId,
+          entityType: ConsentEntityType.InboxId,
+          state: ConsentState.Allowed,
+        },
+      ]);
+      const consentState = await creator?.client.preferences.getConsentState(
+        ConsentEntityType.InboxId,
+        receiver!.client.inboxId,
+      );
+      console.log("consentState", consentState);
+      expect(consentState).toBe(ConsentState.Allowed);
+    });
+  }
 });

--- a/suites/performance.test.ts
+++ b/suites/performance.test.ts
@@ -89,7 +89,7 @@ describe(testName, async () => {
   });
   it("newDmByAddress:measure creating a DM", async () => {
     const dm2 = await receiver!.client.conversations.newDmWithIdentifier({
-      identifier: getRandomAddress(),
+      identifier: getRandomAddress(1)[0],
       identifierKind: IdentifierKind.Ethereum,
     });
 


### PR DESCRIPTION
### Refactor tests to improve clarity and structure by adding group messaging support to send utility and restructuring slowsync test with intensive conversation operations
- Adds group messaging support to the send test utility in [cli/send.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1063/files#diff-f8fb94c34b7b013c8f8d15faba3a11d7f3f18838c97549c35b912573b3deef72) with a new `--groups` flag that creates group conversations with 4 random members instead of direct messages
- Restructures the slowsync test in [suites/bugs/slowsync/test.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1063/files#diff-777a5a9058b7dd1ed393c3195169c7e172440161bac7334bc29bf3690c7b1149) to run 500 iterations of conversation retrieval and consent operations for each worker
- Modifies `getRandomAddress()` function in [inboxes/utils.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1063/files#diff-c9d850d654fd6ceb0a984f2bea2acf40f95d889f1c43bb5996dde6de00e9eb1e) to return multiple addresses based on a count parameter instead of a single address
- Updates XMTP SDK import in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1063/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) from version-specific to generic package name
- Adapts performance test in [suites/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1063/files#diff-aa209b39deaaa8a1f7e707f34a5bf11cc221f5020e028557d86d36cc98f4e967) to use the updated `getRandomAddress()` function signature

#### 📍Where to Start
Start with the command line argument handling and group creation logic in the main function of [cli/send.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1063/files#diff-f8fb94c34b7b013c8f8d15faba3a11d7f3f18838c97549c35b912573b3deef72), which demonstrates the new group messaging functionality and shows how the refactored utility functions are used.

----

_[Macroscope](https://app.macroscope.com) summarized 52ec56a._