### PR TITLE
Refactor client import for improved clarity and usage

### DIFF
--- a/bots/helpers/xmtp-handler.ts
+++ b/bots/helpers/xmtp-handler.ts
@@ -1,5 +1,5 @@
 import {
-  Client,
+  ClientClass,
   type LogLevel,
   type XmtpEnv,
 } from "version-management/client-versions";
@@ -45,7 +45,7 @@ export const DEFAULT_CORE_OPTIONS: ClientOptions = {
  * Handle message streaming with onMessage callback
  */
 const handleStream = async (
-  client: Client,
+  client: ClientClass,
   callBack: MessageHandler,
   skillOpts: SkillOptions,
 ): Promise<void> => {
@@ -86,14 +86,14 @@ const handleStream = async (
 export const initializeClient = async (
   messageHandler: MessageHandler,
   coreOptions: ClientOptions[],
-): Promise<Client[]> => {
+): Promise<ClientClass[]> => {
   // Merge default options with the provided options
   const mergedCoreOptions = coreOptions.map((opt) => ({
     ...DEFAULT_CORE_OPTIONS,
     ...opt,
   }));
 
-  const clients: Client[] = [];
+  const clients: ClientClass[] = [];
   const streamPromises: Promise<void>[] = [];
 
   for (const option of mergedCoreOptions) {
@@ -118,7 +118,7 @@ export const initializeClient = async (
           codecs: option.codecs,
         };
 
-        const client = await Client.create(signer, {
+        const client = await ClientClass.create(signer, {
           dbEncryptionKey,
           env: env as XmtpEnv,
           loggingLevel: option.loggingLevel,

--- a/measurements/measure.test.ts
+++ b/measurements/measure.test.ts
@@ -143,6 +143,9 @@ describe(testName, () => {
           ...workers.getAll().map((w) => w.client.inboxId),
         ])) as Group;
         expect(newGroup.id).toBeDefined();
+        if (!newGroup.id) {
+          throw new Error("Group ID is undefined, cancelling the test");
+        }
         // Add current group to cumulative tracking
         cumulativeGroups.push(newGroup);
       });

--- a/monitoring/functional/clients.test.ts
+++ b/monitoring/functional/clients.test.ts
@@ -23,7 +23,10 @@ describe(testName, async () => {
 
   it(`downgrade last versions`, async () => {
     const versions = getVersions().slice(0, 3);
-    console.log("versions", versions);
+    console.log(
+      "versions",
+      versions.map((v) => v.nodeSDK),
+    );
     const receiverInboxId = getRandomInboxIds(1)[0];
 
     for (const version of versions) {
@@ -35,7 +38,7 @@ describe(testName, async () => {
 
       // When useVersions is false, the worker name doesn't include the version
       // So we need to get it by the base name without the version
-      const downgrade = versionWorkers.get(name);
+      const downgrade = versionWorkers.get("downgrade");
       console.log("Found downgrade worker:", downgrade ? "yes" : "no");
       console.log("Downgraded to ", "sdk:" + String(downgrade?.sdk));
       let convo = await downgrade?.client.conversations.newDm(receiverInboxId);
@@ -58,8 +61,7 @@ describe(testName, async () => {
 
       // When useVersions is false, the worker name doesn't include the version
       // So we need to get it by the base name without the version
-      const baseName = name.split("-")[0]; // "upgrade"
-      const upgrade = versionWorkers.get(baseName);
+      const upgrade = versionWorkers.get("upgrade");
       console.log("Upgraded to ", "sdk:" + String(upgrade?.sdk));
       let convo = await upgrade?.client.conversations.newDm(receiverInboxId);
       expect(convo?.id).toBeDefined();

--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -66,7 +66,7 @@ import {
 } from "@xmtp/node-sdk-4.0.1";
 
 export {
-  Client,
+  Client as ClientClass,
   ConsentState,
   type Signer,
   type ClientOptions,
@@ -92,7 +92,7 @@ export const VersionList = [
     Group: Group401,
     nodeSDK: "4.0.1dev",
     nodeBindings: "1.4.0dev",
-    auto: false,
+    auto: true,
   },
   {
     Client: Client401,
@@ -229,11 +229,6 @@ export const regressionClient = async (
     fs.mkdirSync(dbDir, { recursive: true });
   }
 
-  const versionConfig = VersionList.find((v) => v.nodeSDK === nodeSDK);
-  if (!versionConfig) {
-    throw new Error(`SDK version ${nodeSDK} not found in VersionList`);
-  }
-  const ClientClass = versionConfig.Client;
   let client = null;
 
   const signer = createSigner(walletKey);


### PR DESCRIPTION
### Rename imported Client class to ClientClass across XMTP handler and version management files for improved clarity
- Renames the imported `Client` class to `ClientClass` in [bots/helpers/xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1233/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19) and [version-management/client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1233/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00), updating all function signatures and references consistently
- Enables auto mode for version 4.0.1dev by changing its `auto` property from `false` to `true` in [version-management/client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1233/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00)
- Removes version lookup logic in the `regressionClient` function to use the globally imported `ClientClass` directly instead of dynamically selecting based on SDK version
- Adds null check for group ID after group creation in [measurements/measure.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1233/files#diff-8b8b3461bda2b62f6120289220ca502055d9d22d9963a8c9c456f3bd3521e2f4) that throws an error if undefined
- Fixes worker retrieval in downgrade and upgrade tests to use base names instead of full names in [monitoring/functional/clients.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1233/files#diff-d286afa3438189a7e3acc6c2fa2b4ff1495aee1c49d5531d0d6983f0fbc16dd9)

#### 📍Where to Start
Start with the `Client` import and export statements in [version-management/client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1233/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00) to understand how the `ClientClass` renaming affects the overall client management system.

----

_[Macroscope](https://app.macroscope.com) summarized a137a79._