### PR TITLE
Update @xmtp/node-sdk to version 3.2.2 for fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@xmtp/node-bindings-1.3.0": "npm:@xmtp/node-bindings@1.3.0",
     "@xmtp/node-bindings-1.3.1": "npm:@xmtp/node-bindings@1.3.1",
     "@xmtp/node-bindings-1.3.3": "npm:@xmtp/node-bindings@1.3.3",
-    "@xmtp/node-sdk": "3.2.1",
+    "@xmtp/node-sdk": "3.2.2",
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13",
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47",
     "@xmtp/node-sdk-1.0.5": "npm:@xmtp/node-sdk@1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1675,7 +1675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-3.2.1@npm:@xmtp/node-sdk@3.2.1, @xmtp/node-sdk@npm:3.2.1":
+"@xmtp/node-sdk-3.2.1@npm:@xmtp/node-sdk@3.2.1":
   version: 3.2.1
   resolution: "@xmtp/node-sdk@npm:3.2.1"
   dependencies:
@@ -4820,7 +4820,7 @@ __metadata:
     "@xmtp/node-bindings-1.3.0": "npm:@xmtp/node-bindings@1.3.0"
     "@xmtp/node-bindings-1.3.1": "npm:@xmtp/node-bindings@1.3.1"
     "@xmtp/node-bindings-1.3.3": "npm:@xmtp/node-bindings@1.3.3"
-    "@xmtp/node-sdk": "npm:3.2.1"
+    "@xmtp/node-sdk": "npm:3.2.2"
     "@xmtp/node-sdk-0.0.13": "npm:@xmtp/mls-client@0.0.13"
     "@xmtp/node-sdk-0.0.47": "npm:@xmtp/node-sdk@0.0.47"
     "@xmtp/node-sdk-1.0.5": "npm:@xmtp/node-sdk@1.0.5"


### PR DESCRIPTION
### Update @xmtp/node-sdk dependency from version 3.2.1 to 3.2.2 for fixes
This pull request updates the `@xmtp/node-sdk` package dependency from version 3.2.1 to 3.2.2 in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1089/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) and updates the corresponding lock file entries in [yarn.lock](https://github.com/xmtp/xmtp-qa-tools/pull/1089/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1089/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized d7bd91e._