### PR TITLE
Update version management documentation for clarity

### DIFF
--- a/.cursor/rules/cli-usage.mdc
+++ b/.cursor/rules/cli-usage.mdc
@@ -79,7 +79,7 @@ yarn test functional --no-fail --debug
 
 ```bash
 yarn test functional --versions 3      # Uses 3 random SDK versions
-yarn test functional --nodeVersion 3.1.1  # Use specific Node.js version
+yarn test functional --nodeSDK 3.1.1  # Use specific Node.js version
 
 # Available SDK versions:
 # - 0.0.47 (Legacy)
@@ -174,7 +174,7 @@ yarn test functional --no-fail --debug # Full functional suite with debugging
 
 ```bash
 yarn test functional --versions 3 --debug                # Version compatibility testing
-yarn test functional --nodeVersion 3.1.1 --debug         # Node.js version testing
+yarn test functional --nodeSDK 3.1.1 --debug         # Node.js version testing
 ```
 
 ## Shortcut Commands (from package.json)
@@ -231,7 +231,7 @@ yarn test ./suites/functional/groups.test.ts ./suites/functional/consent.test.ts
 ```bash
 yarn test functional --debug --env dev
 yarn test functional --versions 3
-yarn test functional --nodeVersion 3.1.1
+yarn test functional --nodeSDK 3.1.1
 yarn test functional --sync all,conversations
 yarn test functional --size 5-10
 ```
@@ -240,7 +240,7 @@ yarn test functional --size 5-10
 
 ```bash
 yarn test functional --versions 3 --attempts 5  --debug
-yarn test functional --nodeVersion 3.1.1 --env local --sync all
+yarn test functional --nodeSDK 3.1.1 --env local --sync all
 yarn test functional --size 5-10 --parallel --forks
 ```
 
@@ -257,5 +257,5 @@ yarn test functional --size 5-10 --parallel --forks
 ```bash
 # Advanced example with multiple options
 yarn test functional --versions 3 --attempts 5 --debug --parallel --forks
-yarn test functional --nodeVersion 3.1.1 --env local --sync all,conversations --size 5-10
+yarn test functional --nodeSDK 3.1.1 --env local --sync all,conversations --size 5-10
 ```

--- a/.cursor/rules/testing-framework.mdc
+++ b/.cursor/rules/testing-framework.mdc
@@ -475,7 +475,7 @@ const group = await workers
 
 ```typescript
 // Test with specific SDK version
-const workers = await getWorkers(1, { nodeVersion: "3.1.1" });
+const workers = await getWorkers(1, { nodeSDK: "3.1.1" });
 
 // Multi-version testing
 const workers = await getWorkers(3, { useVersions: true });
@@ -483,7 +483,7 @@ const workers = await getWorkers(3, { useVersions: true });
 // Regression testing pattern
 const versions = getVersions().slice(0, 3);
 for (const version of versions) {
-  const workers = await getWorkers([`alice-a-${version.nodeVersion}`], {
+  const workers = await getWorkers([`alice-a-${version.nodeSDK}`], {
     useVersions: false,
   });
 }
@@ -978,7 +978,7 @@ const group = await workers
 
 ```typescript
 // Test with specific SDK version
-const workers = await getWorkers(1, { nodeVersion: "3.1.1" });
+const workers = await getWorkers(1, { nodeSDK: "3.1.1" });
 
 // Multi-version testing
 const workers = await getWorkers(3, { useVersions: true });
@@ -986,7 +986,7 @@ const workers = await getWorkers(3, { useVersions: true });
 // Regression testing pattern
 const versions = getVersions().slice(0, 3);
 for (const version of versions) {
-  const workers = await getWorkers([`alice-a-${version.nodeVersion}`], {
+  const workers = await getWorkers([`alice-a-${version.nodeSDK}`], {
     useVersions: false,
   });
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ You may ONLY execute the following CLI commands:
 - `--parallel` - Parallel execution
 - `--versions <number>` - Use multiple SDK versions
 - `--env <environment>` - Set XMTP_ENV (dev, production, local)
-- `--nodeVersion <version>` - Use specific Node.js version
+- `--nodeSDK <version>` - Use specific Node.js version
+- `--nodeBindings <version>` - Use specific Node.js bindings version
 - `--sync <strategy>` - Sync strategy (all, conversations, all,conversations)
 - `--size <range>` - Batch size range (e.g., 5-10)
 - `--forks` - Report fork count after test completion
@@ -50,7 +51,7 @@ yarn test functional --versions 3 --no-fail --debug
 yarn test delivery --attempts 3 --debug
 
 # Test with specific Node.js version
-yarn test functional --nodeVersion 3.1.1 --debug
+yarn test functional --nodeSDK 3.1.1 --debug
 
 # Test with sync strategy configuration
 yarn test functional --sync all,conversations --debug
@@ -110,7 +111,7 @@ yarn test functional --sync all --versions 3 --no-fail --debug --size 5-10-50-10
 yarn test functional --versions 3 --attempts 5 --debug --parallel --forks
 
 # Node.js version testing with environment configuration
-yarn test functional --nodeVersion 3.1.1 --env local --sync all
+yarn test functional --nodeSDK 3.1.1 --env local --sync all
 
 # Batch testing with size configuration
 yarn test functional --size 5-10 --parallel --forks

--- a/bots/gm-bot/scripts/generateKeys.ts
+++ b/bots/gm-bot/scripts/generateKeys.ts
@@ -4,8 +4,8 @@ import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { generateEncryptionKeyHex } from "../helpers/client";
 
 // Check Node.js version
-const nodeVersion = process.versions.node;
-const [major] = nodeVersion.split(".").map(Number);
+const nodeSDK = process.versions.node;
+const [major] = nodeSDK.split(".").map(Number);
 if (major < 20) {
   console.error("Node.js version 20 or higher is required");
   process.exit(1);

--- a/bots/gm-bot/scripts/revokeInstallations.ts
+++ b/bots/gm-bot/scripts/revokeInstallations.ts
@@ -5,8 +5,8 @@ import { Client, type XmtpEnv } from "@workers/versions";
 import { createSigner, getEncryptionKeyFromHex } from "../helpers/client";
 
 // Check Node.js version
-const nodeVersion = process.versions.node;
-const [major] = nodeVersion.split(".").map(Number);
+const nodeSDK = process.versions.node;
+const [major] = nodeSDK.split(".").map(Number);
 if (major < 20) {
   console.error("Error: Node.js version 20 or higher is required");
   process.exit(1);

--- a/cli/revoke.ts
+++ b/cli/revoke.ts
@@ -5,8 +5,8 @@ import { createSigner } from "@helpers/client";
 import { Client, type XmtpEnv } from "@workers/versions";
 
 // Check Node.js version
-const nodeVersion = process.versions.node;
-const [major] = nodeVersion.split(".").map(Number);
+const nodeSDK = process.versions.node;
+const [major] = nodeSDK.split(".").map(Number);
 if (major < 20) {
   console.error("Error: Node.js version 20 or higher is required");
   process.exit(1);

--- a/cli/test.ts
+++ b/cli/test.ts
@@ -200,13 +200,13 @@ function parseTestArgs(args: string[]): {
         options.verboseLogging = false;
         env.LOGGING_LEVEL = "debug";
         break;
-      case "--nodeVersion":
+      case "--nodeSDK":
         if (nextArg) {
           env.NODE_VERSION = nextArg;
           i++;
         } else {
           console.warn(
-            "--nodeVersion flag requires a value (e.g., --nodeVersion 3.1.1)",
+            "--nodeSDK flag requires a value (e.g., --nodeSDK 3.1.1)",
           );
         }
         break;

--- a/cli/versions.ts
+++ b/cli/versions.ts
@@ -14,12 +14,12 @@ function createBindingsSymlinks() {
   console.log("Creating bindings symlinks...");
 
   for (const config of VersionList) {
-    if (!config.bindingsPackage) continue;
+    if (!config.nodeBindings) continue;
 
-    const sdkDir = path.join(xmtpDir, `node-sdk-${config.nodeVersion}`);
+    const sdkDir = path.join(xmtpDir, `node-sdk-${config.nodeSDK}`);
     const bindingsDir = path.join(
       xmtpDir,
-      `node-bindings-${config.bindingsPackage}`,
+      `node-bindings-${config.nodeBindings}`,
     );
 
     if (!fs.existsSync(sdkDir) || !fs.existsSync(bindingsDir)) continue;
@@ -44,9 +44,9 @@ function createBindingsSymlinks() {
         bindingsDir,
       );
       fs.symlinkSync(relativeBindingsPath, symlinkTarget);
-      console.log(`${config.nodeVersion} -> ${config.bindingsPackage}`);
+      console.log(`${config.nodeSDK} -> ${config.nodeBindings}`);
     } catch (error) {
-      console.error(`Error linking ${config.nodeVersion}: ${String(error)}`);
+      console.error(`Error linking ${config.nodeSDK}: ${String(error)}`);
     }
   }
 }

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -4,7 +4,7 @@
 
 How XMTP SDK versions relate to the underlying `libxmtp` Rust library and how to test with custom versions.
 
-## Architecture: SDK → Bindings → libxmtp
+## Architecture: [NodeSDK](https://www.npmjs.com/package/@xmtp/node-sdk?activeTab=versions) → [Bindings](https://www.npmjs.com/package/@xmtp/node-bindings?activeTab=versions) → [libxmtp](https://github.com/xmtp/libxmtp)
 
 ```
 Node.js SDK (e.g., @xmtp/node-sdk@3.2.2)
@@ -18,7 +18,7 @@ libxmtp Rust Library (specific commit/version)
 - **Bindings**: Compiled Rust code and native bindings
 - **libxmtp**: Core cryptographic and networking logic
 
-## Version Mapping System
+## Version mapping system
 
 ### Version Mapping
 
@@ -63,14 +63,6 @@ node_modules/@xmtp/
 └── node-bindings-1.3.3/
 ```
 
-## Testing with Custom libxmtp Versions
-
-### Scenario: Testing a Feature Branch
-
-**Q**: _"I have a private branch of libxmtp, can you run your E2E tests on it?"_
-
-**A**: Yes, but requires a full release process.
-
 ### Process
 
 1. Developer creates libxmtp branch
@@ -79,7 +71,7 @@ node_modules/@xmtp/
 4. QA tools updated with new bindings version
 5. Tests run against new version
 
-### Alternative: Use Existing Bindings
+### Switch between versions
 
 If your libxmtp version is already compiled:
 
@@ -95,14 +87,14 @@ If your libxmtp version is already compiled:
 }
 ```
 
-## Version Discovery
+## Version discovery
 
 ### Finding libxmtp Version
 
 The libxmtp commit hash is in:
 
-```
-node_modules/@xmtp/node-bindings-X.X.X/version
+```bash
+node_modules/@xmtp/node-bindings-X.X.X/dist/version.json
 ```
 
 ### Using Versions Command
@@ -130,26 +122,5 @@ yarn test functional --nodeVersion 3.2.2
 ### Regression Testing
 
 ```bash
-yarn regression  # Test multiple versions
+yarn regression  # Vibe check on latest version
 ```
-
-## Best Practices
-
-### Adding New Versions
-
-1. Update package.json with new aliases
-2. Add to workers/versions.ts
-3. Run `yarn versions`
-4. Test before enabling auto-testing
-
-### Removing Buggy Versions
-
-1. Remove from all files
-2. Set previous stable to `auto: true`
-3. Verify bindings version matches
-
-### Version Naming
-
-- Avoid hyphens (breaks worker name conversion)
-- Use semantic versioning
-- Keep mappings consistent

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -6,12 +6,18 @@ How XMTP SDK versions relate to the underlying `libxmtp` Rust library and how to
 
 ## Architecture: [NodeSDK](https://www.npmjs.com/package/@xmtp/node-sdk?activeTab=versions) → [Bindings](https://www.npmjs.com/package/@xmtp/node-bindings?activeTab=versions) → [libxmtp](https://github.com/xmtp/libxmtp)
 
-```
-Node.js SDK (e.g., @xmtp/node-sdk@3.2.2)
-    ↓ depends on
-Node Bindings (e.g., @xmtp/node-bindings@1.3.3)
-    ↓ compiled from
-libxmtp Rust Library (specific commit/version)
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#0D1117', 'primaryTextColor': '#c9d1d9', 'primaryBorderColor': '#30363d', 'lineColor': '#8b949e', 'secondaryColor': '#161b22', 'tertiaryColor': '#161b22' }}}%%
+
+flowchart TD
+  nodeSDK["Node.js SDK<br/>(e.g., @xmtp/node-sdk@3.2.2)"]
+  nodeBindings["Node Bindings<br/>(e.g., @xmtp/node-bindings@1.3.3)"]
+  libxmtp["libxmtp Rust Library<br/>(specific commit/version)"]
+
+  nodeSDK --> |depends on| nodeBindings
+  nodeBindings --> |compiled from| libxmtp
+
+  classDef default fill:#161b22,stroke:#30363d,stroke-width:2px,color:#c9d1d9;
 ```
 
 - **SDKs**: Thin TypeScript wrappers providing developer-friendly API

--- a/docs/version-management.md
+++ b/docs/version-management.md
@@ -20,8 +20,6 @@ libxmtp Rust Library (specific commit/version)
 
 ## Version mapping system
 
-### Version Mapping
-
 Versions are mapped in `workers/versions.ts`:
 
 ```typescript
@@ -31,8 +29,8 @@ export const VersionList = [
     Conversation: Conversation322,
     Dm: Dm322,
     Group: Group322,
-    nodeVersion: "3.2.2", // SDK version
-    bindingsPackage: "1.3.3", // Bindings version
+    nodeSDK: "3.2.2", // SDK version
+    nodeBindings: "1.3.3", // Bindings version
     auto: true, // Include in automated testing
   },
 ];
@@ -81,8 +79,8 @@ If your libxmtp version is already compiled:
 
 ```typescript
 {
-  nodeVersion: "3.2.2",
-  bindingsPackage: "1.3.1",  // Use existing bindings
+  nodeSDK: "3.2.2",
+  nodeBindings: "1.3.1",  // Use existing bindings
   auto: false,               // Manual testing only
 }
 ```
@@ -116,7 +114,7 @@ yarn test functional --versions 3  # Test 3 auto-enabled versions
 ### Manual Testing
 
 ```bash
-yarn test functional --nodeVersion 3.2.2
+yarn test functional --nodeSDK 3.2.2
 ```
 
 ### Regression Testing

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -59,7 +59,7 @@ export const setupTestLifecycle = ({
       operation: operationName,
       test: testNameExtracted,
       GH_CACHE: process.env.GH_CACHE || "false",
-      sdk: sdk || getVersions()[0].nodeVersion,
+      sdk: sdk || getVersions()[0].nodeSDK,
       installations: members,
       members,
     };
@@ -89,7 +89,7 @@ export const setupTestLifecycle = ({
           metric_type: "network",
           metric_subtype: "phase",
           network_phase: networkPhase,
-          sdk: sdk || getVersions()[0].nodeVersion,
+          sdk: sdk || getVersions()[0].nodeSDK,
           operation: operationName,
           test: testNameExtracted,
         };

--- a/suites/forks/README.md
+++ b/suites/forks/README.md
@@ -23,7 +23,7 @@ The main approach creates intentional conflicts by running parallel operations o
 ## Parameters
 
 - **groupCount**: `5` - Number of groups to create in parallel
-- **nodeVersion**: `3.1.1` - Node SDK version to use
+- **nodeSDK**: `3.1.1` - Node SDK version to use
 - **parallelOperations**: `1` - How many operations to perform in parallel
 - **enabledOperations**: - Operations configuration - enable/disable specific operations
   - `updateName`: true, // updates the name of the group

--- a/suites/forks/forks.test.ts
+++ b/suites/forks/forks.test.ts
@@ -8,7 +8,7 @@ import { describe, it } from "vitest";
 // Count of groups to create
 const groupCount = 5;
 const parallelOperations = 1; // How many operations to perform in parallel
-const NODE_VERSION = "3.2.2"; // --nodeVersion=3.1.1
+const NODE_VERSION = "3.2.2"; // --nodeSDK=3.1.1
 // By calling workers with prefix random1, random2, etc. we guarantee that creates a new key each run
 // We want to create a key each run to ensure the forks are "pure"
 const workerNames = [
@@ -85,7 +85,7 @@ describe(testName, () => {
   it("perform concurrent operations with multiple users across 5 groups", async () => {
     let workers = await getWorkers(workerNames, {
       env: network as "local" | "dev" | "production",
-      nodeVersion: NODE_VERSION,
+      nodeSDK: NODE_VERSION,
     });
     // Note: typeofStreamForTest and typeOfSyncForTest are set to None, so no streams or syncs to start
     // Create groups

--- a/suites/functional/clients.test.ts
+++ b/suites/functional/clients.test.ts
@@ -28,7 +28,7 @@ describe(testName, async () => {
 
     for (const version of versions) {
       const versionWorkers = await getWorkers(
-        ["downgrade-" + "a" + "-" + version.nodeVersion],
+        ["downgrade-" + "a" + "-" + version.nodeSDK],
         {
           useVersions: false,
         },
@@ -39,8 +39,7 @@ describe(testName, async () => {
       let convo = await downgrade?.client.conversations.newDm(receiverInboxId);
 
       expect(convo?.id).toBeDefined();
-      if (!convo?.id)
-        console.error("Dowgrading from version", version.nodeVersion);
+      if (!convo?.id) console.error("Dowgrading from version", version.nodeSDK);
     }
   });
 
@@ -50,7 +49,7 @@ describe(testName, async () => {
 
     for (const version of versions.reverse()) {
       const versionWorkers = await getWorkers(
-        ["upgrade-" + "a" + "-" + version.nodeVersion],
+        ["upgrade-" + "a" + "-" + version.nodeSDK],
         {
           useVersions: false,
         },
@@ -60,8 +59,7 @@ describe(testName, async () => {
       console.log("Upgraded to ", "sdk:" + String(upgrade?.sdk));
       let convo = await upgrade?.client.conversations.newDm(receiverInboxId);
       expect(convo?.id).toBeDefined();
-      if (!convo?.id)
-        console.error("Upgrading to version", version.nodeVersion);
+      if (!convo?.id) console.error("Upgrading to version", version.nodeSDK);
     }
   });
 

--- a/workers/README.md
+++ b/workers/README.md
@@ -28,7 +28,7 @@ await getWorkers(3); // 3 random workers
 await getWorkers(["alice", "bob"]); // specific names
 await getWorkers(5, { env: "production" }); // production env
 await getWorkers(3, { useVersions: true }); // random SDK versions
-await getWorkers(1, { nodeVersion: "3.1.1" }); // specific version
+await getWorkers(1, { nodeSDK: "3.1.1" }); // specific version
 ```
 
 ## Conversations
@@ -92,7 +92,7 @@ const workers = await getWorkers(3, { useVersions: true });
 // Specific versions
 const versions = getVersions().slice(0, 3);
 for (const version of versions) {
-  const workers = await getWorkers([`bob-a-${version.nodeVersion}`], {
+  const workers = await getWorkers([`bob-a-${version.nodeSDK}`], {
     useVersions: false,
   });
   // Test logic

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -46,9 +46,9 @@ export function nameWithVersions(workerNames: string[]): string[] {
 
     // If workerName already contains installation ID (has dash), don't add another "-a"
     if (workerName.includes("-")) {
-      descriptors.push(`${workerName}-${randomVersion.nodeVersion}`);
+      descriptors.push(`${workerName}-${randomVersion.nodeSDK}`);
     } else {
-      descriptors.push(`${workerName}-a-${randomVersion.nodeVersion}`);
+      descriptors.push(`${workerName}-a-${randomVersion.nodeSDK}`);
     }
   }
 
@@ -410,12 +410,12 @@ export class WorkerManager {
     const baseName = parts[0];
 
     let providedInstallId: string | undefined;
-    let defaultSdk = getVersions()[0].nodeVersion;
+    let defaultSdk = getVersions()[0].nodeSDK;
 
     if (parts.length > 1) {
       const lastPart = parts[parts.length - 1];
       // Check if last part is a valid SDK version
-      if (lastPart && VersionList.some((v) => v.nodeVersion === lastPart)) {
+      if (lastPart && VersionList.some((v) => v.nodeSDK === lastPart)) {
         defaultSdk = lastPart;
         // Installation ID is everything between baseName and version
         if (parts.length > 2) {
@@ -483,14 +483,14 @@ export async function getWorkers(
   workers: string[] | Record<string, string> | number,
   options: {
     env?: XmtpEnv;
-    nodeVersion?: string;
+    nodeSDK?: string;
     useVersions?: boolean;
     randomNames?: boolean;
   } = {
     env: undefined,
     useVersions: true,
     randomNames: true,
-    nodeVersion: undefined,
+    nodeSDK: undefined,
   },
 ): Promise<WorkerManager> {
   const manager = new WorkerManager(
@@ -507,8 +507,8 @@ export async function getWorkers(
           ? getRandomNames(workers)
           : getFixedNames(workers)
         : workers;
-    let descriptors = options.nodeVersion
-      ? names.map((name) => `${name}-${options.nodeVersion}`)
+    let descriptors = options.nodeSDK
+      ? names.map((name) => `${name}-${options.nodeSDK}`)
       : options.useVersions
         ? nameWithVersions(names)
         : names;

--- a/workers/versions.ts
+++ b/workers/versions.ts
@@ -81,8 +81,8 @@ export const VersionList = [
     Conversation: Conversation322,
     Dm: Dm322,
     Group: Group322,
-    nodeVersion: "3.2.2",
-    bindingsPackage: "1.3.3",
+    nodeSDK: "3.2.2",
+    nodeBindings: "1.3.3",
     auto: true,
   },
   {
@@ -90,8 +90,8 @@ export const VersionList = [
     Conversation: Conversation321,
     Dm: Dm321,
     Group: Group321,
-    nodeVersion: "3.2.1",
-    bindingsPackage: "1.3.1",
+    nodeSDK: "3.2.1",
+    nodeBindings: "1.3.1",
     auto: true,
   },
   {
@@ -99,8 +99,8 @@ export const VersionList = [
     Conversation: Conversation320,
     Dm: Dm320,
     Group: Group320,
-    nodeVersion: "3.2.0",
-    bindingsPackage: "1.3.0",
+    nodeSDK: "3.2.0",
+    nodeBindings: "1.3.0",
     auto: true,
   },
   {
@@ -108,8 +108,8 @@ export const VersionList = [
     Conversation: Conversation312,
     Dm: Dm312,
     Group: Group312,
-    nodeVersion: "3.1.2",
-    bindingsPackage: "1.2.8",
+    nodeSDK: "3.1.2",
+    nodeBindings: "1.2.8",
     auto: true,
   },
   {
@@ -117,8 +117,8 @@ export const VersionList = [
     Conversation: Conversation310,
     Dm: Dm310,
     Group: Group310,
-    nodeVersion: "3.1.1",
-    bindingsPackage: "1.2.7",
+    nodeSDK: "3.1.1",
+    nodeBindings: "1.2.7",
     auto: true,
   },
   {
@@ -126,8 +126,8 @@ export const VersionList = [
     Conversation: Conversation300,
     Dm: Dm300,
     Group: Group300,
-    nodeVersion: "3.0.1",
-    bindingsPackage: "1.2.5",
+    nodeSDK: "3.0.1",
+    nodeBindings: "1.2.5",
     auto: true,
   },
   {
@@ -135,8 +135,8 @@ export const VersionList = [
     Conversation: Conversation220,
     Dm: Dm220,
     Group: Group220,
-    nodeVersion: "2.2.1",
-    bindingsPackage: "1.2.2",
+    nodeSDK: "2.2.1",
+    nodeBindings: "1.2.2",
     auto: true,
   },
   {
@@ -144,8 +144,8 @@ export const VersionList = [
     Conversation: Conversation210,
     Dm: Dm210,
     Group: Group210,
-    nodeVersion: "2.1.0",
-    bindingsPackage: "1.2.0",
+    nodeSDK: "2.1.0",
+    nodeBindings: "1.2.0",
     auto: true,
   },
   {
@@ -153,8 +153,8 @@ export const VersionList = [
     Conversation: Conversation209,
     Dm: Dm209,
     Group: Group209,
-    nodeVersion: "2.0.9",
-    bindingsPackage: "1.1.8",
+    nodeSDK: "2.0.9",
+    nodeBindings: "1.1.8",
     auto: true,
   },
 ];
@@ -167,16 +167,16 @@ export const getVersions = (filterAuto: boolean = true) => {
 export const checkNoNameContains = (versionList: typeof VersionList) => {
   // Versions should no include - because it messes   up with the worker name-installation conversion. FIX
   for (const version of versionList) {
-    if (version.nodeVersion.includes("-")) {
-      throw new Error(`Version ${version.nodeVersion} contains -`);
-    } else if (version.bindingsPackage.includes("-")) {
-      throw new Error(`Bindings package ${version.bindingsPackage} contains -`);
+    if (version.nodeSDK.includes("-")) {
+      throw new Error(`Version ${version.nodeSDK} contains -`);
+    } else if (version.nodeBindings.includes("-")) {
+      throw new Error(`Bindings package ${version.nodeBindings} contains -`);
     }
   }
 };
 
 export const regressionClient = async (
-  nodeVersion: string,
+  nodeSDK: string,
   walletKey: `0x${string}`,
   dbEncryptionKey: Uint8Array,
   dbPath: string,
@@ -187,13 +187,13 @@ export const regressionClient = async (
   const apiUrl = apiURL;
   if (apiUrl) {
     console.debug(
-      `Creating API client with: SDK version: ${nodeVersion} walletKey: ${String(walletKey)} API URL: ${String(apiUrl)}`,
+      `Creating API client with: SDK version: ${nodeSDK} walletKey: ${String(walletKey)} API URL: ${String(apiUrl)}`,
     );
   }
 
-  const versionConfig = VersionList.find((v) => v.nodeVersion === nodeVersion);
+  const versionConfig = VersionList.find((v) => v.nodeSDK === nodeSDK);
   if (!versionConfig) {
-    throw new Error(`SDK version ${nodeVersion} not found in VersionList`);
+    throw new Error(`SDK version ${nodeSDK} not found in VersionList`);
   }
   const ClientClass = versionConfig.Client;
   let client = null;
@@ -210,7 +210,7 @@ export const regressionClient = async (
   });
 
   if (!client) {
-    throw new Error(`Failed to create client for SDK version ${nodeVersion}`);
+    throw new Error(`Failed to create client for SDK version ${nodeSDK}`);
   }
 
   return client;


### PR DESCRIPTION
### Rename `nodeVersion` parameter to `nodeSDK` and `bindingsPackage` to `nodeBindings` across CLI commands, documentation, and worker management code for clarity
This pull request renames parameter and property names throughout the codebase to improve clarity in version management. The changes affect CLI commands, documentation, worker management, and testing framework code:

- Renames `--nodeVersion` CLI flag to `--nodeSDK` in [cli/test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-c8ae179b9daddfdfc3e0fedd868f032dab62c38a4b05a65d61351708ac7b81c4) and updates all documentation examples
- Renames `nodeVersion` property to `nodeSDK` in worker management code in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) and [workers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-910db3846cf9a0d5fc1c527bde6d944858ffb53a43a6717ee43018e0ba23e793)
- Renames `bindingsPackage` property to `nodeBindings` in version configuration in [cli/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-ea7a78fb3677cc6ff5fce562c34071b321225a81244d2f2879b3d78785141f99) and [workers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-910db3846cf9a0d5fc1c527bde6d944858ffb53a43a6717ee43018e0ba23e793)
- Updates documentation in [docs/version-management.md](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-1cf00b5dc8ea5e6fdc8ccc3bb954e5ea64de1e1cb39370f168bbadbe10659686) with improved mermaid diagram and simplified best practices section
- Adds new `--nodeBindings` CLI option to [CLAUDE.md](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7) documentation

#### 📍Where to Start
Start with the CLI flag changes in [cli/test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1097/files#diff-c8ae179b9daddfdfc3e0fedd868f032dab62c38a4b05a65d61351708ac7b81c4) to understand how the `--nodeVersion` flag is renamed to `--nodeSDK` and how it affects the argument parsing logic.

----

_[Macroscope](https://app.macroscope.com) summarized e1d4d6a._