### PR TITLE
Refactor Slack notification action for consistency

### DIFF
--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -1,31 +1,28 @@
-name: 'Slack Notification'
-description: 'Send Slack notification for workflow status'
+name: "Slack Notification"
+description: "Send Slack notification for workflow status"
 inputs:
   workflow-name:
-    description: 'Name of the workflow'
+    description: "Name of the workflow"
     required: true
   status:
-    description: 'Status of the workflow (success, failure, cancelled)'
+    description: "Status of the workflow (success, failure, cancelled)"
     required: false
     default: ${{ job.status }}
-  slack-bot-token:
-    description: 'Slack bot token'
-    required: true
   slack-channel:
-    description: 'Slack channel to send notification to'
+    description: "Slack channel to send notification to"
     required: false
-    default: 'notify-qa-tools-test'
+    default: "notify-qa-tools-test"
   mention-user:
-    description: 'User to mention in the notification'
+    description: "User to mention in the notification"
     required: false
-    default: 'fabri'
+    default: "fabri"
   notify-on-success:
-    description: 'Whether to send notifications for successful workflows'
+    description: "Whether to send notifications for successful workflows"
     required: false
-    default: 'false'
+    default: "false"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Send Slack notification
       shell: bash
@@ -33,16 +30,16 @@ runs:
         # Set workflow status based on input or job status
         STATUS="${{ inputs.status }}"
         NOTIFY_ON_SUCCESS="${{ inputs.notify-on-success }}"
-        
+
         if [ -z "$STATUS" ]; then
           STATUS="success"
         fi
-        
+
         if [ "$STATUS" = "success" ] && [ "$NOTIFY_ON_SUCCESS" != "true" ]; then
           echo "Skipping notification for successful workflow (notify-on-success=false)"
           exit 0
         fi
-        
+
         # Determine status emoji and message
         if [ "$STATUS" = "failure" ]; then
           EMOJI="❌"
@@ -61,25 +58,25 @@ runs:
           STATUS_TEXT="$STATUS"
           MENTION_USER="<@${{ inputs.mention-user }}>"
         fi
-        
+
         # Build the Slack message
         WORKFLOW_NAME="${{ inputs.workflow-name }}"
         TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        
+
         MESSAGE="*Workflow*: ${WORKFLOW_NAME} ${STATUS_TEXT} ${EMOJI} ${MENTION_USER}
         *Timestamp*: \`${TIMESTAMP}\`
         *env*: \`${XMTP_ENV:-unknown}\` | *region*: \`${REGION:-unknown}\`
         <${RUN_URL}|View run>"
-        
+
         # Send to Slack
         curl -X POST https://slack.com/api/chat.postMessage \
-          -H "Authorization: Bearer ${{ inputs.slack-bot-token }}" \
+          -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
           -H "Content-Type: application/json" \
           -d "{
             \"channel\": \"${{ inputs.slack-channel }}\",
             \"text\": \"${MESSAGE}\",
             \"mrkdwn\": true
           }"
-        
+
         echo "Slack notification sent for workflow: ${WORKFLOW_NAME} (${STATUS_TEXT})"

--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -20,7 +20,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
       LOG_LEVEL: "info"
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -41,5 +41,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Agent health (${{ matrix.test }}, ${{ matrix.env }})'
+          workflow-name: "Agent health (${{ matrix.test }}, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Agents (tagged, ${{ matrix.env }})'
+          workflow-name: "Agents (tagged, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
 
   agents-untagged:
@@ -51,7 +51,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -72,5 +72,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Agents (untagged, ${{ matrix.env }})'
+          workflow-name: "Agents (untagged, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Browser.yml
+++ b/.github/workflows/Browser.yml
@@ -20,7 +20,7 @@ jobs:
       REGION: ${{ vars.REGION }}
       LOGGING_LEVEL: "off"
       LOG_LEVEL: "info"
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env
@@ -40,5 +40,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Browser (${{ matrix.test }}, ${{ matrix.env }})'
+          workflow-name: "Browser (${{ matrix.test }}, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Delivery.yml
+++ b/.github/workflows/Delivery.yml
@@ -20,7 +20,7 @@ jobs:
       REGION: ${{ vars.REGION }}
       DELIVERY_AMOUNT: 100
       ERROR_TRESHOLD: 90
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env
@@ -40,5 +40,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Delivery (${{ matrix.test }}, ${{ matrix.env }})'
+          workflow-name: "Delivery (${{ matrix.test }}, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -38,7 +38,6 @@ jobs:
     if: needs.detect-version-bump.outputs.version_changed == 'true'
     runs-on: ubuntu-latest
     env:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       REGION: ${{ vars.REGION }}
     steps:
       - name: Checkout code
@@ -122,5 +121,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Deploy'
+          workflow-name: "Deploy"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Forks.yml
+++ b/.github/workflows/Forks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
       XMTP_ENV: local
     steps:
       - uses: actions/checkout@v4
@@ -50,5 +50,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Forks'
+          workflow-name: "Forks"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -20,7 +20,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       XMTP_ENV: ${{ matrix.env }}
       REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env

--- a/.github/workflows/Performance-L.yml
+++ b/.github/workflows/Performance-L.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -19,10 +19,6 @@ jobs:
         # test: [functional] # full functional test
         # test: [performance] # performance test with more large groups
         # test: [dms] # health check
-    env:
-      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-
-      REGION: ${{ vars.REGION }}
     steps:
       - uses: actions/checkout@v4
 
@@ -33,6 +29,11 @@ jobs:
           echo ""
           echo "Full IP info:"
           curl -s https://ipinfo.io/json | jq .
+
+      - name: Force failure for Slack notification test
+        run: |
+          echo "Forcing failure to test Slack notification"
+          exit 1
 
       - name: Setup test env
         uses: ./.github/actions/xmtp-test-setup

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -2,7 +2,7 @@ name: Wildcard
 description: "Manual PR verification workflow - supports functional and performance tests"
 
 on:
-  #pull_request:
+  pull_request:
   schedule:
     - cron: "0 0 1 1 *"
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
         # test: [dms] # health check
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
       REGION: ${{ vars.REGION }}
     steps:
       - uses: actions/checkout@v4
@@ -57,5 +57,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Wildcard (${{ matrix.test }}, ${{ matrix.env }})'
+          workflow-name: "Wildcard (${{ matrix.test }}, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/validate-agents-repo.yml
+++ b/.github/workflows/validate-agents-repo.yml
@@ -10,7 +10,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       REGION: ${{ vars.REGION }}
 
     steps:
@@ -58,5 +57,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Validate agents repo'
+          workflow-name: "Validate agents repo"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/validate-code-quality.yml
+++ b/.github/workflows/validate-code-quality.yml
@@ -11,7 +11,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       REGION: ${{ vars.REGION }}
     steps:
       - uses: actions/checkout@v4
@@ -41,5 +40,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Validate code quality'
+          workflow-name: "Validate code quality"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/validate-package-compatibility.yml
+++ b/.github/workflows/validate-package-compatibility.yml
@@ -10,7 +10,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     env:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       REGION: ${{ vars.REGION }}
     strategy:
       fail-fast: false
@@ -106,5 +105,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Validate package compatibility (${{ matrix.node-version }}, ${{ matrix.package-manager }})'
+          workflow-name: "Validate package compatibility (${{ matrix.node-version }}, ${{ matrix.package-manager }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/validate-qa-repo.yml
+++ b/.github/workflows/validate-qa-repo.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
 
     steps:
@@ -44,5 +44,5 @@ jobs:
         if: failure() || cancelled()
         uses: ./.github/actions/slack-notification
         with:
-          workflow-name: 'Validate QA repo'
+          workflow-name: "Validate QA repo"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/cli/test.ts
+++ b/cli/test.ts
@@ -81,7 +81,9 @@ function runAnsiForksAndReport(options: TestOptions): void {
       if (fs.existsSync(logsDir)) {
         const forkCount = fs.readdirSync(logsDir).length;
         console.info(`Found ${forkCount} forks in logs/cleaned`);
-
+        if (forkCount > 0) {
+          process.exit(1);
+        }
         // Remove the cleaned folder if it's empty
         if (forkCount === 0) {
           fs.rmdirSync(logsDir);


### PR DESCRIPTION
### Refactor Slack notification action to access bot token directly from GitHub secrets instead of requiring it as an input parameter
- Modifies the Slack notification action in [action.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1126/files#diff-053f878227713988ac597ef2eb139fa0b8dd04d5c697713df8bdad0e895afe20) to access `SLACK_BOT_TOKEN` directly from GitHub secrets context instead of accepting it as an input parameter
- Removes `SLACK_BOT_TOKEN` environment variables from job-level configurations across multiple GitHub workflow files
- Changes string literal formatting from single quotes to double quotes throughout workflow files
- Adds process exit with code 1 in [test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1126/files#diff-c8ae179b9daddfdfc3e0fedd868f032dab62c38a4b05a65d61351708ac7b81c4) when fork count exceeds 0
- Enables pull request trigger and adds intentional failure step in [Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1126/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085) for testing Slack notifications

#### 📍Where to Start
Start with the Slack notification action definition in [action.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1126/files#diff-053f878227713988ac597ef2eb139fa0b8dd04d5c697713df8bdad0e895afe20) to understand how the token access mechanism has changed from input parameter to direct secrets access.

----

_[Macroscope](https://app.macroscope.com) summarized 991781b._