### PR TITLE
Remove unused GH_CACHE variable for cleaner metrics

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -21,7 +21,6 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
-      GH_CACHE: true
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -30,7 +30,6 @@ interface MetricTags {
   env?: string;
   region?: string;
   sdk: string;
-  GH_CACHE?: string;
   operation?: string;
   test?: string;
   country_iso_code?: string;

--- a/helpers/vitest.ts
+++ b/helpers/vitest.ts
@@ -53,19 +53,16 @@ export const setupTestLifecycle = ({
     const { testNameExtracted, operationType, operationName, members } =
       parseTestName(testName);
 
-    const values: DurationMetricTags = {
-      metric_type: "operation",
-      metric_subtype: operationType,
-      operation: operationName,
-      test: testNameExtracted,
-      GH_CACHE: process.env.GH_CACHE || "false",
-      sdk: sdk || getVersions()[0].nodeSDK,
-      installations: members,
-      members,
-    };
-
     if (sendMetrics && sendDurationMetrics) {
-      sendMetric("duration", duration, values);
+      sendMetric("duration", duration, {
+        metric_type: "operation",
+        metric_subtype: operationType,
+        operation: operationName,
+        test: testNameExtracted,
+        sdk: sdk || getVersions()[0].nodeSDK,
+        installations: members,
+        members,
+      } as DurationMetricTags);
     }
 
     // Network stats handling for performance tests
@@ -102,5 +99,11 @@ export const setupTestLifecycle = ({
 
   afterAll(async () => {
     await flushMetrics();
+    sendMetric("duration", performance.now() - start, {
+      metric_type: "test",
+      metric_subtype: "duration",
+      test: testName,
+      sdk: sdk || getVersions()[0].nodeSDK,
+    });
   });
 };


### PR DESCRIPTION
### Remove unused GH_CACHE variable from GitHub Actions workflow, MetricTags interface, and test metrics for cleaner metrics
- Removes the `GH_CACHE` environment variable from the GitHub Actions workflow configuration in [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1110/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3)
- Removes the `GH_CACHE` optional property from the `MetricTags` interface in [datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1110/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3)
- Refactors metric tag creation in [vitest.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1110/files#diff-51c9bb2d3f52c040ff7d70ba679c7ae32efe962784a51fc99c69d3f7983909b4) by inlining the tags object and removing the `GH_CACHE` property, while adding a new duration metric in the `afterAll` hook that tracks total test duration with metric type 'test' and subtype 'duration'

#### 📍Where to Start
Start with the GitHub Actions workflow configuration in [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1110/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) to see the removal of the environment variable, then review the interface changes in [datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1110/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3).

----

_[Macroscope](https://app.macroscope.com) summarized 29581d3._