### PR TITLE
Enable pull request trigger for agent health checks

### DIFF
--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: ${{ matrix.test }} ${{ matrix.env }}
-        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} --no-fail --debug --no-error-logs
+        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} --no-fail --no-error-logs
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         test: [agents-dms]
-        env: [dev, production]
+        env: [production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}

--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: ${{ matrix.test }} ${{ matrix.env }}
-        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} -t onit
+        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }}
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: ${{ matrix.test }} ${{ matrix.env }}
-        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} --no-fail --no-error-logs
+        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} -t onit
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -2,7 +2,7 @@ name: Agent health
 description: "verify health of the agents"
 
 on:
-  #pull_request:
+  pull_request:
   schedule:
     - cron: "*/10 * * * *" # Runs every 5 minutes for agents-dms
   workflow_dispatch:

--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/xmtp-test-setup
 
       - name: ${{ matrix.test }} ${{ matrix.env }}
-        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }}
+        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} -t onit
 
       - name: Cleanup and upload artifacts
         if: always()

--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
-      LOG_LEVEL: "info"
+      LOG_LEVEL: "debug"
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -226,6 +226,7 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
             fallbackTimestamp,
             finalTimestamp,
             message: getMessage(ev).substring(0, 100) + "...",
+            rawEvent: JSON.stringify(ev, null, 2),
           });
         }
 
@@ -261,22 +262,20 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
           msg.receivedAt - (sentEvents[sentIdx] as { sentAt: number }).sentAt;
 
         // Debug logging for Onit agent specifically
-        if (msg.message.includes("Onit prediction market agent")) {
-          console.debug(
-            "Onit timing calculation debug:",
-            JSON.stringify(
-              {
-                receivedAt: msg.receivedAt,
-                sentAt: (sentEvents[sentIdx] as { sentAt: number }).sentAt,
-                duration,
-                positiveDuration: Math.max(0, duration),
-                message: msg.message.substring(0, 100) + "...",
-              },
-              null,
-              2,
-            ),
-          );
-        }
+        console.debug(
+          "Onit timing calculation debug:",
+          JSON.stringify(
+            {
+              receivedAt: msg.receivedAt,
+              sentAt: (sentEvents[sentIdx] as { sentAt: number }).sentAt,
+              duration,
+              positiveDuration: Math.max(0, duration),
+              message: msg.message.substring(0, 100) + "...",
+            },
+            null,
+            2,
+          ),
+        );
 
         // Ensure we don't have negative durations due to clock skew or processing delays
         // Use a minimum of 1ms instead of 0 to avoid metric validation errors

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -670,13 +670,12 @@ export async function verifyAgentMessageStream(
           customTimeout ?? undefined,
         ),
       triggerEvents: async () => {
+        await group.send(triggerMessage);
         const sentAt = Date.now();
         console.debug(
           "Onit triggerEvents debug:",
           JSON.stringify({ sentAt, triggerMessage }, null, 2),
         );
-        await group.send(triggerMessage);
-
         return [{ conversationId: group.id, sentAt }];
       },
       getKey: () => group.id, // Use conversation ID as consistent key for both sent and received

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -623,6 +623,7 @@ export function calculateMessageStats(
     const inOrder = isOrderedSubsequence(messages, expectedMessages);
     return { inOrder, expectedMessages };
   };
+
   let totalExpectedMessages = amount * messagesByWorker.length;
   let totalReceivedMessages = messagesByWorker.reduce(
     (sum, msgs) => sum + msgs.length,
@@ -630,10 +631,21 @@ export function calculateMessageStats(
   );
   let workersInOrder = 0;
   const workerCount = messagesByWorker.length;
-  for (const messages of messagesByWorker) {
-    const { inOrder } = verifyMessageOrder(messages, prefix, amount);
-    if (inOrder) workersInOrder++;
+
+  // Special case for single message scenarios (like agent responses)
+  // Order percentage is 100% if any messages were received
+  if (amount === 1) {
+    for (const messages of messagesByWorker) {
+      if (messages.length > 0) workersInOrder++;
+    }
+  } else {
+    // Standard ordered message verification for multi-message scenarios
+    for (const messages of messagesByWorker) {
+      const { inOrder } = verifyMessageOrder(messages, prefix, amount);
+      if (inOrder) workersInOrder++;
+    }
   }
+
   const receptionPercentage =
     (totalReceivedMessages / totalExpectedMessages) * 100;
   const orderPercentage = (workersInOrder / workerCount) * 100;

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -147,7 +147,7 @@ function extractTimestamp(ev: unknown): number | null {
       }
     }
 
-    // Try nested in message object
+    // Try nested in message object (for StreamTextMessage structure)
     if (
       Object.prototype.hasOwnProperty.call(ev, "message") &&
       typeof (ev as Record<string, unknown>).message === "object" &&

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -7,7 +7,7 @@ import {
   type Client,
   type Conversation,
   type Group,
-} from "@workers/versions";
+} from "@xmtp/node-sdk";
 
 // Define the expected return type of verifyMessageStream
 export type VerifyStreamResult = {

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -7,7 +7,7 @@ import {
   type Client,
   type Conversation,
   type Group,
-} from "@xmtp/node-sdk";
+} from "@workers/versions";
 
 // Define the expected return type of verifyMessageStream
 export type VerifyStreamResult = {

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -233,13 +233,20 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
 
         // Debug logging for Onit agent specifically
         if (msg.message.includes("Onit prediction market agent")) {
-          console.debug("Onit timing calculation debug:", {
-            receivedAt: msg.receivedAt,
-            sentAt: (sentEvents[sentIdx] as { sentAt: number }).sentAt,
-            duration,
-            positiveDuration: Math.max(0, duration),
-            message: msg.message.substring(0, 100) + "...",
-          });
+          console.debug(
+            "Onit timing calculation debug:",
+            JSON.stringify(
+              {
+                receivedAt: msg.receivedAt,
+                sentAt: (sentEvents[sentIdx] as { sentAt: number }).sentAt,
+                duration,
+                positiveDuration: Math.max(0, duration),
+                message: msg.message.substring(0, 100) + "...",
+              },
+              null,
+              2,
+            ),
+          );
         }
 
         // Ensure we don't have negative durations due to clock skew or processing delays

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -120,13 +120,30 @@ function extractTimestamp(ev: unknown): number | null {
   if (typeof ev === "object" && ev !== null) {
     // Try different timestamp fields that might exist in message events
     const possibleFields = ["receivedAt", "timestamp", "sentAt", "createdAt"];
+    const nanosecondFields = [
+      "receivedAtNs",
+      "timestampNs",
+      "sentAtNs",
+      "createdAtNs",
+    ];
 
+    // First try regular timestamp fields (in milliseconds)
     for (const field of possibleFields) {
       if (
         Object.prototype.hasOwnProperty.call(ev, field) &&
         typeof (ev as Record<string, unknown>)[field] === "number"
       ) {
         return (ev as Record<string, number>)[field];
+      }
+    }
+
+    // Then try nanosecond timestamp fields and convert to milliseconds
+    for (const field of nanosecondFields) {
+      if (
+        Object.prototype.hasOwnProperty.call(ev, field) &&
+        typeof (ev as Record<string, unknown>)[field] === "number"
+      ) {
+        return Number((ev as Record<string, number>)[field]) / 1_000_000;
       }
     }
 
@@ -137,12 +154,24 @@ function extractTimestamp(ev: unknown): number | null {
       (ev as Record<string, unknown>).message !== null
     ) {
       const message = (ev as { message: Record<string, unknown> }).message;
+
+      // First try regular timestamp fields
       for (const field of possibleFields) {
         if (
           Object.prototype.hasOwnProperty.call(message, field) &&
           typeof message[field] === "number"
         ) {
           return message[field];
+        }
+      }
+
+      // Then try nanosecond timestamp fields and convert to milliseconds
+      for (const field of nanosecondFields) {
+        if (
+          Object.prototype.hasOwnProperty.call(message, field) &&
+          typeof message[field] === "number"
+        ) {
+          return Number(message[field]) / 1_000_000;
         }
       }
     }

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -250,7 +250,8 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
         }
 
         // Ensure we don't have negative durations due to clock skew or processing delays
-        const positiveDuration = Math.max(0, duration);
+        // Use a minimum of 1ms instead of 0 to avoid metric validation errors
+        const positiveDuration = Math.max(1, duration);
 
         eventTimings[r.name][sentIdx] = positiveDuration;
         timingSum += positiveDuration;

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -219,16 +219,19 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
         const fallbackTimestamp = Date.now();
         const finalTimestamp = eventTimestamp || fallbackTimestamp;
 
-        // Debug logging for Onit agent specifically
-        if (getMessage(ev).includes("Onit prediction market agent")) {
-          console.debug("Onit message timestamp debug:", {
-            eventTimestamp,
-            fallbackTimestamp,
-            finalTimestamp,
-            message: getMessage(ev).substring(0, 100) + "...",
-            rawEvent: JSON.stringify(ev, null, 2),
-          });
-        }
+        console.debug(
+          "Onit message timestamp debug:",
+          JSON.stringify(
+            {
+              eventTimestamp,
+              fallbackTimestamp,
+              finalTimestamp,
+              message: getMessage(ev).substring(0, 100) + "...",
+            },
+            null,
+            2,
+          ),
+        );
 
         return {
           key: getKey(ev),
@@ -668,7 +671,10 @@ export async function verifyAgentMessageStream(
         ),
       triggerEvents: async () => {
         const sentAt = Date.now();
-        console.debug("Onit triggerEvents debug:", { sentAt, triggerMessage });
+        console.debug(
+          "Onit triggerEvents debug:",
+          JSON.stringify({ sentAt, triggerMessage }, null, 2),
+        );
         await group.send(triggerMessage);
 
         return [{ conversationId: group.id, sentAt }];

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -217,10 +217,8 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
       if (sentIdx !== -1 && hasSentAt(sentEvents[sentIdx])) {
         const duration =
           msg.receivedAt - (sentEvents[sentIdx] as { sentAt: number }).sentAt;
-        // Ensure we don't have negative durations due to clock skew or processing delays
-        const positiveDuration = Math.max(0, duration);
-        eventTimings[r.name][sentIdx] = positiveDuration;
-        timingSum += positiveDuration;
+        eventTimings[r.name][sentIdx] = duration;
+        timingSum += duration;
         timingCount++;
       }
     });
@@ -604,9 +602,10 @@ export async function verifyAgentMessageStream(
           ["text", "reply", "reaction", "actions"],
           customTimeout ?? undefined,
         ),
-      triggerEvents: async () => {
+      // @ts-expect-error - TODO: fix this
+      triggerEvents: () => {
         const sentAt = Date.now();
-        await group.send(triggerMessage);
+        group.send(triggerMessage).catch(console.error);
 
         return [{ conversationId: group.id, sentAt }];
       },

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -94,6 +94,7 @@ interface StreamTextMessage extends BaseStreamMessage {
     contentType?: {
       typeId: string;
     };
+    receivedAt?: number; // Add timestamp for when message was received
   };
 }
 
@@ -556,6 +557,7 @@ export class WorkerClient extends Worker {
                     senderInboxId: message.senderInboxId,
                     content: message.content as string,
                     contentType: message.contentType,
+                    receivedAt: Date.now(), // Capture timestamp when message is received from stream
                   },
                 });
               } else {


### PR DESCRIPTION
### Enable pull request trigger for agent health checks and modify timing calculations to handle nanosecond timestamps and negative durations in agent response processing
- Modifies the AgentHealth workflow in [.github/workflows/AgentHealth.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1095/files#diff-0a19540e18309384870187f47a34aa0ded2308f23c099d2612946c097a34bbac) to run on pull requests, test only production environment, use debug logging, and target 'onit' tests with the `-t` flag
- Updates the `extractTimestamp` function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1095/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to handle nanosecond timestamp fields by converting to milliseconds and adds special handling for negative durations in agent auto-responses with an estimation algorithm
- Extends the `StreamTextMessage` interface in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1095/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1) to include a `receivedAt` timestamp field that captures message reception time

#### 📍Where to Start
Start with the `extractTimestamp` function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1095/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to understand the core timing calculation changes, then review the workflow modifications in [.github/workflows/AgentHealth.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1095/files#diff-0a19540e18309384870187f47a34aa0ded2308f23c099d2612946c097a34bbac).

----

_[Macroscope](https://app.macroscope.com) summarized 076456a._