### PR TITLE
Refactor documentation for clarity on workers usage

### DIFF
--- a/.cursor/rules/testing-framework.mdc
+++ b/.cursor/rules/testing-framework.mdc
@@ -528,7 +528,7 @@ describe(testName, async () => {
 });
 ```
 
-## getWorkers API
+## Workers
 
 The `getWorkers` function has three input modes with optional configuration:
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -158,7 +158,7 @@ Link to test code [../suites/functional/browser.test.ts](../suites/functional/br
 - `conversation stream for new member`
 - `new installation and message stream`
 
-## 5. Large groups (`performance.test.ts`)
+## 5. Large groups
 
 **Purpose**: Validates scalability and performance at scale (50-250 members).
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -71,11 +71,11 @@ Link to test code [../suites/delivery.test.ts](../suites/delivery.test.ts)
 
 Link to test code [../suites/functional/clients.test.ts](../suites/functional/clients.test.ts)
 
-- `validation and key package status`
-- `inbox state from external inbox IDs`
 - `downgrade last versions`
+- `validation and key package status`
+- `inbox state`
+- `installations`
 - `upgrade last versions`
-- `shared identity and separate storage`
 
 ### Content handling
 
@@ -93,12 +93,6 @@ Link to test code [../suites/functional/debug.test.ts](../suites/functional/debu
 - `detect potential forks in group state`
 - `debug info after metadata changes`
 - `debug info structure completeness`
-
-### Installation management
-
-Link to test code [../suites/functional/installations.test.ts](../suites/functional/installations.test.ts)
-
-- `shared identity and separate storage`
 
 ### Metadata operations
 
@@ -121,7 +115,7 @@ Link to test code [../suites/functional/permissions.test.ts](../suites/functiona
 - `admin can remove other members`
 - `super admin can manage other admins`
 
-### Stream validation
+### Streams
 
 Link to test code [../suites/functional/streams.test.ts](../suites/functional/streams.test.ts)
 


### PR DESCRIPTION
### Refactor documentation for clarity on workers usage by restructuring headings and content organization across testing framework rules, monitoring documentation, and Workers README
This pull request restructures documentation across three files to improve clarity and organization:

- Updates section heading from "getWorkers API" to "Workers" in [.cursor/rules/testing-framework.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/1152/files#diff-6cb7d5467068aef81ad7c4b1470eb736dae13ba1b56523e17a6901a834507738)
- Reorganizes test categories in [docs/monitoring.md](https://github.com/xmtp/xmtp-qa-tools/pull/1152/files#diff-5451393354374ef994bc816d1c0a86459be726bd231dc37b4385707be6b56921) by reordering client management items, removing the "Installation management" section, and renaming "Stream validation" to "Streams"
- Completely rewrites [workers/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1152/files#diff-7869f58a0c6c87cd3f01d427aab93e4a7d88d3566f8296b9cb181224da759a52) with a more concise structure focused on the `getWorkers` function, replacing detailed sections with streamlined content covering input modes, configuration options, and common usage patterns

#### 📍Where to Start
Start with the rewritten [workers/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1152/files#diff-7869f58a0c6c87cd3f01d427aab93e4a7d88d3566f8296b9cb181224da759a52) as it contains the most substantial changes, moving from detailed examples to a more focused structure around the `getWorkers` function.

----

_[Macroscope](https://app.macroscope.com) summarized caa7783._