### PR TITLE
Add fallback for nodeSDK in worker descriptor generation

### DIFF
--- a/monitoring/performance.test.ts
+++ b/monitoring/performance.test.ts
@@ -107,6 +107,11 @@ describe(testName, () => {
     const dmId = await dm!.send("gm");
     expect(dmId).toBeDefined();
   });
+  it(`streamMessage:measure receiving a gm`, async () => {
+    const verifyResult = await verifyMessageStream(dm!, [receiver!]);
+    setCustomDuration(verifyResult.averageEventTiming);
+    expect(verifyResult.allReceived).toBe(true);
+  });
 
   it(`setConsentStates:group consent`, async () => {
     await creator!.client.preferences.setConsentStates([
@@ -116,12 +121,6 @@ describe(testName, () => {
         state: ConsentState.Allowed,
       },
     ]);
-  });
-
-  it(`streamMessage:measure receiving a gm`, async () => {
-    const verifyResult = await verifyMessageStream(dm!, [receiver!]);
-    setCustomDuration(verifyResult.averageEventTiming);
-    expect(verifyResult.allReceived).toBe(true);
   });
 
   for (const i of BATCH_SIZE) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@anthropic-ai/sdk": "^0.54.0",
     "@xmtp/content-type-reaction": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",
-    "@xmtp/node-bindings": "npm:@xmtp/node-bindings@1.4.0-dev.7f5d8e0",
+    "@xmtp/node-bindings": "npm:@xmtp/node-bindings@1.3.4",
     "@xmtp/node-bindings-0.0.9": "npm:@xmtp/mls-client-bindings-node@0.0.9",
     "@xmtp/node-bindings-0.4.1": "npm:@xmtp/node-bindings@0.0.41",
     "@xmtp/node-bindings-1.0.0": "npm:@xmtp/node-bindings@1.0.0",

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -553,7 +553,7 @@ export async function getWorkers(
   const manager = new WorkerManager(
     (options.env as XmtpEnv) || (process.env.XMTP_ENV as XmtpEnv),
   );
-
+  const nodeSDK = options.nodeSDK || process.env.NODE_VERSION;
   let workerPromises: Promise<Worker>[] = [];
   let descriptors: string[] = [];
 
@@ -565,8 +565,8 @@ export async function getWorkers(
           ? getRandomNames(workers)
           : getFixedNames(workers)
         : workers;
-    descriptors = options.nodeSDK
-      ? names.map((name) => `${name}-${options.nodeSDK}`)
+    descriptors = nodeSDK
+      ? names.map((name) => `${name}-${nodeSDK}`)
       : options.useVersions
         ? nameWithVersions(names)
         : names;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,14 +1532,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings-1.3.4@npm:@xmtp/node-bindings@1.3.4, @xmtp/node-bindings@npm:1.3.4":
+"@xmtp/node-bindings-1.3.4@npm:@xmtp/node-bindings@1.3.4, @xmtp/node-bindings@npm:1.3.4, @xmtp/node-bindings@npm:@xmtp/node-bindings@1.3.4":
   version: 1.3.4
   resolution: "@xmtp/node-bindings@npm:1.3.4"
   checksum: 10/51a92c7a88567d666c4f3742998a29171a54962e9bf3028c91eeb58c95df2287a85ec70b7d5c007f19bf854cf498820d3dce68c006b074f6018ac9127256aae9
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings-1.4.0dev@npm:@xmtp/node-bindings@1.4.0-dev.7f5d8e0, @xmtp/node-bindings@npm:@xmtp/node-bindings@1.4.0-dev.7f5d8e0":
+"@xmtp/node-bindings-1.4.0dev@npm:@xmtp/node-bindings@1.4.0-dev.7f5d8e0":
   version: 1.4.0-dev.7f5d8e0
   resolution: "@xmtp/node-bindings@npm:1.4.0-dev.7f5d8e0"
   checksum: 10/6df7bb3bde964e1cd9be881c66c3ead182b861874a953f227377ac06491fdc1d7cc208f8678aafee7efcb8056e80fc0413300f5d9087eeb568f0cc98b25dd0b7
@@ -4742,7 +4742,7 @@ __metadata:
     "@vitest/ui": "npm:^3.2.4"
     "@xmtp/content-type-reaction": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:@xmtp/node-bindings@1.4.0-dev.7f5d8e0"
+    "@xmtp/node-bindings": "npm:@xmtp/node-bindings@1.3.4"
     "@xmtp/node-bindings-0.0.9": "npm:@xmtp/mls-client-bindings-node@0.0.9"
     "@xmtp/node-bindings-0.4.1": "npm:@xmtp/node-bindings@0.0.41"
     "@xmtp/node-bindings-1.0.0": "npm:@xmtp/node-bindings@1.0.0"


### PR DESCRIPTION
### Add fallback for nodeSDK in worker descriptor generation by using process.env.NODE_VERSION when options.nodeSDK is not provided in WorkerManager.getWorkers
The `WorkerManager.getWorkers` function in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1229/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) now uses `process.env.NODE_VERSION` as a fallback when `options.nodeSDK` is not provided. The code introduces a new `nodeSDK` variable that combines the explicit `options.nodeSDK` parameter with the environment variable fallback, replacing the previous direct usage of `options.nodeSDK` in worker descriptor generation logic.

#### 📍Where to Start
Start with the `getWorkers` function in [workers/manager.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1229/files#diff-0745e41dd19dbedf4ad7e47db8c978f664a21acc68fb6db79e61f2fb5e4a6d42) where the new `nodeSDK` variable is introduced and used in worker descriptor generation.

----

_[Macroscope](https://app.macroscope.com) summarized db3ea20._