### PR TITLE
Add pull request trigger and set log level to info

### DIFF
--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -2,6 +2,7 @@ name: Agent health
 description: "verify health of the agents"
 
 on:
+  pull_request:
   schedule:
     - cron: "*/10 * * * *" # Runs every 5 minutes for agents-dms
   workflow_dispatch:
@@ -17,6 +18,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
+      LOG_LEVEL: "info"
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +27,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: agents-dms ${{ matrix.env }}
-        run: yarn test agents-dms --no-fail --debug --no-error-logs --env ${{ matrix.env }}
+        run: yarn test agents-dms  --env ${{ matrix.env }} --no-fail --debug --no-error-logs
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/cli/test.ts
+++ b/cli/test.ts
@@ -291,6 +291,7 @@ function processEnvironmentVariables(
   if (envArg) {
     const envValue = envArg.split("=")[1];
     env.XMTP_ENV = envValue;
+    process.env.XMTP_ENV = envValue;
   }
 
   // Extract --sync parameter and set as environment variable


### PR DESCRIPTION
### Add pull request trigger and set log level to info for AgentHealth workflow
Modifies the AgentHealth workflow configuration to run on pull request events and sets the logging level to info. The changes include:

- Adds `pull_request` trigger to the workflow configuration
- Sets `LOG_LEVEL` environment variable to "info" 
- Reorders command parameters in the `yarn test agents-dms` command without changing functionality

#### 📍Where to Start
Start with the workflow trigger configuration at the top of [.github/workflows/AgentHealth.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1075/files#diff-0a19540e18309384870187f47a34aa0ded2308f23c099d2612946c097a34bbac).

----

_[Macroscope](https://app.macroscope.com) summarized 685bfb6._