### PR TITLE
Add CLI for managing XMTP installations and messaging

### DIFF
--- a/cli/bot.ts
+++ b/cli/bot.ts
@@ -119,8 +119,8 @@ async function main() {
       process.exit(1);
     });
 
-    child.on("exit", (code) => {
-      process.exit(code ?? 0);
+    child.on("exit", () => {
+      process.exit(0);
     });
   } catch (error) {
     console.error("Error:", error);

--- a/cli/installations.ts
+++ b/cli/installations.ts
@@ -1,0 +1,351 @@
+import { IdentifierKind, type XmtpEnv } from "@workers/versions";
+import "dotenv/config";
+import {
+  createSigner,
+  generateEncryptionKeyHex,
+  getEncryptionKeyFromHex,
+} from "@helpers/client";
+import { Client } from "@xmtp/node-sdk";
+import { generatePrivateKey } from "viem/accounts";
+
+interface Config {
+  env: string;
+  target?: string;
+  message?: string;
+  name?: string;
+  list: boolean;
+  revoke?: string;
+  create: boolean;
+  load?: string;
+  walletKey?: string;
+  encryptionKey?: string;
+}
+
+function showHelp() {
+  console.log(`
+XMTP Installations CLI - Manage installations and send messages
+
+USAGE:
+  yarn installations [options]
+
+OPTIONS:
+  --create                    Create a new installation
+  --name <name>              Name for the installation (default: random)
+  --target <address>         Target wallet address to send message to
+  --message <text>           Message to send to target
+  --list                     List all installations
+  --revoke <installation-id> Revoke a specific installation
+  --load <name>              Load existing installation by name
+  --wallet-key <key>         Wallet private key (for loading existing installation)
+  --encryption-key <key>     Encryption key (for loading existing installation)
+  --env <environment>        XMTP environment (local, dev, production) [default: production]
+  -h, --help                 Show this help message
+
+EXAMPLES:
+  # Create a new installation
+  yarn installations --create
+
+  # Create installation with custom name
+  yarn installations --create --name "my-installation"
+
+  # Create installation and send message
+  yarn installations --create --target 0x1234... --message "Hello!"
+
+  # List all installations
+  yarn installations --list
+
+  # Load existing installation by name
+  yarn installations --load "my-installation"
+
+  # Send message using saved installation
+  yarn installations --load "my-installation" --target 0x1234... --message "Hello!"
+
+  # Send message using provided keys
+  yarn installations --wallet-key 0x... --encryption-key ... --target 0x1234... --message "Hello!"
+
+  # Revoke an installation
+  yarn installations --revoke abc123...
+
+ENVIRONMENT VARIABLES:
+  XMTP_ENV                   Default environment
+
+For more information, see: cli/readme.md
+`);
+}
+
+function parseArgs(): Config {
+  const args = process.argv.slice(2);
+  const config: Config = {
+    env: process.env.XMTP_ENV ?? "production",
+    list: false,
+    create: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const nextArg = args[i + 1];
+
+    if (arg === "--help" || arg === "-h") {
+      showHelp();
+      process.exit(0);
+    } else if (arg === "--create") {
+      config.create = true;
+    } else if (arg === "--name" && nextArg) {
+      config.name = nextArg;
+      i++;
+    } else if (arg === "--target" && nextArg) {
+      config.target = nextArg;
+      i++;
+    } else if (arg === "--message" && nextArg) {
+      config.message = nextArg;
+      i++;
+    } else if (arg === "--list") {
+      config.list = true;
+    } else if (arg === "--revoke" && nextArg) {
+      config.revoke = nextArg;
+      i++;
+    } else if (arg === "--env" && nextArg) {
+      config.env = nextArg;
+      i++;
+    } else if (arg === "--load" && nextArg) {
+      config.load = nextArg;
+      i++;
+    } else if (arg === "--wallet-key" && nextArg) {
+      config.walletKey = nextArg;
+      i++;
+    } else if (arg === "--encryption-key" && nextArg) {
+      config.encryptionKey = nextArg;
+      i++;
+    }
+  }
+
+  // Validation
+  if (
+    !config.create &&
+    !config.list &&
+    !config.revoke &&
+    !config.target &&
+    !config.load
+  ) {
+    console.error(
+      "❌ Error: Must specify --create, --list, --revoke, --target, or --load",
+    );
+    process.exit(1);
+  }
+
+  if (config.message && !config.target) {
+    console.error("❌ Error: --message requires --target");
+    process.exit(1);
+  }
+
+  return config;
+}
+
+async function createInstallation(config: Config): Promise<void> {
+  console.log(`🔧 Creating new installation on ${config.env}...`);
+
+  // Generate keys
+  const walletKey = generatePrivateKey();
+  const encryptionKey = generateEncryptionKeyHex();
+
+  // Create signer and client
+  const signer = createSigner(walletKey);
+  const dbEncryptionKey = getEncryptionKeyFromHex(encryptionKey);
+
+  const client = await Client.create(signer, {
+    dbEncryptionKey,
+    env: config.env as XmtpEnv,
+  });
+
+  const identifier = await signer.getIdentifier();
+  console.log(`✅ Installation created successfully!`);
+  console.log(`📋 Installation ID: ${client.installationId}`);
+  console.log(`📬 Inbox ID: ${client.inboxId}`);
+  console.log(`🔑 Wallet Address: ${identifier.identifier}`);
+  console.log(`\n💾 Keys (save these for future use):`);
+  console.log(`WALLET_KEY=${walletKey}`);
+  console.log(`ENCRYPTION_KEY=${encryptionKey}`);
+
+  // Save to file if name provided
+  if (config.name) {
+    const fs = await import("fs");
+    const path = await import("path");
+
+    const dataDir = path.resolve(".data/installations");
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+
+    const filePath = path.join(dataDir, `${config.name}.json`);
+    const data = {
+      name: config.name,
+      installationId: client.installationId,
+      inboxId: client.inboxId,
+      walletKey,
+      encryptionKey,
+      address: identifier.identifier,
+      env: config.env,
+      createdAt: new Date().toISOString(),
+    };
+
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+    console.log(`💾 Saved to: ${filePath}`);
+  }
+
+  // Send message if target specified
+  if (config.target && config.message) {
+    await sendMessage(client, config.target, config.message);
+  }
+}
+
+async function sendMessage(
+  client: Client,
+  target: string,
+  message: string,
+): Promise<void> {
+  console.log(`📤 Sending message to ${target}...`);
+
+  try {
+    // Create conversation
+    const conversation = await client.conversations.newDmWithIdentifier({
+      identifier: target,
+      identifierKind: IdentifierKind.Ethereum,
+    });
+
+    // Send message
+    const sendStart = Date.now();
+    await conversation.send(message);
+    const sendTime = Date.now() - sendStart;
+
+    console.log(`✅ Message sent successfully in ${sendTime}ms`);
+    console.log(`💬 Message: "${message}"`);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`❌ Failed to send message: ${errorMessage}`);
+  }
+}
+
+async function listInstallations(): Promise<void> {
+  console.log(`📋 Listing installations...`);
+
+  const fs = await import("fs");
+  const path = await import("path");
+
+  const dataDir = path.resolve(".data/installations");
+  if (!fs.existsSync(dataDir)) {
+    console.log(`📁 No installations directory found at ${dataDir}`);
+    return;
+  }
+
+  const files = fs
+    .readdirSync(dataDir)
+    .filter((file) => file.endsWith(".json"));
+
+  if (files.length === 0) {
+    console.log(`📁 No saved installations found`);
+    return;
+  }
+
+  console.log(`📋 Found ${files.length} installation(s):\n`);
+
+  for (const file of files) {
+    const filePath = path.join(dataDir, file);
+    const data = JSON.parse(fs.readFileSync(filePath, "utf8"));
+
+    console.log(`📁 ${data.name || file.replace(".json", "")}`);
+    console.log(`   Installation ID: ${data.installationId}`);
+    console.log(`   Inbox ID: ${data.inboxId}`);
+    console.log(`   Address: ${data.address}`);
+    console.log(`   Environment: ${data.env}`);
+    console.log(`   Created: ${data.createdAt}`);
+    console.log("");
+  }
+}
+
+function revokeInstallation(installationId: string): void {
+  console.log(`🗑️  Revoking installation ${installationId}...`);
+
+  // This would require the original keys to revoke
+  // For now, just show instructions
+  console.log(
+    `⚠️  To revoke an installation, you need the original wallet key and encryption key.`,
+  );
+  console.log(`📋 Installation ID: ${installationId}`);
+  console.log(`💡 Use the saved keys from when the installation was created.`);
+}
+
+async function loadInstallation(config: Config): Promise<Client> {
+  if (config.load) {
+    // Load from saved file
+    const fs = await import("fs");
+    const path = await import("path");
+
+    const dataDir = path.resolve(".data/installations");
+    const filePath = path.join(dataDir, `${config.load}.json`);
+
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`Installation "${config.load}" not found`);
+    }
+
+    const data = JSON.parse(fs.readFileSync(filePath, "utf8")) as {
+      name: string;
+      walletKey: string;
+      encryptionKey: string;
+      env: string;
+    };
+    console.log(`📂 Loading installation: ${data.name}`);
+
+    const signer = createSigner(data.walletKey);
+    const dbEncryptionKey = getEncryptionKeyFromHex(data.encryptionKey);
+
+    return await Client.create(signer, {
+      dbEncryptionKey,
+      env: data.env as XmtpEnv,
+    });
+  } else if (config.walletKey && config.encryptionKey) {
+    // Load from provided keys
+    console.log(`🔑 Loading installation from provided keys...`);
+
+    const signer = createSigner(config.walletKey);
+    const dbEncryptionKey = getEncryptionKeyFromHex(config.encryptionKey);
+
+    return await Client.create(signer, {
+      dbEncryptionKey,
+      env: config.env as XmtpEnv,
+    });
+  } else {
+    throw new Error(
+      "Must provide either --load <name> or both --wallet-key and --encryption-key",
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const config = parseArgs();
+
+  try {
+    if (config.create) {
+      await createInstallation(config);
+    } else if (config.list) {
+      await listInstallations();
+    } else if (config.revoke) {
+      revokeInstallation(config.revoke);
+    } else if (config.target && config.message) {
+      // Load existing installation and send message
+      const client = await loadInstallation(config);
+      await sendMessage(client, config.target, config.message);
+    } else if (config.load) {
+      // Just load and show installation info
+      const client = await loadInstallation(config);
+      console.log(`✅ Installation loaded successfully!`);
+      console.log(`📋 Installation ID: ${client.installationId}`);
+      console.log(`📬 Inbox ID: ${client.inboxId}`);
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error(`❌ Error: ${errorMessage}`);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -4,17 +4,18 @@ A comprehensive CLI for testing XMTP protocol implementations across environment
 
 ## Quick Reference
 
-| Command                                     | Purpose               | Help                      |
-| ------------------------------------------- | --------------------- | ------------------------- |
-| `yarn test <suite>`                         | Run test suites       | `yarn test --help`        |
-| `yarn send --target <addr> --users <count>` | Test message delivery | `yarn send --help`        |
-| `yarn bot <name>`                           | Run interactive bots  | `yarn bot --help`         |
-| `yarn gen`                                  | Generate test data    | `yarn gen --help`         |
-| `yarn versions`                             | Manage SDK versions   | `yarn versions --help`    |
-| `yarn revoke <inbox-id>`                    | Revoke installations  | `yarn revoke --help`      |
-| `yarn groups`                               | Create DMs/groups     | `yarn groups --help`      |
-| `yarn permissions`                          | Manage permissions    | `yarn permissions --help` |
-| `yarn mock`                                 | Mock client           | `yarn mock --help`        |
+| Command                                     | Purpose               | Help                        |
+| ------------------------------------------- | --------------------- | --------------------------- |
+| `yarn test <suite>`                         | Run test suites       | `yarn test --help`          |
+| `yarn send --target <addr> --users <count>` | Test message delivery | `yarn send --help`          |
+| `yarn installations`                        | Manage installations  | `yarn installations --help` |
+| `yarn bot <name>`                           | Run interactive bots  | `yarn bot --help`           |
+| `yarn gen`                                  | Generate test data    | `yarn gen --help`           |
+| `yarn versions`                             | Manage SDK versions   | `yarn versions --help`      |
+| `yarn revoke <inbox-id>`                    | Revoke installations  | `yarn revoke --help`        |
+| `yarn groups`                               | Create DMs/groups     | `yarn groups --help`        |
+| `yarn permissions`                          | Manage permissions    | `yarn permissions --help`   |
+| `yarn mock`                                 | Mock client           | `yarn mock --help`          |
 
 ## Core Commands
 
@@ -58,6 +59,40 @@ yarn send [options]
 - `--users <count>` - Number of users [default: 5]
 - `--tresshold <percent>` - Success threshold [default: 95]
 - `--wait` - Wait for responses
+
+### Installations Command
+
+```bash
+yarn installations [options]
+```
+
+**Options:**
+
+- `--create` - Create a new installation
+- `--name <name>` - Name for the installation
+- `--target <addr>` - Target wallet address to send message to
+- `--message <text>` - Message to send to target
+- `--list` - List all installations
+- `--load <name>` - Load existing installation by name
+- `--wallet-key <key>` - Wallet private key (for loading existing installation)
+- `--encryption-key <key>` - Encryption key (for loading existing installation)
+- `--env <env>` - XMTP environment [default: production]
+
+**Examples:**
+
+```bash
+# Create a new installation
+yarn installations --create --name "my-installation"
+
+# Create installation and send message
+yarn installations --create --target 0x1234... --message "Hello!"
+
+# Load existing installation and send message
+yarn installations --load "my-installation" --target 0x1234... --message "Hello!"
+
+# List all installations
+yarn installations --list
+```
 
 ### Bot Command
 

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -495,7 +495,7 @@ export const browserTimeout = 10000;
 export const streamColdStartTimeout = 1000; // 1 second
 export const streamTimeout = process.env.DEFAULT_STREAM_TIMEOUT_MS
   ? parseInt(process.env.DEFAULT_STREAM_TIMEOUT_MS)
-  : 10000; // 10 seconds
+  : 3000; // 10 seconds
 
 export const formatBytes = (bytes: number): string => {
   if (bytes === 0) return "0 B";

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -266,8 +266,8 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
       .map(([k, v]) => `${k}: ${v.join(",")}`)
       .join(","),
     averageEventTiming,
-    receptionPercentage: stats?.receptionPercentage ?? 0,
-    orderPercentage: stats?.orderPercentage ?? 0,
+    receptionPercentage: stats?.receptionPercentage,
+    orderPercentage: stats?.orderPercentage,
   };
   console.debug("allResults", JSON.stringify(allResults, null, 2));
   return allResults;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format": "prettier -w .",
     "gen": "tsx cli/gen.ts",
     "groups": "tsx cli/groups.ts",
+    "installations": "tsx cli/installations.ts",
     "lint": "eslint .",
     "mock": "tsx cli/mock-client.ts",
     "monitor:yarn": "httpstat https://grpc.dev.xmtp.network:443",

--- a/suites/agents/json.json
+++ b/suites/agents/json.json
@@ -1,0 +1,663 @@
+{
+  "title": "XMTP SDK Performance",
+  "description": "Metrics for XMTP SDK operations (DNS, TLS, Server Processing)",
+  "widgets": [
+    {
+      "id": 504026830671482,
+      "definition": {
+        "title": "Delivery Rate (%)",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.delivery{$env,$region,$test,$sdk,$members}",
+                "aggregator": "avg"
+              }
+            ],
+            "formulas": [{ "formula": "query1" }],
+            "conditional_formats": [
+              { "comparator": ">=", "value": 99, "palette": "white_on_green" },
+              { "comparator": ">=", "value": 95, "palette": "white_on_yellow" },
+              { "comparator": "<", "value": 95, "palette": "white_on_red" }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 0
+      },
+      "layout": { "x": 0, "y": 0, "width": 2, "height": 1 }
+    },
+    {
+      "id": 7386776256176399,
+      "definition": {
+        "title": "Order Rate (%)",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.order{$env,$region,$test,$sdk,$members}",
+                "aggregator": "avg"
+              }
+            ],
+            "formulas": [{ "formula": "query1" }],
+            "conditional_formats": [
+              { "comparator": ">=", "value": 99, "palette": "white_on_green" },
+              { "comparator": ">=", "value": 95, "palette": "white_on_yellow" },
+              { "comparator": "<", "value": 95, "palette": "white_on_red" }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 0
+      },
+      "layout": { "x": 2, "y": 0, "width": 2, "height": 1 }
+    },
+    {
+      "id": 2409904999307821,
+      "definition": {
+        "title": "Avg response time (ms)",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "query_value",
+        "requests": [
+          {
+            "response_format": "scalar",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.response{$env,$region,$sdk,$live}"
+              }
+            ],
+            "formulas": [
+              {
+                "number_format": {
+                  "unit": {
+                    "type": "canonical_unit",
+                    "unit_name": "millisecond"
+                  }
+                },
+                "formula": "query1"
+              }
+            ],
+            "conditional_formats": [
+              {
+                "comparator": "<=",
+                "value": 3000,
+                "palette": "white_on_green"
+              },
+              {
+                "comparator": "<=",
+                "value": 5000,
+                "palette": "white_on_yellow"
+              },
+              { "comparator": ">", "value": 5000, "palette": "white_on_red" }
+            ]
+          }
+        ],
+        "autoscale": true,
+        "precision": 0
+      },
+      "layout": { "x": 4, "y": 0, "width": 2, "height": 1 }
+    },
+    {
+      "id": 4136910938597047,
+      "definition": {
+        "title": "",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "request_type": "slo_list",
+            "query": {
+              "query_string": "slo_creator:\"Fabrizio Guespe\" tags:protocol",
+              "limit": 100,
+              "rollup": { "type": "week" }
+            }
+          }
+        ],
+        "type": "slo_list"
+      },
+      "layout": { "x": 6, "y": 0, "width": 6, "height": 3 }
+    },
+    {
+      "id": 5871193681027559,
+      "definition": {
+        "title": "Streams",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "alias": "Stream Delivery", "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.delivery{$env,$test,$sdk,$region}"
+              }
+            ],
+            "response_format": "timeseries",
+            "on_right_yaxis": true,
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          },
+          {
+            "formulas": [{ "alias": "Stream Order", "formula": "query4" }],
+            "queries": [
+              {
+                "name": "query4",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.order{$env,$region,$test,$sdk}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "datadog16",
+              "order_reverse": false,
+              "line_type": "solid",
+              "line_width": "thick"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": {
+          "label": "Percentage (%)",
+          "include_zero": false,
+          "scale": "linear",
+          "min": "95",
+          "max": "100"
+        },
+        "markers": [
+          {
+            "label": " Tresshold ",
+            "value": "y = 99",
+            "display_type": "warning dashed"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 1, "width": 6, "height": 2 }
+    },
+    {
+      "id": 1933279114458496,
+      "definition": {
+        "title": "Agents response times",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "horizontal",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.response{$env,$region,test:agents-dms,$sdk,$live} by {agent}"
+              }
+            ],
+            "formulas": [{ "formula": "query1" }],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "yaxis": { "include_zero": true, "max": "auto" },
+        "markers": [{ "value": "y = 8000", "display_type": "error dashed" }]
+      },
+      "layout": { "x": 0, "y": 3, "width": 6, "height": 2 }
+    },
+    {
+      "id": 4980151126779186,
+      "definition": {
+        "title": "Operations performance by network",
+        "show_legend": true,
+        "legend_layout": "vertical",
+        "legend_columns": ["avg", "value"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "alias": "Operations (ms)", "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{$env,$region,$sdk,$operation,metric_subtype:core} by {operation}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "markers": [{ "value": "y = 1000", "display_type": "error dashed" }]
+      },
+      "layout": { "x": 6, "y": 3, "width": 6, "height": 3 }
+    },
+    {
+      "id": 4734823640655268,
+      "definition": {
+        "title": "Response time by test",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:xmtp.sdk.response{$env,$sdk,$region, $operation} by {test}"
+              }
+            ],
+            "formulas": [{ "alias": "Response time", "formula": "query1" }],
+            "style": {
+              "palette": "dog_classic",
+              "order_by": "values",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 5, "width": 6, "height": 2 }
+    },
+    {
+      "id": 7792773130762525,
+      "definition": {
+        "title": "Network Performance",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,$env,$region,$test,$sdk,$members} by {network_phase}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "markers": [{ "value": "y = 250", "display_type": "error dashed" }]
+      },
+      "layout": { "x": 6, "y": 6, "width": 6, "height": 2 }
+    },
+    {
+      "id": 5297767210484191,
+      "definition": {
+        "title": "Fail lines",
+        "title_size": "16",
+        "title_align": "left",
+        "requests": [
+          {
+            "response_format": "event_list",
+            "query": {
+              "data_source": "logs_stream",
+              "query_string": "@service:xmtp-qa-tools",
+              "indexes": [],
+              "storage": "hot"
+            },
+            "columns": [
+              { "field": "status_line", "width": "auto" },
+              { "field": "timestamp", "width": "auto" },
+              { "field": "env", "width": "auto" },
+              { "field": "region", "width": "auto" },
+              { "field": "fail_lines", "width": "auto" },
+              { "field": "batch_size", "width": "auto" },
+              { "field": "test", "width": "auto" }
+            ]
+          }
+        ],
+        "type": "list_stream"
+      },
+      "layout": { "x": 0, "y": 7, "width": 6, "height": 4 }
+    },
+    {
+      "id": 3966285800702611,
+      "definition": {
+        "title": "Performance by region",
+        "show_legend": true,
+        "legend_layout": "vertical",
+        "legend_columns": ["avg", "value"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [{ "alias": "Operations (ms)", "formula": "query1" }],
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{$env,$sdk,metric_subtype:core, $members, $operation} by {region}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ],
+        "markers": [{ "value": "y = 1500", "display_type": "error dashed" }]
+      },
+      "layout": { "x": 6, "y": 8, "width": 6, "height": 3 }
+    },
+    {
+      "id": 3602281815818011,
+      "definition": {
+        "title": "newGroup performance over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "name": "query2",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{metric_subtype:group,$env,$members,$operation,$region, $sdk} by {members}"
+              }
+            ],
+            "formulas": [{ "alias": "performance", "formula": "query2" }],
+            "style": {
+              "palette": "semantic",
+              "order_by": "tags",
+              "order_reverse": false,
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 11, "width": 6, "height": 2 }
+    },
+    {
+      "id": 8060176852557109,
+      "definition": {
+        "title": "Operation duration outliers",
+        "type": "query_table",
+        "requests": [
+          {
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:xmtp.sdk.duration{$env,$region,$test,$sdk,$members} by {operation,test,members,region,env}",
+                "aggregator": "max"
+              }
+            ],
+            "response_format": "scalar",
+            "sort": {
+              "count": 500,
+              "order_by": [{ "type": "formula", "index": 0, "order": "desc" }]
+            },
+            "formulas": [
+              {
+                "alias": "Duration (ms)",
+                "number_format": {
+                  "precision": 0,
+                  "unit_scale": {
+                    "type": "canonical_unit",
+                    "unit_name": "second"
+                  }
+                },
+                "formula": "query1"
+              }
+            ]
+          }
+        ],
+        "has_search_bar": "auto"
+      },
+      "layout": { "x": 6, "y": 11, "width": 6, "height": 5 }
+    },
+    {
+      "id": 688867209980098,
+      "definition": {
+        "title": "100 member performance over time",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "time": {},
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "name": "query2",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{metric_subtype:group,$env,$members,$region, members:100, $sdk} by {operation}"
+              }
+            ],
+            "formulas": [{ "alias": "performance", "formula": "query2" }],
+            "style": {
+              "palette": "semantic",
+              "order_by": "tags",
+              "order_reverse": false,
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 13, "width": 6, "height": 2 }
+    },
+    {
+      "id": 3075918014507898,
+      "definition": {
+        "title": "Network performance",
+        "type": "query_table",
+        "requests": [
+          {
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,env:production,$region,$test,$sdk,$members} by {region,network_phase}"
+              },
+              {
+                "data_source": "metrics",
+                "name": "query2",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,env:dev,$region,$test,$sdk,$members} by {region,network_phase}"
+              }
+            ],
+            "response_format": "scalar",
+            "sort": {
+              "order_by": [
+                { "type": "group", "name": "region", "order": "asc" }
+              ],
+              "count": 500
+            },
+            "formulas": [
+              {
+                "alias": "Production (ms)",
+                "number_format": { "precision": 0 },
+                "formula": "query1"
+              },
+              {
+                "alias": "Dev (ms)",
+                "formula": "query2",
+                "number_format": { "precision": 0 }
+              }
+            ]
+          }
+        ],
+        "has_search_bar": "auto"
+      },
+      "layout": { "x": 0, "y": 15, "width": 6, "height": 2 }
+    },
+    {
+      "id": 403905557672626,
+      "definition": {
+        "title": "Performance by region",
+        "title_size": "16",
+        "title_align": "left",
+        "type": "geomap",
+        "requests": [
+          {
+            "queries": [
+              {
+                "name": "query1",
+                "data_source": "metrics",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,network_phase:server_call,$sdk,$env} by {country_iso_code}"
+              }
+            ],
+            "response_format": "scalar",
+            "formulas": [
+              { "alias": "Server call duration (ms)", "formula": "query1" }
+            ]
+          }
+        ],
+        "style": { "palette": "green_to_orange", "palette_flip": false },
+        "view": { "focus": "WORLD" }
+      },
+      "layout": { "x": 6, "y": 16, "width": 6, "height": 5 }
+    },
+    {
+      "id": 3999933580218354,
+      "definition": {
+        "title": "Performance average by region",
+        "show_legend": true,
+        "legend_layout": "auto",
+        "legend_columns": ["avg", "min", "max", "value", "sum"],
+        "type": "timeseries",
+        "requests": [
+          {
+            "formulas": [
+              {
+                "alias": "Production (ms)",
+                "number_format": {},
+                "formula": "query1"
+              }
+            ],
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:xmtp.sdk.duration{metric_type:network,$sdk,$members,$env} by {region}"
+              }
+            ],
+            "response_format": "timeseries",
+            "style": {
+              "palette": "dog_classic",
+              "order_by": "values",
+              "line_type": "solid",
+              "line_width": "normal"
+            },
+            "display_type": "line"
+          }
+        ]
+      },
+      "layout": { "x": 0, "y": 17, "width": 6, "height": 3 }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "env",
+      "prefix": "env",
+      "available_values": ["dev", "production", "local"],
+      "default": "production"
+    },
+    {
+      "name": "region",
+      "prefix": "region",
+      "available_values": [],
+      "default": "us-east"
+    },
+    {
+      "name": "test",
+      "prefix": "test",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "operation",
+      "prefix": "operation",
+      "available_values": [],
+      "default": "*"
+    },
+    {
+      "name": "members",
+      "prefix": "members",
+      "available_values": [],
+      "default": "*"
+    },
+    { "name": "sdk", "prefix": "sdk", "available_values": [], "default": "*" },
+    { "name": "live", "prefix": "live", "available_values": [], "default": "*" }
+  ],
+  "layout_type": "ordered",
+  "notify_list": [],
+  "template_variable_presets": [
+    {
+      "name": "Debugging",
+      "description": "",
+      "template_variables": [
+        { "name": "env", "value": "local" },
+        { "name": "region", "value": "south-america" },
+        { "name": "test", "value": "*" },
+        { "name": "libxmtp", "value": "*" },
+        { "name": "operation", "value": "*" },
+        { "name": "metric_type", "value": "*" },
+        { "name": "members", "value": "*" }
+      ]
+    }
+  ],
+  "reflow_type": "fixed"
+}

--- a/suites/delivery.test.ts
+++ b/suites/delivery.test.ts
@@ -15,7 +15,7 @@ describe(testName, async () => {
   setupTestLifecycle({
     testName,
     sendMetrics: true,
-    sendDurationMetrics: true,
+    sendDurationMetrics: false,
   });
   const ERROR_TRESHOLD = parseInt(process.env.ERROR_TRESHOLD ?? "90");
   const MESSAGE_COUNT = parseInt(process.env.DELIVERY_AMOUNT ?? "10");

--- a/suites/performance.test.ts
+++ b/suites/performance.test.ts
@@ -199,23 +199,6 @@ describe(testName, () => {
         await newGroup.send(groupMessage);
         expect(groupMessage).toBeDefined();
       });
-      it(`streamMessage-${i}(${populateSize}):group message`, async () => {
-        const verifyResult = await verifyMessageStream(
-          newGroup,
-          workers.getAllButCreator(),
-        );
-        sendMetric("response", verifyResult.averageEventTiming, {
-          test: testName,
-          metric_type: "stream",
-          metric_subtype: "message",
-          sdk: workers.getCreator().sdk,
-          members: i.toString(),
-          installations: i.toString(),
-        } as ResponseMetricTags);
-
-        setCustomDuration(verifyResult?.averageEventTiming);
-        expect(verifyResult.almostAllReceived).toBe(true);
-      });
       it(`addMember-${i}(${populateSize}):add members to a group`, async () => {
         await newGroup.addMembers([workers.getAll()[2].inboxId]);
       });

--- a/suites/performance.test.ts
+++ b/suites/performance.test.ts
@@ -213,7 +213,7 @@ describe(testName, () => {
           installations: i.toString(),
         } as ResponseMetricTags);
 
-        setCustomDuration(verifyResult?.averageEventTiming ?? 0);
+        setCustomDuration(verifyResult?.averageEventTiming);
         expect(verifyResult.almostAllReceived).toBe(true);
       });
       it(`addMember-${i}(${populateSize}):add members to a group`, async () => {

--- a/suites/performance.test.ts
+++ b/suites/performance.test.ts
@@ -1,4 +1,3 @@
-import { streamTimeout } from "@helpers/client";
 import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
 import {
   verifyMembershipStream,
@@ -152,7 +151,7 @@ describe(testName, () => {
         sdk: receiver!.sdk,
       } as ResponseMetricTags);
 
-      setCustomDuration(verifyResult.averageEventTiming ?? streamTimeout);
+      setCustomDuration(verifyResult.averageEventTiming);
       expect(verifyResult.allReceived).toBe(true);
     });
 
@@ -215,7 +214,6 @@ describe(testName, () => {
       });
       it(`streamMembership-${i}(${populateSize}): stream members of additions in ${i} member group`, async () => {
         const extraMember = allMembersWithExtra.slice(i, i + 1);
-        console.log("extraMember", extraMember);
         const verifyResult = await verifyMembershipStream(
           newGroup,
           workers.getAllButCreator(),
@@ -239,6 +237,7 @@ describe(testName, () => {
           sdk: workers.getCreator().sdk,
         } as ResponseMetricTags);
 
+        console.log("verifyResult", JSON.stringify(verifyResult, null, 2));
         setCustomDuration(verifyResult.averageEventTiming);
         expect(verifyResult.almostAllReceived).toBe(true);
       });

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -277,7 +277,7 @@ export class WorkerManager implements IWorkerManager {
             await currentWorker.client.preferences.inboxState();
           workersToPrint.push(
             `${this.env}:${baseName}-${installationId} ${currentWorker.address} ${currentWorker.sdk} ${installationCount.installations.length} - ${formatBytes(
-              (await currentWorker.worker.getSQLiteFileSizes())?.total ?? 0,
+              (await currentWorker.worker.getSQLiteFileSizes())?.total,
             )}`,
           );
         }


### PR DESCRIPTION
### Add CLI for managing XMTP installations and messaging through new installations command
- Creates new CLI tool in [cli/installations.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-ea89aed8604b3f9b5c5ed426c2647a32fbf771df4a3ba69cf9523053d6f9c23c) that provides functionality to create, list, load, and manage XMTP installations with cryptographic key generation and message sending capabilities
- Adds `installations` npm script to [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) that executes the new CLI tool using tsx
- Updates CLI documentation in [cli/readme.md](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-342f32409d54083a9538f9a50e990595e78bfee7aa292f316b1602eed8a938f8) to include the new installations command reference
- Modifies exit handler in [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) to always exit with code 0 instead of propagating child process exit codes
- Changes `collectAndTimeEventsWithStats` function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to allow undefined values for `receptionPercentage` and `orderPercentage` statistics
- Adds performance metrics dashboard configuration in [suites/agents/json.json](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-42d52c1b497916012ba05db88b40b5ae0d0e3672d0e2166098dee4e5dd8c3289) for monitoring XMTP SDK delivery rates and response times
- Disables duration metrics in [suites/delivery.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-5ee4d09e7f113dc1e0a7f3562761bd9ecc34c227c2691254878e6e9f1091da78) by setting `sendDurationMetrics` to false
- Removes group message streaming test case from [suites/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-aa209b39deaaa8a1f7e707f34a5bf11cc221f5020e028557d86d36cc98f4e967)
- Modifies SQLite file size handling in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) to pass undefined values directly to `formatBytes` function

#### 📍Where to Start
Start with the main CLI implementation in [cli/installations.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1175/files#diff-ea89aed8604b3f9b5c5ed426c2647a32fbf771df4a3ba69cf9523053d6f9c23c) which contains the command-line argument parsing and core functionality for managing XMTP installations.

----

_[Macroscope](https://app.macroscope.com) summarized 6c4e442._