### PR TITLE
Refactor tests and improve logging for clarity

### DIFF
--- a/.github/workflows/AgentHealth.yml
+++ b/.github/workflows/AgentHealth.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [agents-dms]
+        test: [agents-health]
         env: [dev, production]
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -2,7 +2,6 @@ import fs from "fs";
 import { getRandomValues } from "node:crypto";
 import { createRequire } from "node:module";
 import path from "node:path";
-import manualUsers from "@inboxes/manualusers.json";
 import type { Worker, WorkerManager } from "@workers/manager";
 import {
   Client,
@@ -411,12 +410,6 @@ export const randomlyRemoveDb = async (
       await worker.worker?.initialize();
     }
   }
-};
-
-export const getManualUsers = (filterBy: string[] = []): ManualUser[] => {
-  return (manualUsers as ManualUser[]).filter(
-    (r) => filterBy.includes(r.name) || filterBy.includes(r.app),
-  );
 };
 
 /**

--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -279,12 +279,12 @@ function loadDataPath(name: string, installationId: string): string {
   const preBasePath = process.env.RAILWAY_VOLUME_MOUNT_PATH ?? process.cwd();
 
   // Check if name includes "random" and add subfolder if it does
-  const randomSubfolder = name.toLowerCase().includes("random")
-    ? "/random"
-    : "";
+  const randomSubfolder = baseName.toLowerCase().includes("random")
+    ? "random/" + name
+    : name;
 
   // Use baseName for the parent folder, not the full name
-  let basePath = `${preBasePath}/.data/${baseName}${randomSubfolder}/${installationId}`;
+  let basePath = `${preBasePath}/.data/${randomSubfolder}/${installationId}`;
 
   return basePath;
 }

--- a/suites/agents/agents-health.test.ts
+++ b/suites/agents/agents-health.test.ts
@@ -46,7 +46,6 @@ describe(testName, () => {
         message: string;
       };
       console.log(JSON.stringify(result, null, 2));
-      expect(result.success).toBe(true);
       sendMetric("response", Number(result.responseTime), {
         test: testName,
         metric_type: "agent",
@@ -59,8 +58,7 @@ describe(testName, () => {
         api_endpoint: API_ENDPOINT,
         sdk: "api",
       } as ResponseMetricTags);
-
-      expect(true).toBe(true);
+      expect(result.success).toBe(true);
     });
   }
 });

--- a/suites/agents/agents-health.test.ts
+++ b/suites/agents/agents-health.test.ts
@@ -36,7 +36,6 @@ describe(testName, () => {
           network: env,
           message: agent.sendMessage,
         }),
-        signal: AbortSignal.timeout(20000),
       });
 
       const result = (await response.json()) as {

--- a/suites/agents/agents.json
+++ b/suites/agents/agents.json
@@ -107,7 +107,7 @@
     "address": "0xb6469a25ba51c59303eb24c04dad0e0ee1127d5b",
     "sendMessage": "hola",
     "live": false,
-    "networks": ["production"],
+    "networks": ["local"],
     "slackChannel": "#local-alerts",
     "respondOnTagged": false
   },

--- a/suites/agents/endpoint.ts
+++ b/suites/agents/endpoint.ts
@@ -68,7 +68,7 @@ const initClient = async (network: XmtpEnv = "dev") => {
   return client;
 };
 
-async function handler(req: Request) {
+export async function handler(req: Request) {
   if (req.method !== "POST") {
     return new Response(JSON.stringify({ error: "Method not allowed" }), {
       status: 405,

--- a/suites/measurements/concurrency-race.test.ts
+++ b/suites/measurements/concurrency-race.test.ts
@@ -1,15 +1,10 @@
-import {
-  createSigner,
-  getEncryptionKeyFromHex,
-  getManualUsers,
-} from "@helpers/client";
+import { createSigner, getEncryptionKeyFromHex } from "@helpers/client";
 import { setupTestLifecycle } from "@helpers/vitest";
 import { getRandomInboxIdsWithRandomInstallations } from "@inboxes/utils";
 import { Client, type XmtpEnv } from "@xmtp/node-sdk";
 import { beforeAll, describe, it } from "vitest";
 
 const testConfig = {
-  manualUsers: getManualUsers([(process.env.XMTP_ENV as string) + "-testing"]),
   randomInboxIds: getRandomInboxIdsWithRandomInstallations(100), // 100 DMs like the Rust test
   groupCount: 200, // 200 groups like the Rust test
   timeoutSeconds: 15, // Same timeout as Rust test

--- a/suites/measurements/populate.test.ts
+++ b/suites/measurements/populate.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 describe("populate", () => {
   const POPULATE_SIZE = process.env.POPULATE_SIZE
     ? process.env.POPULATE_SIZE.split("-").map((v) => Number(v))
-    : [0, 500, 1000, 2000];
+    : [0, 500, 1000, 2000, 5000, 10000];
   let uniqueNames: string[] = [];
   let workers: WorkerManager | undefined;
 

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -1242,7 +1242,7 @@ export class WorkerClient extends Worker implements IWorkerClient {
       // Create conversations for this batch
       await Promise.all(
         senderWorkers.map(async (sender, i) => {
-          console.log(`Creating conversation ${i + 1} of ${batchSize}...`);
+          console.debug(`Creating conversation ${i + 1} of ${batchSize}...`);
           await sender.client.conversations.newDmWithIdentifier({
             identifier: this.address,
             identifierKind: IdentifierKind.Ethereum,

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -1241,7 +1241,8 @@ export class WorkerClient extends Worker implements IWorkerClient {
 
       // Create conversations for this batch
       await Promise.all(
-        senderWorkers.map(async (sender, index) => {
+        senderWorkers.map(async (sender, i) => {
+          console.log(`Creating conversation ${i + 1} of ${batchSize}...`);
           await sender.client.conversations.newDmWithIdentifier({
             identifier: this.address,
             identifierKind: IdentifierKind.Ethereum,

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -590,7 +590,7 @@ export async function getWorkers(
   // Initialize progress bar
   const progressBar = new ProgressBar(workerPromises.length);
   console.log(`🚀 Initializing ${workerPromises.length} workers...`);
-  
+
   // Show initial progress immediately
   progressBar.update(0);
 


### PR DESCRIPTION
### Refactor data path structure in `loadDataPath` function and remove manual user functionality for test clarity
- Modifies the `loadDataPath` function in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to change how random subfolder paths are constructed, using "random/" + name format instead of separate random subfolders
- Removes the `getManualUsers` function and related manual user imports from [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) and [suites/measurements/concurrency-race.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-e7837b1006de3852fb4c9be3af0c4151d47612c54e7a5e699679dee14c3fdf42)
- Increases default population test sizes in [suites/measurements/populate.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-8c604ce81f9b747a8aa099b399755ac83aee9a49d46fc48672ef02db0ba96b73) to include 5000 and 10000 values
- Removes 20-second timeout from fetch request in [suites/agents/agents-health.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-50c71e70004bafc60b4872b692391cc959277c48133c5be6752a9d3769e7d660)
- Exports the `handler` function in [suites/agents/endpoint.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-fd28cad10475d0597620ceff106020eddfea8779e87f38d9e82c2f551857a5be)
- Adds debug logging to conversation creation progress in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1)

#### 📍Where to Start
Start with the `loadDataPath` function in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1188/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to understand the core data path structure changes.

----

_[Macroscope](https://app.macroscope.com) summarized ad66f3d._