### PR TITLE
Enable scheduled runs for functional tests

### DIFF
--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -18,7 +18,6 @@ jobs:
         env: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-      XMTP_ENV: ${{ matrix.env }}
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:

--- a/.github/workflows/Functional.yml
+++ b/.github/workflows/Functional.yml
@@ -2,9 +2,9 @@ name: Functional
 description: "last 3 versions of the library"
 
 on:
-  pull_request:
-  # schedule:
-  #   - cron: "25 */2 * * *" # Runs every 2 hours at 25 minutes past
+  #pull_request:
+  schedule:
+    - cron: "25 */2 * * *" # Runs every 2 hours at 25 minutes past
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Change functional tests workflow from pull request trigger to scheduled execution every 2 hours at 25 minutes past the hour
The GitHub workflow configuration modifies the trigger mechanism and environment setup for functional tests. The workflow removes pull request-based execution and implements scheduled runs every 2 hours at 25 minutes past the hour using a cron expression. Additionally, the `XMTP_ENV` environment variable that was previously set to the matrix environment value is removed from the job configuration in [.github/workflows/Functional.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1139/files#diff-a1f32d9141b58464309cfc532a2528f90960df9b7ec194da3b443710e8805b88).

#### 📍Where to Start
Start with the trigger configuration changes in [.github/workflows/Functional.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1139/files#diff-a1f32d9141b58464309cfc532a2528f90960df9b7ec194da3b443710e8805b88) to understand how the workflow execution timing has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized c11c591._