### PR TITLE
Enable pull request trigger for performance workflow

### DIFF
--- a/.github/workflows/Performance-L.yml
+++ b/.github/workflows/Performance-L.yml
@@ -2,7 +2,7 @@ name: Performance Large
 description: "performance of large groups"
 
 on:
-  pull_request:
+  #pull_request:
   schedule:
     - cron: "0 */4 * * *" # Runs every 4 hours at the top of the hour
   workflow_dispatch:


### PR DESCRIPTION
### Fix sleep command arithmetic in performance workflow to use shell expansion instead of GitHub Actions expression syntax
The change modifies the `sleep` command in [.github/workflows/Performance-L.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1149/files#diff-63954d4ae90a082f800aab15243eca2327548a76825c6283bfce75c8d81bf64e) to use shell arithmetic expansion `$(( ${{ matrix.delay_minutes }} * 60 ))` instead of GitHub Actions expression syntax `${{ matrix.delay_minutes * 60 }}` for calculating the delay in seconds.

#### 📍Where to Start
Start with the modified `sleep` command in [.github/workflows/Performance-L.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1149/files#diff-63954d4ae90a082f800aab15243eca2327548a76825c6283bfce75c8d81bf64e).

----

_[Macroscope](https://app.macroscope.com) summarized a5f63d4._