### PR TITLE
Update error line for browser test clarity

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -13,7 +13,9 @@ export const PATTERNS = {
     },
     {
       testName: "Browser",
-      uniqueErrorLines: ["FAIL browser > conversation stream with message"],
+      uniqueErrorLines: [
+        "FAIL  monitoring/browser/browser.test.ts > browser > conversation stream for new member",
+      ],
     },
     {
       testName: "Browser",


### PR DESCRIPTION
### Update error line pattern in KNOWN_ISSUES array from generic browser conversation stream test to specific new member conversation stream test in helpers/analyzer.ts
Updates the `uniqueErrorLines` entry for the 'Browser' test issue in the `KNOWN_ISSUES` array within [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1218/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193). The error pattern changes from 'FAIL browser > conversation stream with message' to 'FAIL monitoring/browser/browser.test.ts > browser > conversation stream for new member', providing a more specific test failure path that includes the full file path and targets new member functionality specifically.

#### 📍Where to Start
Start with the `KNOWN_ISSUES` array in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1218/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) to see the updated error pattern for the Browser test issue.

----

_[Macroscope](https://app.macroscope.com) summarized cdb14de._