### PR TITLE
Enable auto versioning for Client401 configuration

### DIFF
--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -92,7 +92,7 @@ export const VersionList = [
     Group: Group401,
     nodeSDK: "4.0.1dev",
     nodeBindings: "1.4.0dev",
-    auto: false,
+    auto: true,
   },
   {
     Client: Client401,


### PR DESCRIPTION
### Enable auto versioning for Client401 configuration by setting auto property to true for nodeSDK "4.0.1dev" and nodeBindings "1.4.0dev" version entry
Changes the `auto` property from `false` to `true` for the first version entry in the `VersionList` array in [client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1234/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00). This version entry corresponds to the client version with nodeSDK "4.0.1dev" and nodeBindings "1.4.0dev".

#### 📍Where to Start
Start with the `VersionList` array in [client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1234/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00) where the auto property is modified for the development version entry.

----

_[Macroscope](https://app.macroscope.com) summarized 4bdb628._