### PR TITLE
Remove outdated CLI overview for clarity

### DIFF
--- a/.cursor/rules/cli-usage.mdc
+++ b/.cursor/rules/cli-usage.mdc
@@ -2,17 +2,6 @@
 
 This repository provides a comprehensive CLI interface for testing XMTP protocol implementations across multiple environments and SDK versions.
 
-## Overview
-
-| Script        | Purpose              | Use Case                                     |
-| ------------- | -------------------- | -------------------------------------------- |
-| `test.ts`     | Test runner          | Run tests with retry logic                   |
-| `versions.ts` | SDK manager          | Setup multiple SDK versions for testing      |
-| `send.ts`     | send test            | Run send tests with retry logic              |
-| `revoke.ts`   | Installation manager | Revoke XMTP installations for inboxes        |
-| `gen.ts`      | Data generator       | Generate test data and inboxes               |
-| `bot.ts`      | Bot launcher         | Launch interactive bots from bots/ directory |
-
 ## Quick start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ We can test all XMTP bindings using three main applications. We use [xmtp.chat](
 - Network: Network chaos testing - see [section](./suites/networkchaos/README.md)
 - Forks: Probabilistic fork testing - see [section](./suites/forks/README.md)
 - Version management: How to manage SDK and bindings versions - see [section](./docs/version-management.md)
+- CLI: Command line interface for testing - see [section](./cli/readme.md)
 
 ## Tools & utilities
 
@@ -158,7 +159,6 @@ yarn test functional --no-fail --debug
 
 ### Resources
 
-- CLI: Command line interface for testing - see [section](./cli/readme.md)
 - Test suites: Test suites directory - [see section](https://github.com/xmtp/xmtp-qa-tools/tree/main/suites/)
 - Inboxes: Inboxes for testing - [see section](/inboxes/)
 - Networks: Work in [local](/dev/) or [multinode](/dev/multinode) network

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -2,17 +2,6 @@
 
 This repository provides a comprehensive CLI interface for testing XMTP protocol implementations across multiple environments and SDK versions.
 
-## Overview
-
-| Script        | Purpose              | Use Case                                     |
-| ------------- | -------------------- | -------------------------------------------- |
-| `test.ts`     | Test runner          | Run tests with retry logic                   |
-| `versions.ts` | SDK manager          | Setup multiple SDK versions for testing      |
-| `send.ts`     | send test            | Run send tests with retry logic              |
-| `revoke.ts`   | Installation manager | Revoke XMTP installations for inboxes        |
-| `gen.ts`      | Data generator       | Generate test data and inboxes               |
-| `bot.ts`      | Bot launcher         | Launch interactive bots from bots/ directory |
-
 ## Quick start
 
 ```bash


### PR DESCRIPTION
### Remove outdated CLI overview table from documentation files for clarity
Removes the Overview section containing a table of CLI scripts from [.cursor/rules/cli-usage.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/1109/files#diff-a292c83bcf804c2a26b973b70840ae2c7ddfc8df1ae1155a69f02825a81d5fa6) and [cli/readme.md](https://github.com/xmtp/xmtp-qa-tools/pull/1109/files#diff-342f32409d54083a9538f9a50e990595e78bfee7aa292f316b1602eed8a938f8), and moves the CLI documentation reference from the Resources section to the Documentation section in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1109/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

#### 📍Where to Start
Start with the changes in [cli/readme.md](https://github.com/xmtp/xmtp-qa-tools/pull/1109/files#diff-342f32409d54083a9538f9a50e990595e78bfee7aa292f316b1602eed8a938f8) to see the removal of the Overview section containing the CLI scripts table.

----

_[Macroscope](https://app.macroscope.com) summarized 14d4e50._