### PR TITLE
Update cron schedule for more frequent testing

### DIFF
--- a/.github/workflows/Forks.yml
+++ b/.github/workflows/Forks.yml
@@ -3,8 +3,8 @@ description: "Daily forks testing on local network"
 
 on:
   schedule:
-    # Run once a day at 2 AM UTC
-    - cron: "0 2 * * *"
+    # Run every 12 hours at 2 AM and 2 PM UTC
+    - cron: "0 2,14 * * *"
 
 jobs:
   test:
@@ -30,7 +30,7 @@ jobs:
         run: sleep 30
 
       - name: Run forks test
-        run: yarn test forks --attempts 5 --env local --debug --forks
+        run: yarn test forks --attempts 50 --env local --debug --forks
 
       - name: Stop local XMTP network
         if: always()


### PR DESCRIPTION
### Update cron schedule for more frequent testing by modifying the GitHub workflow to run twice daily and increase test attempts from 5 to 50
This pull request modifies the [.github/workflows/Forks.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1091/files#diff-61145192fc1eca7377399b4707a01cd2b9107f69c78dd3720861f782ea7304d3) GitHub workflow file to change the testing frequency and thoroughness:

- Changes the cron schedule from `"0 2 * * *"` to `"0 2,14 * * *"` to run twice daily at 2 AM and 2 PM UTC instead of once daily
- Increases the test attempts parameter from `--attempts 5` to `--attempts 50` in the "Run forks test" step

#### 📍Where to Start
Start with the cron schedule configuration and the "Run forks test" step in [.github/workflows/Forks.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1091/files#diff-61145192fc1eca7377399b4707a01cd2b9107f69c78dd3720861f782ea7304d3).

----

_[Macroscope](https://app.macroscope.com) summarized ca242fb._