### PR TITLE
Track message timing for improved performance metrics

### DIFF
--- a/.cursor/rules/cli-usage.mdc
+++ b/.cursor/rules/cli-usage.mdc
@@ -15,9 +15,9 @@ This repository provides a comprehensive CLI interface for testing XMTP protocol
 ### Basic Command Structure
 
 ```bash
-yarn test <test_suite> [options...]              # Direct vitest execution
-yarn bot <bot_name> [args...]                    # Interactive bots
-yarn <script_name> [args...]              # Utility scripts
+yarn test <test_suite> [options...]     --env <environment> # Direct vitest execution
+yarn bot <bot_name> [args...]           --env <environment> # Interactive bots
+yarn send <args...>                     --env <environment> # Send messages
 ```
 
 ### Test Suites

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,10 +77,10 @@ yarn send --agent gm --env dev --users 200
 
 ```bash
 # Launch available bots
-yarn bot simple
-yarn bot gm-bot
-yarn bot debug
-yarn bot key-check
+yarn bot simple --env dev
+yarn bot gm-bot --env dev
+yarn bot debug --env dev
+yarn bot key-check --env dev
 ```
 
 ### Data Management

--- a/bots/README.md
+++ b/bots/README.md
@@ -16,10 +16,10 @@ Test bots for the XMTP protocol that validate functionality, automate testing sc
 
 ```bash
 # Run the debug bot
-yarn bot debug
+yarn bot debug --env dev
 
 # Run the echo bot
-yarn bot echo
+yarn bot echo --env dev
 
 # Run the GM bot
 yarn bot gm-bot

--- a/bots/echo/index.ts
+++ b/bots/echo/index.ts
@@ -14,7 +14,7 @@ const processMessage = async (
     `Received message: ${message.content as string} by ${message.senderInboxId}`,
   );
 
-  await conversation.send(`echo: ${message.content as string}`);
+  void conversation.send(`echo: ${message.content as string}`);
 };
 
 // Initialize the client with the message processor

--- a/bots/echo/index.ts
+++ b/bots/echo/index.ts
@@ -22,7 +22,6 @@ await initializeClient(processMessage, [
   {
     walletKey: process.env.WALLET_KEY as `0x${string}`,
     dbEncryptionKey: process.env.ENCRYPTION_KEY as `0x${string}`,
-    networks: ["production"],
     acceptGroups: true,
   },
 ]);

--- a/bots/helpers/xmtp-handler.ts
+++ b/bots/helpers/xmtp-handler.ts
@@ -43,7 +43,7 @@ export const DEFAULT_CORE_OPTIONS: ClientOptions = {
   walletKey: (process.env.WALLET_KEY ?? generatePrivateKey()) as `0x${string}`,
   dbEncryptionKey: process.env.ENCRYPTION_KEY ?? generateEncryptionKeyHex(),
   loggingLevel: (process.env.LOGGING_LEVEL || "error") as LogLevel,
-  networks: ["dev"],
+  networks: [process.env.XMTP_ENV ?? "local"],
   ...DEFAULT_SKILL_OPTIONS,
 };
 

--- a/cli/bot.ts
+++ b/cli/bot.ts
@@ -6,43 +6,76 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = join(__filename, "..");
 
-async function main() {
-  const botName = process.argv[2];
+interface Config {
+  botName: string;
+  env: string;
+}
 
-  if (!botName) {
-    console.error("Usage: yarn bot <bot-name>");
+function parseArgs(): Config {
+  const args = process.argv.slice(2);
+  const config: Config = {
+    botName: "",
+    env: process.env.XMTP_ENV ?? "local",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const nextArg = args[i + 1];
+
+    if (arg === "--env" && nextArg) {
+      config.env = nextArg;
+      i++;
+    } else if (!config.botName) {
+      // First non-flag argument is the bot name
+      config.botName = arg;
+    }
+  }
+
+  return config;
+}
+
+async function main() {
+  const config = parseArgs();
+
+  if (!config.botName) {
+    console.error("Usage: yarn bot <bot-name> [--env <environment>]");
     console.error(
       "Available bots: simple, gm-bot, send, echo, debug, key-check",
     );
     process.exit(1);
   }
 
-  const botPath = join(__dirname, "..", "bots", botName, "index.ts");
+  const botPath = join(__dirname, "..", "bots", config.botName, "index.ts");
 
   try {
     // Check if the bot directory exists
     const fs = await import("fs");
-    const botDir = join(__dirname, "..", "bots", botName);
+    const botDir = join(__dirname, "..", "bots", config.botName);
 
     if (!fs.existsSync(botDir)) {
       console.error(
-        `Bot '${botName}' not found. Available bots: simple, gm-bot, send, echo, debug, key-check`,
+        `Bot '${config.botName}' not found. Available bots: simple, gm-bot, send, echo, debug, key-check`,
       );
       process.exit(1);
     }
 
     if (!fs.existsSync(botPath)) {
-      console.error(`Bot '${botName}' index.ts not found at ${botPath}`);
+      console.error(`Bot '${config.botName}' index.ts not found at ${botPath}`);
       process.exit(1);
     }
 
-    console.log(`Starting bot: ${botName}`);
+    console.log(`Starting bot: ${config.botName}`);
+    console.log(`Environment: ${config.env}`);
     console.log(`Path: ${botPath}`);
 
-    // Run the bot using tsx
+    // Run the bot using tsx with environment variable
     const child = spawn("npx", ["tsx", botPath], {
       stdio: "inherit",
       cwd: process.cwd(),
+      env: {
+        ...process.env,
+        XMTP_ENV: config.env,
+      },
     });
 
     child.on("error", (error) => {

--- a/cli/bot.ts
+++ b/cli/bot.ts
@@ -69,7 +69,7 @@ async function main() {
     console.log(`Path: ${botPath}`);
 
     // Run the bot using tsx with environment variable
-    const child = spawn("npx", ["tsx", botPath], {
+    const child = spawn("npx", ["tsx", "--watch", botPath], {
       stdio: "inherit",
       cwd: process.cwd(),
       env: {

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -72,10 +72,10 @@ yarn send --agent gm --env dev --users 200
 
 ```bash
 # Launch available bots
-yarn bot simple
-yarn bot gm-bot
-yarn bot send
-yarn bot echo
+yarn bot simple --env dev
+yarn bot gm-bot --env dev
+yarn bot send --env dev
+yarn bot echo --env dev
 yarn bot debug
 yarn bot key-check
 ```

--- a/cli/send.ts
+++ b/cli/send.ts
@@ -17,7 +17,11 @@ import {
 } from "../helpers/client";
 import { getRandomInboxIds } from "../inboxes/utils";
 
-// yarn send --address 0xe89391F8911d329308B7DD122829b2110DA47eD3 --users 100 --env local --wait
+// gm-bot
+// yarn send --address 0x194c31cae1418d5256e8c58e0d08aee1046c6ed0 --env production --users 500 --wait
+
+// echo
+// yarn send --address 0x7723d790a5e00b650bf146a0961f8bb148f0450c --env production --users 500 --wait
 
 interface Config {
   userCount: number;
@@ -27,7 +31,6 @@ interface Config {
   tresshold: number;
   loggingLevel: LogLevel;
   waitForResponse: boolean;
-  useGroups: boolean;
 }
 
 function parseArgs(): Config {
@@ -40,7 +43,6 @@ function parseArgs(): Config {
     tresshold: 95,
     loggingLevel: process.env.LOGGING_LEVEL as LogLevel,
     waitForResponse: false,
-    useGroups: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -65,9 +67,6 @@ function parseArgs(): Config {
     }
     if (arg === "--wait") {
       config.waitForResponse = true;
-    }
-    if (arg === "--groups") {
-      config.useGroups = true;
     }
   }
 
@@ -254,18 +253,10 @@ async function runsendTest(config: Config): Promise<void> {
         try {
           let conversation: Conversation;
 
-          if (config.useGroups) {
-            const groupMembers = getRandomInboxIds(4);
-            conversation = (await worker.conversations.newGroup(
-              groupMembers,
-            )) as Conversation;
-          } else {
-            // Create DM
-            conversation = (await worker.conversations.newDmWithIdentifier({
-              identifier: config.address,
-              identifierKind: IdentifierKind.Ethereum,
-            })) as Conversation;
-          }
+          conversation = (await worker.conversations.newDmWithIdentifier({
+            identifier: config.address,
+            identifierKind: IdentifierKind.Ethereum,
+          })) as Conversation;
 
           if (config.waitForResponse) {
             console.log(`📡 ${i}: Setting up message stream...`);

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -15,9 +15,9 @@ This repository provides a comprehensive CLI interface for testing XMTP protocol
 ### Basic Command Structure
 
 ```bash
-yarn test <test_suite> [options...]              # Direct vitest execution
-yarn bot <bot_name> [args...]                    # Interactive bots
-yarn <script_name> [args...]              # Utility scripts
+yarn test <test_suite> [options...]     --env <environment> # Direct vitest execution
+yarn bot <bot_name> [args...]           --env <environment> # Interactive bots
+yarn send <args...>                     --env <environment> # Send messages
 ```
 
 ### Test Suites

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -49,8 +49,8 @@ yarn test datadog                     # Datadog log analysis and monitoring
 ### Bots
 
 ```bash
-yarn bot gm-bot                        # GM greeting bot
-yarn bot send 5                      # send testing with 5 concurrent users
+yarn bot gm-bot --env dev                        # GM greeting bot
+yarn bot send 5 --env dev                      # send testing with 5 concurrent users
 ```
 
 ### Scripts

--- a/workers/versions.ts
+++ b/workers/versions.ts
@@ -72,7 +72,7 @@ export {
   type GroupMember,
   type KeyPackageStatus,
   ConsentEntityType,
-} from "@xmtp/node-sdk";
+} from "@xmtp/node-sdk"; // replace with @xmtp/node-sdk 3.2.2 for specific version across all files
 
 // SDK version mappings
 export const VersionList = [


### PR DESCRIPTION
### Track message timing for improved performance metrics in the send testing tool and add environment configuration support to bot CLI
- Refactors the send testing tool in [cli/send.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1100/files#diff-f8fb94c34b7b013c8f8d15faba3a11d7f3f18838c97549c35b912573b3deef72) to track first and last message times for more accurate throughput calculation based on actual messaging time rather than total test duration, and removes group messaging support
- Adds environment configuration support to the bot CLI in [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1100/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) with `--env` parameter parsing, environment variable passing to child processes, and automatic reloading with `--watch` flag
- Updates XMTP client configuration in [bots/helpers/xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1100/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19) to use `process.env.XMTP_ENV` environment variable instead of hardcoded network values
- Updates documentation across multiple files to include `--env` parameter examples for bot commands

#### 📍Where to Start
Start with the `main` function in [cli/send.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1100/files#diff-f8fb94c34b7b013c8f8d15faba3a11d7f3f18838c97549c35b912573b3deef72) to understand the message timing tracking changes, then review the `parseArgs` function in [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1100/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) to see the environment configuration implementation.

----

_[Macroscope](https://app.macroscope.com) summarized dcc9dc6._