### PR TITLE
Set agent status to inactive for maintenance purposes

### DIFF
--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -76,7 +76,7 @@
     "baseName": "onit.base.eth",
     "address": "0xE9C89b50f3b947125FdBCdF8FBff35b9f38fB0C4",
     "sendMessage": "hey there how are you?",
-    "live": true,
+    "live": false,
     "networks": ["production"],
     "slackChannel": "#onit-alerts",
     "respondOnTagged": true


### PR DESCRIPTION
### Disable agents system by setting live property to false in agents configuration for maintenance purposes
This change modifies the agents configuration by setting the `live` property from `true` to `false` in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/1123/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5), which disables the agents system.

#### 📍Where to Start
Start by reviewing the configuration change in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/1123/files#diff-104b61e4cdd2c05c36b75a31b7654ce854bd17d3992e27e324571bae2cf152e5) where the `live` property has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized 6932399._