### PR TITLE
Reduce performance test timeout for efficiency

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -2,7 +2,7 @@ name: Performance
 description: "performance "
 
 on:
-  pull_request:
+  #pull_request:
   schedule:
     - cron: "30 * * * *" # Runs every hour at 30 minutes past (30+ min separation from Large at :00)
   workflow_dispatch:


### PR DESCRIPTION
### Reduce performance test timeout from 30 to 10 minutes and consolidate matrix size configuration to single '5-10-50' value in GitHub workflow
The GitHub Actions performance testing workflow [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1165/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) modifies timeout and matrix configuration settings:

- Reduces `timeout-minutes` from 30 to 10 minutes for workflow execution
- Consolidates matrix `size` configuration from two separate values ('5-10' and '50-100') to single '5-10-50' value
- Removes `include` section that previously defined `delay_minutes` values (0 minutes for '5-10' and 5 minutes for '50-100')

#### 📍Where to Start
Start with the workflow configuration changes in [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1165/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) to review the timeout and matrix modifications.

----

_[Macroscope](https://app.macroscope.com) summarized e44604c._