### PR TITLE
Update default batch size for performance tests

### DIFF
--- a/monitoring/performance.test.ts
+++ b/monitoring/performance.test.ts
@@ -25,7 +25,7 @@ const testName = "performance";
 describe(testName, () => {
   const BATCH_SIZE = process.env.BATCH_SIZE
     ? process.env.BATCH_SIZE.split("-").map((v) => Number(v))
-    : [50, 100];
+    : [100, 150];
 
   let newGroup: Group;
 
@@ -139,6 +139,9 @@ describe(testName, () => {
         ...workers.getAllButCreator().map((w) => w.client.inboxId),
       ])) as Group;
       expect(newGroup.id).toBeDefined();
+      if (!newGroup.id) {
+        throw new Error("Group ID is undefined, cancelling the test");
+      }
       // Add current group to cumulative tracking
       cumulativeGroups.push(newGroup);
     });


### PR DESCRIPTION
### Update default batch size from [50, 100] to [100, 150] and add group ID validation in performance tests
This pull request modifies the performance testing configuration in [monitoring/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1232/files#diff-aff39dac951484583ac130da3ca93c458531496cc8efe52c86075b72d555f07d) by:

- Increasing the default `BATCH_SIZE` from [50, 100] to [100, 150] to run tests with larger batches
- Adding error handling that throws an error if `newGroup.id` is undefined after group creation, preventing tests from proceeding with invalid group IDs

#### 📍Where to Start
Start with the `BATCH_SIZE` configuration and the new error handling check for `newGroup.id` in [monitoring/performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1232/files#diff-aff39dac951484583ac130da3ca93c458531496cc8efe52c86075b72d555f07d).

----

_[Macroscope](https://app.macroscope.com) summarized 386d90e._