### PR TITLE
Add test for new conversation stream verification

### DIFF
--- a/suites/functional/streams.test.ts
+++ b/suites/functional/streams.test.ts
@@ -22,7 +22,12 @@ describe(testName, async () => {
   setupTestLifecycle({ testName });
   let group: Group;
   let workers = await getWorkers(5);
-
+  it("conversations: new conversation stream", async () => {
+    const verifyResult = await verifyConversationStream(workers.getCreator(), [
+      workers.getReceiver(),
+    ]);
+    expect(verifyResult.allReceived).toBe(true);
+  });
   it("membership: member addition stream", async () => {
     group = await workers.createGroupBetweenAll();
     const verifyResult = await verifyMembershipStream(
@@ -76,13 +81,6 @@ describe(testName, async () => {
       group,
       workers.getAllButCreator(),
     );
-    expect(verifyResult.allReceived).toBe(true);
-  });
-
-  it("conversations: new conversation stream", async () => {
-    const verifyResult = await verifyConversationStream(workers.getCreator(), [
-      workers.getReceiver(),
-    ]);
     expect(verifyResult.allReceived).toBe(true);
   });
 


### PR DESCRIPTION
### Reorder conversation stream test case to beginning of test suite in streams.test.ts
The test case `conversations: new conversation stream` has been moved from its original position near the end of the test suite to the beginning, right after the setup code in [streams.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1134/files#diff-1bdd93e6cf68b6ccb536b4b88ae40180332d20b308276731a36d7347512f52a3). The content and functionality of the test case remains unchanged.

#### 📍Where to Start
Start with the reordered test case `conversations: new conversation stream` at the beginning of [streams.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1134/files#diff-1bdd93e6cf68b6ccb536b4b88ae40180332d20b308276731a36d7347512f52a3).

----

_[Macroscope](https://app.macroscope.com) summarized 2c538eb._