### PR TITLE
Refactor worker variable declarations for clarity

### DIFF
--- a/suites/functional/sync.test.ts
+++ b/suites/functional/sync.test.ts
@@ -1,6 +1,6 @@
 import { verifyMessageStream } from "@helpers/streams";
 import { setupTestLifecycle } from "@helpers/vitest";
-import { getWorkers, type WorkerManager } from "@workers/manager";
+import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
 import { type Dm } from "@workers/versions";
 import { describe, expect, it } from "vitest";
 
@@ -9,11 +9,13 @@ describe(testName, () => {
   setupTestLifecycle({ testName });
   let workers: WorkerManager;
   let dm: Dm;
+  let creator: Worker;
+  let receiver: Worker;
 
   it("stitching", async () => {
     workers = await getWorkers(["randombob-a", "alice"]);
-    let creator = workers.get("randombob", "a")!;
-    const receiver = workers.get("alice")!;
+    creator = workers.get("randombob", "a")!;
+    receiver = workers.get("alice")!;
     dm = (await creator.client.conversations.newDm(
       receiver.client.inboxId,
     )) as Dm;


### PR DESCRIPTION
### Refactor worker variable declarations to use top-level variables instead of local variables in sync test suite
Moves `creator` and `receiver` worker variable declarations from local scope within the test to top-level scope in [suites/functional/sync.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1179/files#diff-0bfd336e2f19157ab40251717ea5595ca52525fbdac5aca7ded3b4ab57b9f9fc). Adds import for `Worker` type from `@workers/manager` and modifies variable assignments throughout the test to reference the new top-level variables instead of creating local variables.

#### 📍Where to Start
Start with the top-level variable declarations for `creator` and `receiver` in [suites/functional/sync.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1179/files#diff-0bfd336e2f19157ab40251717ea5595ca52525fbdac5aca7ded3b4ab57b9f9fc).

----

_[Macroscope](https://app.macroscope.com) summarized f23097d._