### PR TITLE
Optimize progress bar usage for large worker sets

### DIFF
--- a/suites/measurements/size-performance.test.ts
+++ b/suites/measurements/size-performance.test.ts
@@ -1,0 +1,292 @@
+import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
+import {
+  verifyMembershipStream,
+  verifyMessageStream,
+  verifyMetadataStream,
+} from "@helpers/streams";
+import { setupTestLifecycle } from "@helpers/vitest";
+import { getAddresses, getInboxIds, getRandomAddress } from "@inboxes/utils";
+import { getWorkers, type Worker, type WorkerManager } from "@workers/manager";
+import {
+  Client,
+  ConsentEntityType,
+  ConsentState,
+  IdentifierKind,
+  type Dm,
+  type Group,
+} from "@workers/versions";
+import { describe, expect, it } from "vitest";
+
+const testName = "performance";
+describe(testName, () => {
+  const BATCH_SIZE = process.env.BATCH_SIZE
+    ? process.env.BATCH_SIZE.split("-").map((v) => Number(v))
+    : [10];
+  let dm: Dm | undefined;
+
+  let newGroup: Group;
+  const POPULATE_SIZE = process.env.POPULATE_SIZE
+    ? process.env.POPULATE_SIZE.split("-").map((v) => Number(v))
+    : [0, 1000, 2000, 5000, 10000];
+  let customDuration: number | undefined = undefined;
+  const setCustomDuration = (duration: number | undefined) => {
+    customDuration = duration;
+  };
+  let allMembers: string[] = [];
+  let allMembersWithExtra: string[] = [];
+  // Cumulative tracking variables
+  let cumulativeGroups: Group[] = [];
+
+  setupTestLifecycle({
+    testName,
+    getCustomDuration: () => customDuration,
+    setCustomDuration: (v) => {
+      customDuration = v;
+    },
+    initDataDog: true,
+    sendDurationMetrics: true,
+    networkStats: true,
+    summaryTableConfig: {
+      showStats: true,
+      sortBy: "testName",
+    },
+  });
+
+  for (const populateSize of POPULATE_SIZE) {
+    let workers: WorkerManager;
+    let creator: Worker | undefined;
+    let receiver: Worker | undefined;
+    it(`create(${populateSize}): measure creating a client`, async () => {
+      workers = await getWorkers(6, {
+        randomNames: false,
+      });
+      creator = workers.get("edward")!;
+      receiver = workers.get("bob")!;
+      setCustomDuration(creator.initializationTime);
+    });
+    it(`sync(${populateSize}):measure sync`, async () => {
+      await creator!.client.conversations.sync();
+    });
+    it(`syncAll(${populateSize}):measure syncAll`, async () => {
+      await creator!.client.conversations.syncAll();
+    });
+
+    it(`inboxState(${populateSize}):measure inboxState`, async () => {
+      const inboxState = await creator!.client.preferences.inboxState();
+      console.log("inboxState", inboxState);
+    });
+    it(`canMessage(${populateSize}):measure canMessage`, async () => {
+      const randomAddress = receiver!.address;
+      if (!randomAddress) {
+        throw new Error("Random client not found");
+      }
+      const start = Date.now();
+      const canMessage = await Client.canMessage(
+        [
+          {
+            identifier: randomAddress,
+            identifierKind: IdentifierKind.Ethereum,
+          },
+        ],
+        receiver!.env,
+      );
+      setCustomDuration(Date.now() - start);
+      expect(canMessage.get(randomAddress.toLowerCase())).toBe(true);
+    });
+
+    it(`newDm(${populateSize}):measure creating a DM`, async () => {
+      dm = (await creator!.client.conversations.newDm(
+        receiver!.client.inboxId,
+      )) as Dm;
+      expect(dm).toBeDefined();
+      expect(dm.id).toBeDefined();
+    });
+    it(`newDmByAddress(${populateSize}):measure creating a DM`, async () => {
+      const dm2 = await receiver!.client.conversations.newDmWithIdentifier({
+        identifier: getRandomAddress(1)[0],
+        identifierKind: IdentifierKind.Ethereum,
+      });
+
+      expect(dm2).toBeDefined();
+      expect(dm2.id).toBeDefined();
+    });
+    it(`getConversationById(${populateSize}):measure getting a conversation by id`, async () => {
+      const conversation =
+        await creator!.client.conversations.getConversationById(dm!.id);
+      expect(conversation!.id).toBe(dm!.id);
+    });
+    it(`send(${populateSize}):measure sending a gm`, async () => {
+      const dmId = await dm!.send("gm");
+      expect(dmId).toBeDefined();
+    });
+
+    it(`consent:group consent`, async () => {
+      await creator!.client.preferences.setConsentStates([
+        {
+          entity: receiver!.client.inboxId,
+          entityType: ConsentEntityType.InboxId,
+          state: ConsentState.Allowed,
+        },
+      ]);
+      const consentState = await creator!.client.preferences.getConsentState(
+        ConsentEntityType.InboxId,
+        receiver!.client.inboxId,
+      );
+      console.log("consentState", consentState);
+      expect(consentState).toBe(ConsentState.Allowed);
+    });
+    it(`stream(${populateSize}):measure receiving a gm`, async () => {
+      const verifyResult = await verifyMessageStream(dm!, [receiver!]);
+
+      sendMetric("response", verifyResult.averageEventTiming, {
+        test: testName,
+        metric_type: "stream",
+        metric_subtype: "message",
+        sdk: receiver!.sdk,
+      } as ResponseMetricTags);
+
+      setCustomDuration(verifyResult.averageEventTiming);
+      expect(verifyResult.allReceived).toBe(true);
+    });
+
+    for (const i of BATCH_SIZE) {
+      it(`newGroup-${i}(${populateSize}):create a large group of ${i} members ${i}`, async () => {
+        allMembersWithExtra = getInboxIds(i + 1);
+        allMembers = allMembersWithExtra.slice(0, i);
+
+        newGroup = (await creator!.client.conversations.newGroup([
+          ...allMembers,
+          ...workers.getAllButCreator().map((w) => w.client.inboxId),
+        ])) as Group;
+        expect(newGroup.id).toBeDefined();
+        // Add current group to cumulative tracking
+        cumulativeGroups.push(newGroup);
+      });
+      it(`newGroupByAddress-${i}(${populateSize}):create a large group of ${i} members ${i}`, async () => {
+        const callMembersWithExtraWithAddress = getAddresses(i + 1);
+        const newGroupByIdentifier =
+          await creator!.client.conversations.newGroupWithIdentifiers(
+            callMembersWithExtraWithAddress.map((address) => ({
+              identifier: address,
+              identifierKind: IdentifierKind.Ethereum,
+            })),
+          );
+        expect(newGroupByIdentifier.id).toBeDefined();
+      });
+      it(`groupsync-${i}(${populateSize}):sync a large group of ${i} members ${i}`, async () => {
+        await newGroup.sync();
+        const members = await newGroup.members();
+        expect(members.length).toBe(members.length);
+      });
+
+      it(`updateName-${i}(${populateSize}):update the group name`, async () => {
+        const newName = "Large Group";
+        await newGroup.updateName(newName);
+        const name = newGroup.name;
+        expect(name).toBe(newName);
+      });
+      it(`send-${i}(${populateSize}):measure sending a gm in a group of ${i} members`, async () => {
+        const groupMessage =
+          "gm-" + Math.random().toString(36).substring(2, 15);
+
+        await newGroup.send(groupMessage);
+        expect(groupMessage).toBeDefined();
+      });
+      it(`addMember-${i}(${populateSize}):add members to a group`, async () => {
+        await newGroup.addMembers([workers.getAll()[2].inboxId]);
+      });
+      it(`removeMembers-${i}(${populateSize}):remove a participant from a group`, async () => {
+        const previousMembers = await newGroup.members();
+        await newGroup.removeMembers([
+          previousMembers.filter(
+            (member) => member.inboxId !== newGroup.addedByInboxId,
+          )[0].inboxId,
+        ]);
+
+        const members = await newGroup.members();
+        expect(members.length).toBe(previousMembers.length - 1);
+      });
+      it(`streamMembership-${i}(${populateSize}): stream members of additions in ${i} member group`, async () => {
+        const extraMember = allMembersWithExtra.slice(i, i + 1);
+        const verifyResult = await verifyMembershipStream(
+          newGroup,
+          workers.getAllButCreator(),
+          extraMember,
+        );
+
+        setCustomDuration(verifyResult.averageEventTiming);
+        expect(verifyResult.almostAllReceived).toBe(true);
+      });
+
+      it(`streamMessage-${i}(${populateSize}): stream members of message changes in ${i} member group`, async () => {
+        const verifyResult = await verifyMessageStream(
+          newGroup,
+          workers.getAllButCreator(),
+        );
+
+        sendMetric("response", verifyResult.averageEventTiming, {
+          test: testName,
+          metric_type: "stream",
+          metric_subtype: "message",
+          sdk: workers.getCreator().sdk,
+        } as ResponseMetricTags);
+
+        console.log("verifyResult", JSON.stringify(verifyResult, null, 2));
+        setCustomDuration(verifyResult.averageEventTiming);
+        expect(verifyResult.almostAllReceived).toBe(true);
+      });
+
+      it(`streamMetadata-${i}(${populateSize}): stream members of metadata changes in ${i} member group`, async () => {
+        const verifyResult = await verifyMetadataStream(
+          newGroup,
+          workers.getAllButCreator(),
+        );
+
+        setCustomDuration(verifyResult.averageEventTiming);
+        expect(verifyResult.almostAllReceived).toBe(true);
+      });
+
+      it(`sync-${i}(${populateSize}):perform cold start sync operations on ${i} member group`, async () => {
+        const singleSyncWorkers = await getWorkers(["randomA"]);
+        const clientSingleSync = singleSyncWorkers.get("randomA")!.client;
+        await newGroup.addMembers([clientSingleSync.inboxId]);
+        const start = performance.now();
+        await clientSingleSync.conversations.sync();
+        const end = performance.now();
+        setCustomDuration(end - start);
+      });
+      it(`syncAll-${i}(${populateSize}):perform cold start sync operations on ${i} member group`, async () => {
+        const singleSyncWorkers = await getWorkers(["randomB"]);
+        const clientSingleSync = singleSyncWorkers.get("randomB")!.client;
+        await newGroup.addMembers([clientSingleSync.inboxId]);
+        const start = performance.now();
+        await clientSingleSync.conversations.syncAll();
+        const end = performance.now();
+        setCustomDuration(end - start);
+      });
+
+      it(`syncCumulative-${i}(${populateSize}):perform cumulative sync operations on ${i} member group`, async () => {
+        const singleSyncWorkers = await getWorkers(["randomC"]);
+        const clientSingleSync = singleSyncWorkers.get("randomC")!.client;
+        for (const group of cumulativeGroups) {
+          await group.addMembers([clientSingleSync.inboxId]);
+        }
+        const start = performance.now();
+        await clientSingleSync.conversations.sync();
+        const end = performance.now();
+        setCustomDuration(end - start);
+      });
+      it(`syncAllCumulative-${i}(${populateSize}):perform cumulative syncAll operations on ${i} member group`, async () => {
+        const singleSyncWorkers = await getWorkers(["randomD"]);
+        const clientSingleSync = singleSyncWorkers.get("randomD")!.client;
+        for (const group of cumulativeGroups) {
+          await group.addMembers([clientSingleSync.inboxId]);
+        }
+        const start = performance.now();
+        await clientSingleSync.conversations.syncAll();
+        const end = performance.now();
+        setCustomDuration(end - start);
+      });
+    }
+  }
+});

--- a/suites/performance.test.ts
+++ b/suites/performance.test.ts
@@ -25,9 +25,7 @@ describe(testName, () => {
   let dm: Dm | undefined;
 
   let newGroup: Group;
-  const POPULATE_SIZE = process.env.POPULATE_SIZE
-    ? process.env.POPULATE_SIZE.split("-").map((v) => Number(v))
-    : [0];
+
   let customDuration: number | undefined = undefined;
   const setCustomDuration = (duration: number | undefined) => {
     customDuration = duration;
@@ -48,241 +46,238 @@ describe(testName, () => {
     networkStats: true,
   });
 
-  for (const populateSize of POPULATE_SIZE) {
-    let workers: WorkerManager;
-    let creator: Worker | undefined;
-    let receiver: Worker | undefined;
-    it(`create(${populateSize}): measure creating a client`, async () => {
-      workers = await getWorkers(6, {
-        randomNames: false,
-      });
-      creator = workers.get("edward")!;
-      receiver = workers.get("bob")!;
-      setCustomDuration(creator.initializationTime);
+  let workers: WorkerManager;
+  let creator: Worker | undefined;
+  let receiver: Worker | undefined;
+  it(`create: measure creating a client`, async () => {
+    workers = await getWorkers(6, {
+      randomNames: false,
     });
-    it(`sync(${populateSize}):measure sync`, async () => {
-      await creator!.client.conversations.sync();
-    });
-    it(`syncAll(${populateSize}):measure syncAll`, async () => {
-      await creator!.client.conversations.syncAll();
-    });
+    creator = workers.get("edward")!;
+    receiver = workers.get("bob")!;
+    setCustomDuration(creator.initializationTime);
+  });
+  it(`sync:measure sync`, async () => {
+    await creator!.client.conversations.sync();
+  });
+  it(`syncAll:measure syncAll`, async () => {
+    await creator!.client.conversations.syncAll();
+  });
 
-    it(`inboxState(${populateSize}):measure inboxState`, async () => {
-      const inboxState = await creator!.client.preferences.inboxState();
-      console.log("inboxState", inboxState);
-    });
-    it(`canMessage(${populateSize}):measure canMessage`, async () => {
-      const randomAddress = receiver!.address;
-      if (!randomAddress) {
-        throw new Error("Random client not found");
-      }
-      const start = Date.now();
-      const canMessage = await Client.canMessage(
-        [
-          {
-            identifier: randomAddress,
-            identifierKind: IdentifierKind.Ethereum,
-          },
-        ],
-        receiver!.env,
-      );
-      setCustomDuration(Date.now() - start);
-      expect(canMessage.get(randomAddress.toLowerCase())).toBe(true);
-    });
-
-    it(`newDm(${populateSize}):measure creating a DM`, async () => {
-      dm = (await creator!.client.conversations.newDm(
-        receiver!.client.inboxId,
-      )) as Dm;
-      expect(dm).toBeDefined();
-      expect(dm.id).toBeDefined();
-    });
-    it(`newDmByAddress(${populateSize}):measure creating a DM`, async () => {
-      const dm2 = await receiver!.client.conversations.newDmWithIdentifier({
-        identifier: getRandomAddress(1)[0],
-        identifierKind: IdentifierKind.Ethereum,
-      });
-
-      expect(dm2).toBeDefined();
-      expect(dm2.id).toBeDefined();
-    });
-    it(`getConversationById(${populateSize}):measure getting a conversation by id`, async () => {
-      const conversation =
-        await creator!.client.conversations.getConversationById(dm!.id);
-      expect(conversation!.id).toBe(dm!.id);
-    });
-    it(`send(${populateSize}):measure sending a gm`, async () => {
-      const dmId = await dm!.send("gm");
-      expect(dmId).toBeDefined();
-    });
-
-    it(`consent:group consent`, async () => {
-      await creator!.client.preferences.setConsentStates([
+  it(`inboxState:measure inboxState`, async () => {
+    const inboxState = await creator!.client.preferences.inboxState();
+    console.log("inboxState", inboxState);
+  });
+  it(`canMessage:measure canMessage`, async () => {
+    const randomAddress = receiver!.address;
+    if (!randomAddress) {
+      throw new Error("Random client not found");
+    }
+    const start = Date.now();
+    const canMessage = await Client.canMessage(
+      [
         {
-          entity: receiver!.client.inboxId,
-          entityType: ConsentEntityType.InboxId,
-          state: ConsentState.Allowed,
+          identifier: randomAddress,
+          identifierKind: IdentifierKind.Ethereum,
         },
-      ]);
-      const consentState = await creator!.client.preferences.getConsentState(
-        ConsentEntityType.InboxId,
-        receiver!.client.inboxId,
-      );
-      console.log("consentState", consentState);
-      expect(consentState).toBe(ConsentState.Allowed);
+      ],
+      receiver!.env,
+    );
+    setCustomDuration(Date.now() - start);
+    expect(canMessage.get(randomAddress.toLowerCase())).toBe(true);
+  });
+
+  it(`newDm:measure creating a DM`, async () => {
+    dm = (await creator!.client.conversations.newDm(
+      receiver!.client.inboxId,
+    )) as Dm;
+    expect(dm).toBeDefined();
+    expect(dm.id).toBeDefined();
+  });
+  it(`newDmByAddress:measure creating a DM`, async () => {
+    const dm2 = await receiver!.client.conversations.newDmWithIdentifier({
+      identifier: getRandomAddress(1)[0],
+      identifierKind: IdentifierKind.Ethereum,
     });
-    it(`stream(${populateSize}):measure receiving a gm`, async () => {
-      const verifyResult = await verifyMessageStream(dm!, [receiver!]);
+
+    expect(dm2).toBeDefined();
+    expect(dm2.id).toBeDefined();
+  });
+  it(`getConversationById:measure getting a conversation by id`, async () => {
+    const conversation =
+      await creator!.client.conversations.getConversationById(dm!.id);
+    expect(conversation!.id).toBe(dm!.id);
+  });
+  it(`send:measure sending a gm`, async () => {
+    const dmId = await dm!.send("gm");
+    expect(dmId).toBeDefined();
+  });
+
+  it(`consent:group consent`, async () => {
+    await creator!.client.preferences.setConsentStates([
+      {
+        entity: receiver!.client.inboxId,
+        entityType: ConsentEntityType.InboxId,
+        state: ConsentState.Allowed,
+      },
+    ]);
+    const consentState = await creator!.client.preferences.getConsentState(
+      ConsentEntityType.InboxId,
+      receiver!.client.inboxId,
+    );
+    console.log("consentState", consentState);
+    expect(consentState).toBe(ConsentState.Allowed);
+  });
+  it(`stream:measure receiving a gm`, async () => {
+    const verifyResult = await verifyMessageStream(dm!, [receiver!]);
+
+    sendMetric("response", verifyResult.averageEventTiming, {
+      test: testName,
+      metric_type: "stream",
+      metric_subtype: "message",
+      sdk: receiver!.sdk,
+    } as ResponseMetricTags);
+
+    setCustomDuration(verifyResult.averageEventTiming);
+    expect(verifyResult.allReceived).toBe(true);
+  });
+
+  for (const i of BATCH_SIZE) {
+    it(`newGroup-${i}:create a large group of ${i} members ${i}`, async () => {
+      allMembersWithExtra = getInboxIds(i + 1);
+      allMembers = allMembersWithExtra.slice(0, i);
+
+      newGroup = (await creator!.client.conversations.newGroup([
+        ...allMembers,
+        ...workers.getAllButCreator().map((w) => w.client.inboxId),
+      ])) as Group;
+      expect(newGroup.id).toBeDefined();
+      // Add current group to cumulative tracking
+      cumulativeGroups.push(newGroup);
+    });
+    it(`newGroupByAddress-${i}:create a large group of ${i} members ${i}`, async () => {
+      const callMembersWithExtraWithAddress = getAddresses(i + 1);
+      const newGroupByIdentifier =
+        await creator!.client.conversations.newGroupWithIdentifiers(
+          callMembersWithExtraWithAddress.map((address) => ({
+            identifier: address,
+            identifierKind: IdentifierKind.Ethereum,
+          })),
+        );
+      expect(newGroupByIdentifier.id).toBeDefined();
+    });
+    it(`groupsync-${i}:sync a large group of ${i} members ${i}`, async () => {
+      await newGroup.sync();
+      const members = await newGroup.members();
+      expect(members.length).toBe(members.length);
+    });
+
+    it(`updateName-${i}:update the group name`, async () => {
+      const newName = "Large Group";
+      await newGroup.updateName(newName);
+      const name = newGroup.name;
+      expect(name).toBe(newName);
+    });
+    it(`send-${i}:measure sending a gm in a group of ${i} members`, async () => {
+      const groupMessage = "gm-" + Math.random().toString(36).substring(2, 15);
+
+      await newGroup.send(groupMessage);
+      expect(groupMessage).toBeDefined();
+    });
+    it(`addMember-${i}:add members to a group`, async () => {
+      await newGroup.addMembers([workers.getAll()[2].inboxId]);
+    });
+    it(`removeMembers-${i}:remove a participant from a group`, async () => {
+      const previousMembers = await newGroup.members();
+      await newGroup.removeMembers([
+        previousMembers.filter(
+          (member) => member.inboxId !== newGroup.addedByInboxId,
+        )[0].inboxId,
+      ]);
+
+      const members = await newGroup.members();
+      expect(members.length).toBe(previousMembers.length - 1);
+    });
+    it(`streamMembership-${i}: stream members of additions in ${i} member group`, async () => {
+      const extraMember = allMembersWithExtra.slice(i, i + 1);
+      const verifyResult = await verifyMembershipStream(
+        newGroup,
+        workers.getAllButCreator(),
+        extraMember,
+      );
+
+      setCustomDuration(verifyResult.averageEventTiming);
+      expect(verifyResult.almostAllReceived).toBe(true);
+    });
+
+    it(`streamMessage-${i}: stream members of message changes in ${i} member group`, async () => {
+      const verifyResult = await verifyMessageStream(
+        newGroup,
+        workers.getAllButCreator(),
+      );
 
       sendMetric("response", verifyResult.averageEventTiming, {
         test: testName,
         metric_type: "stream",
         metric_subtype: "message",
-        sdk: receiver!.sdk,
+        sdk: workers.getCreator().sdk,
       } as ResponseMetricTags);
 
+      console.log("verifyResult", JSON.stringify(verifyResult, null, 2));
       setCustomDuration(verifyResult.averageEventTiming);
-      expect(verifyResult.allReceived).toBe(true);
+      expect(verifyResult.almostAllReceived).toBe(true);
     });
 
-    for (const i of BATCH_SIZE) {
-      it(`newGroup-${i}(${populateSize}):create a large group of ${i} members ${i}`, async () => {
-        allMembersWithExtra = getInboxIds(i + 1);
-        allMembers = allMembersWithExtra.slice(0, i);
+    it(`streamMetadata-${i}: stream members of metadata changes in ${i} member group`, async () => {
+      const verifyResult = await verifyMetadataStream(
+        newGroup,
+        workers.getAllButCreator(),
+      );
 
-        newGroup = (await creator!.client.conversations.newGroup([
-          ...allMembers,
-          ...workers.getAllButCreator().map((w) => w.client.inboxId),
-        ])) as Group;
-        expect(newGroup.id).toBeDefined();
-        // Add current group to cumulative tracking
-        cumulativeGroups.push(newGroup);
-      });
-      it(`newGroupByAddress-${i}(${populateSize}):create a large group of ${i} members ${i}`, async () => {
-        const callMembersWithExtraWithAddress = getAddresses(i + 1);
-        const newGroupByIdentifier =
-          await creator!.client.conversations.newGroupWithIdentifiers(
-            callMembersWithExtraWithAddress.map((address) => ({
-              identifier: address,
-              identifierKind: IdentifierKind.Ethereum,
-            })),
-          );
-        expect(newGroupByIdentifier.id).toBeDefined();
-      });
-      it(`groupsync-${i}(${populateSize}):sync a large group of ${i} members ${i}`, async () => {
-        await newGroup.sync();
-        const members = await newGroup.members();
-        expect(members.length).toBe(members.length);
-      });
+      setCustomDuration(verifyResult.averageEventTiming);
+      expect(verifyResult.almostAllReceived).toBe(true);
+    });
 
-      it(`updateName-${i}(${populateSize}):update the group name`, async () => {
-        const newName = "Large Group";
-        await newGroup.updateName(newName);
-        const name = newGroup.name;
-        expect(name).toBe(newName);
-      });
-      it(`send-${i}(${populateSize}):measure sending a gm in a group of ${i} members`, async () => {
-        const groupMessage =
-          "gm-" + Math.random().toString(36).substring(2, 15);
+    it(`sync-${i}:perform cold start sync operations on ${i} member group`, async () => {
+      const singleSyncWorkers = await getWorkers(["randomA"]);
+      const clientSingleSync = singleSyncWorkers.get("randomA")!.client;
+      await newGroup.addMembers([clientSingleSync.inboxId]);
+      const start = performance.now();
+      await clientSingleSync.conversations.sync();
+      const end = performance.now();
+      setCustomDuration(end - start);
+    });
+    it(`syncAll-${i}:perform cold start sync operations on ${i} member group`, async () => {
+      const singleSyncWorkers = await getWorkers(["randomB"]);
+      const clientSingleSync = singleSyncWorkers.get("randomB")!.client;
+      await newGroup.addMembers([clientSingleSync.inboxId]);
+      const start = performance.now();
+      await clientSingleSync.conversations.syncAll();
+      const end = performance.now();
+      setCustomDuration(end - start);
+    });
 
-        await newGroup.send(groupMessage);
-        expect(groupMessage).toBeDefined();
-      });
-      it(`addMember-${i}(${populateSize}):add members to a group`, async () => {
-        await newGroup.addMembers([workers.getAll()[2].inboxId]);
-      });
-      it(`removeMembers-${i}(${populateSize}):remove a participant from a group`, async () => {
-        const previousMembers = await newGroup.members();
-        await newGroup.removeMembers([
-          previousMembers.filter(
-            (member) => member.inboxId !== newGroup.addedByInboxId,
-          )[0].inboxId,
-        ]);
-
-        const members = await newGroup.members();
-        expect(members.length).toBe(previousMembers.length - 1);
-      });
-      it(`streamMembership-${i}(${populateSize}): stream members of additions in ${i} member group`, async () => {
-        const extraMember = allMembersWithExtra.slice(i, i + 1);
-        const verifyResult = await verifyMembershipStream(
-          newGroup,
-          workers.getAllButCreator(),
-          extraMember,
-        );
-
-        setCustomDuration(verifyResult.averageEventTiming);
-        expect(verifyResult.almostAllReceived).toBe(true);
-      });
-
-      it(`streamMessage-${i}(${populateSize}): stream members of message changes in ${i} member group`, async () => {
-        const verifyResult = await verifyMessageStream(
-          newGroup,
-          workers.getAllButCreator(),
-        );
-
-        sendMetric("response", verifyResult.averageEventTiming, {
-          test: testName,
-          metric_type: "stream",
-          metric_subtype: "message",
-          sdk: workers.getCreator().sdk,
-        } as ResponseMetricTags);
-
-        console.log("verifyResult", JSON.stringify(verifyResult, null, 2));
-        setCustomDuration(verifyResult.averageEventTiming);
-        expect(verifyResult.almostAllReceived).toBe(true);
-      });
-
-      it(`streamMetadata-${i}(${populateSize}): stream members of metadata changes in ${i} member group`, async () => {
-        const verifyResult = await verifyMetadataStream(
-          newGroup,
-          workers.getAllButCreator(),
-        );
-
-        setCustomDuration(verifyResult.averageEventTiming);
-        expect(verifyResult.almostAllReceived).toBe(true);
-      });
-
-      it(`sync-${i}(${populateSize}):perform cold start sync operations on ${i} member group`, async () => {
-        const singleSyncWorkers = await getWorkers(["randomA"]);
-        const clientSingleSync = singleSyncWorkers.get("randomA")!.client;
-        await newGroup.addMembers([clientSingleSync.inboxId]);
-        const start = performance.now();
-        await clientSingleSync.conversations.sync();
-        const end = performance.now();
-        setCustomDuration(end - start);
-      });
-      it(`syncAll-${i}(${populateSize}):perform cold start sync operations on ${i} member group`, async () => {
-        const singleSyncWorkers = await getWorkers(["randomB"]);
-        const clientSingleSync = singleSyncWorkers.get("randomB")!.client;
-        await newGroup.addMembers([clientSingleSync.inboxId]);
-        const start = performance.now();
-        await clientSingleSync.conversations.syncAll();
-        const end = performance.now();
-        setCustomDuration(end - start);
-      });
-
-      it(`syncCumulative-${i}(${populateSize}):perform cumulative sync operations on ${i} member group`, async () => {
-        const singleSyncWorkers = await getWorkers(["randomC"]);
-        const clientSingleSync = singleSyncWorkers.get("randomC")!.client;
-        for (const group of cumulativeGroups) {
-          await group.addMembers([clientSingleSync.inboxId]);
-        }
-        const start = performance.now();
-        await clientSingleSync.conversations.sync();
-        const end = performance.now();
-        setCustomDuration(end - start);
-      });
-      it(`syncAllCumulative-${i}(${populateSize}):perform cumulative syncAll operations on ${i} member group`, async () => {
-        const singleSyncWorkers = await getWorkers(["randomD"]);
-        const clientSingleSync = singleSyncWorkers.get("randomD")!.client;
-        for (const group of cumulativeGroups) {
-          await group.addMembers([clientSingleSync.inboxId]);
-        }
-        const start = performance.now();
-        await clientSingleSync.conversations.syncAll();
-        const end = performance.now();
-        setCustomDuration(end - start);
-      });
-    }
+    it(`syncCumulative-${i}:perform cumulative sync operations on ${i} member group`, async () => {
+      const singleSyncWorkers = await getWorkers(["randomC"]);
+      const clientSingleSync = singleSyncWorkers.get("randomC")!.client;
+      for (const group of cumulativeGroups) {
+        await group.addMembers([clientSingleSync.inboxId]);
+      }
+      const start = performance.now();
+      await clientSingleSync.conversations.sync();
+      const end = performance.now();
+      setCustomDuration(end - start);
+    });
+    it(`syncAllCumulative-${i}:perform cumulative syncAll operations on ${i} member group`, async () => {
+      const singleSyncWorkers = await getWorkers(["randomD"]);
+      const clientSingleSync = singleSyncWorkers.get("randomD")!.client;
+      for (const group of cumulativeGroups) {
+        await group.addMembers([clientSingleSync.inboxId]);
+      }
+      const start = performance.now();
+      await clientSingleSync.conversations.syncAll();
+      const end = performance.now();
+      setCustomDuration(end - start);
+    });
   }
 });

--- a/suites/performance.test.ts
+++ b/suites/performance.test.ts
@@ -50,9 +50,7 @@ describe(testName, () => {
   let creator: Worker | undefined;
   let receiver: Worker | undefined;
   it(`create: measure creating a client`, async () => {
-    workers = await getWorkers(6, {
-      randomNames: false,
-    });
+    workers = await getWorkers(6);
     creator = workers.get("edward")!;
     receiver = workers.get("bob")!;
     setCustomDuration(creator.initializationTime);

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -673,14 +673,18 @@ export async function getWorkers(
     );
   }
 
-  // Initialize progress bar
-  const progressBar = new ProgressBar(
-    workerPromises.length,
-    `Initializing ${workerPromises.length} workers...`,
-  );
+  // Only use progress bar if there are more than 50 workers
+  const useProgressBar = workerPromises.length > 50;
+  let progressBar: ProgressBar | undefined;
 
-  // Show initial progress immediately
-  progressBar.update(0);
+  if (useProgressBar) {
+    progressBar = new ProgressBar(
+      workerPromises.length,
+      `Initializing ${workerPromises.length} workers...`,
+    );
+    // Show initial progress immediately
+    progressBar.update(0);
+  }
 
   // Track all workers in parallel and update progress as each completes
   let completedCount = 0;
@@ -689,11 +693,15 @@ export async function getWorkers(
       try {
         const worker = await workerPromise;
         completedCount++;
-        progressBar.update(completedCount);
+        if (useProgressBar && progressBar) {
+          progressBar.update(completedCount);
+        }
         return worker;
       } catch (error) {
         completedCount++;
-        progressBar.update(completedCount);
+        if (useProgressBar && progressBar) {
+          progressBar.update(completedCount);
+        }
         throw error;
       }
     }),


### PR DESCRIPTION
### Optimize progress bar usage for large worker sets by displaying progress bar only when initializing more than 50 workers in workers/manager.ts
- Adds a new performance testing suite in [suites/measurements/size-performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1192/files#diff-b673d92198177077949c5a505778049574d0c022f71109de329a87c6c65a3965) that measures execution times for client creation, conversation syncing, message sending, and group management operations across population sizes of 0, 1000, 2000, 5000, and 10000 members with Datadog metrics collection
- Modifies [suites/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1192/files#diff-aa209b39deaaa8a1f7e707f34a5bf11cc221f5020e028557d86d36cc98f4e967) to remove the `POPULATE_SIZE` environment variable loop, causing tests to run once instead of iterating through multiple population sizes
- Updates [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1192/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) to conditionally display progress bar only when initializing more than 50 workers

#### 📍Where to Start
Start with the worker initialization logic in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1192/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) where the progress bar condition has been added.

----

_[Macroscope](https://app.macroscope.com) summarized cdd4a9c._