### PR TITLE
Add custom timeout to message stream verification

### DIFF
--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -281,6 +281,7 @@ export async function verifyMessageStream(
   receivers: Worker[],
   count = 1,
   messageTemplate: string = "gm-{i}-{randomSuffix}",
+  customTimeout?: number,
 ): Promise<VerifyStreamResult> {
   const randomSuffix = Math.random().toString(36).substring(2, 15);
   receivers.forEach((worker) => {
@@ -290,7 +291,7 @@ export async function verifyMessageStream(
   return collectAndTimeEventsWithStats({
     receivers,
     startCollectors: (r) =>
-      r.worker.collectMessages(group.id, count, ["text"], 60000), // 60s timeout
+      r.worker.collectMessages(group.id, count, ["text"], customTimeout),
     triggerEvents: async () => {
       const sent: { content: string; sentAt: number }[] = [];
       for (let i = 0; i < count; i++) {

--- a/suites/bugs/stitch/stitch.test.ts
+++ b/suites/bugs/stitch/stitch.test.ts
@@ -26,10 +26,13 @@ describe(testName, () => {
   });
 
   it("verify message delivery works after DM stitching", async () => {
-    // Send a test message and verify delivery
-    const verifyResult = await verifyMessageStream(dm, [receiver]);
-
-    // Verify message delivery works after stitching
+    const verifyResult = await verifyMessageStream(
+      dm,
+      [receiver],
+      1,
+      undefined,
+      2000,
+    );
     expect(verifyResult.allReceived).toBe(true);
     expect(verifyResult.receptionPercentage).toBeGreaterThan(95);
   });
@@ -38,14 +41,17 @@ describe(testName, () => {
     // Create fresh random1 client
     const freshrandom1 = await getWorkers(["random1-fresh"]);
     const random1Fresh = freshrandom1.get("random1", "fresh")!;
-
     const testDm = (await random1Fresh.client.conversations.newDm(
       receiver.client.inboxId,
     )) as Dm;
     console.log(testDm.id);
-    await receiver.client.conversations.syncAll();
-    await random1Fresh.client.conversations.syncAll();
-    const verifyResult = await verifyMessageStream(testDm, [receiver]);
+    const verifyResult = await verifyMessageStream(
+      testDm,
+      [receiver],
+      1,
+      undefined,
+      2000,
+    );
 
     // Verify message delivery works after stitching
     expect(verifyResult.allReceived).toBe(true);

--- a/suites/bugs/stitch/stitch.test.ts
+++ b/suites/bugs/stitch/stitch.test.ts
@@ -43,7 +43,8 @@ describe(testName, () => {
       receiver.client.inboxId,
     )) as Dm;
     console.log(testDm.id);
-
+    await receiver.client.conversations.syncAll();
+    await random1Fresh.client.conversations.syncAll();
     const verifyResult = await verifyMessageStream(testDm, [receiver]);
 
     // Verify message delivery works after stitching

--- a/suites/delivery.test.ts
+++ b/suites/delivery.test.ts
@@ -28,6 +28,8 @@ describe(testName, async () => {
       group,
       workers.getAllButCreator(),
       MESSAGE_COUNT,
+      undefined,
+      60000, // 60s timeout
     );
 
     sendMetric("response", stats.averageEventTiming, {


### PR DESCRIPTION
### Add custom timeout parameter to `verifyMessageStream` function in helpers/streams.ts to replace hardcoded 60-second timeout
- The `verifyMessageStream` function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1115/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) now accepts an optional `customTimeout` parameter that replaces the previously hardcoded 60000ms timeout value
- The stitch test in [suites/bugs/stitch/stitch.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1115/files#diff-b85b748a63dc5d6412c6d477f882195d7721e883820fe1c56a8aa1f7cf383cb8) adds explicit `syncAll()` calls for both receiver and random1Fresh clients before message stream verification
- The delivery test in [suites/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1115/files#diff-5ee4d09e7f113dc1e0a7f3562761bd9ecc34c227c2691254878e6e9f1091da78) explicitly passes a 60000ms timeout value to maintain the same timeout behavior

#### 📍Where to Start
Start with the `verifyMessageStream` function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1115/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to understand how the custom timeout parameter is implemented and passed to the `collectMessages` method.

----

_[Macroscope](https://app.macroscope.com) summarized 45a522d._