### PR TITLE
Update consent terminology for clarity in metrics

### DIFF
--- a/measurements/README.md
+++ b/measurements/README.md
@@ -30,12 +30,10 @@ Individual SDK operation performance metrics including client creation, messagin
 | send                | Sending a group message                | 95  | <200   | On Target   |
 | sync                | Syncing group state                    | 77  | <200   | On Target   |
 | updateName          | Updating group metadata                | 76  | <200   | On Target   |
-| stream              | Receiving a group message              | 69  | <200   | On Target   |
 | groupSync           | Group sync operation                   | 66  | <200   | On Target   |
 | addMember           | Adding a member to a group             | 32  | <250   | On Target   |
-| populate            | Populating conversation data           | 28  | <200   | On Target   |
 | inboxState          | Checking inbox state                   | 16  | <350   | On Target   |
-| consent             | Managing consent preferences           | 2   | <100   | On Target   |
+| setConsentStates    | Managing consent preferences           | 2   | <100   | On Target   |
 | getConversationById | Getting conversation by ID             | 1   | <100   | On Target   |
 
 _Note: Baseline is `us-east` region and `production` network._

--- a/measurements/measure.test.ts
+++ b/measurements/measure.test.ts
@@ -136,7 +136,7 @@ describe(testName, () => {
       expect(dmId).toBeDefined();
     });
 
-    it(`consent:group consent`, async () => {
+    it(`setConsentStates:group consent`, async () => {
       await creator!.client.preferences.setConsentStates([
         {
           entity: receiver!.client.inboxId,

--- a/monitoring/functional/streams.test.ts
+++ b/monitoring/functional/streams.test.ts
@@ -46,7 +46,7 @@ describe(testName, async () => {
     expect(verifyResult.allReceived).toBe(true);
   });
 
-  it("consent: consent state changes in groups", async () => {
+  it("groupConsent: consent state changes in groups", async () => {
     group = await workers.createGroupBetweenAll();
     const verifyResult = await verifyGroupConsentStream(
       group,

--- a/monitoring/performance.test.ts
+++ b/monitoring/performance.test.ts
@@ -108,7 +108,7 @@ describe(testName, () => {
     expect(dmId).toBeDefined();
   });
 
-  it(`consent:group consent`, async () => {
+  it(`setConsentStates:group consent`, async () => {
     await creator!.client.preferences.setConsentStates([
       {
         entity: receiver!.client.inboxId,


### PR DESCRIPTION
### Update consent terminology from 'consent' to 'setConsentStates' in test names and performance metrics documentation for clarity
Updates test names and documentation to use more specific terminology for consent operations. The changes rename the `consent` operation to `setConsentStates` in test names across [measurements/measure.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1213/files#diff-8b8b3461bda2b62f6120289220ca502055d9d22d9963a8c9c456f3bd3521e2f4) and [monitoring/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1213/files#diff-aff39dac951484583ac130da3ca93c458531496cc8efe52c86075b72d555f07d), update the group consent test name from 'consent' to 'groupConsent' in [monitoring/functional/streams.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1213/files#diff-d5c3d004ebdc7ec04d4f1d69957950fee880040d1301133c102c8ff27674d6f0), and remove outdated performance metrics for 'stream' and 'populate' operations from [measurements/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1213/files#diff-1fdf3bc4aa3e65ae2a5cd8535d62663871fd557fd8ffc61e524e3df754fa8af8) while renaming the consent metric to match the updated terminology.

#### 📍Where to Start
Start with the performance metrics table in [measurements/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1213/files#diff-1fdf3bc4aa3e65ae2a5cd8535d62663871fd557fd8ffc61e524e3df754fa8af8) to understand the documentation changes, then review the test name updates in [measurements/measure.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1213/files#diff-8b8b3461bda2b62f6120289220ca502055d9d22d9963a8c9c456f3bd3521e2f4).

----

_[Macroscope](https://app.macroscope.com) summarized 4be3e98._