### PR TITLE
Remove unused VersionList import for cleaner code

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -10,7 +10,6 @@ import {
   getActiveVersion,
   IdentifierKind,
   regressionClient,
-  VersionList,
   type Conversation,
   type Signer,
   type XmtpEnv,


### PR DESCRIPTION
### Remove unused VersionList import from helpers/client.ts module for cleaner code
This pull request removes an unused `VersionList` import from the `version-management/client-versions` module in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1250/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1). The change eliminates dead code without affecting runtime behavior.

#### 📍Where to Start
Start with the import statements at the top of [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1250/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) to see the removed `VersionList` import.

----

_[Macroscope](https://app.macroscope.com) summarized 443bddc._