### PR TITLE
Add logging level configuration to argument parser

### DIFF
--- a/bots/helpers/xmtp-handler.ts
+++ b/bots/helpers/xmtp-handler.ts
@@ -1,5 +1,6 @@
 import {
-  Client,
+  VersionList,
+  type Client,
   type LogLevel,
   type XmtpEnv,
 } from "version-management/client-versions";
@@ -118,7 +119,11 @@ export const initializeClient = async (
           codecs: option.codecs,
         };
 
-        const client = await Client.create(signer, {
+        const ClientClass = VersionList.find(
+          (v) => v.nodeSDK === process.env.NODE_VERSION,
+        )?.Client;
+        // @ts-expect-error - TODO: fix this
+        const client = await ClientClass.create(signer, {
           dbEncryptionKey,
           env: env as XmtpEnv,
           loggingLevel: option.loggingLevel,

--- a/cli/bot.ts
+++ b/cli/bot.ts
@@ -64,12 +64,11 @@ function parseArgs(): Config {
       config.env = nextArg;
       i++;
     } else if (arg === "--nodeSDK" && nextArg) {
-      if (nextArg) {
-        process.env.NODE_VERSION = nextArg;
-        i++;
-      } else {
-        console.warn("--nodeSDK flag requires a value (e.g., --nodeSDK 3.1.1)");
-      }
+      process.env.NODE_VERSION = nextArg;
+      i++;
+    } else if (arg === "--log" && nextArg) {
+      process.env.LOGGING_LEVEL = nextArg;
+      i++;
     } else if (!config.botName) {
       // First non-flag argument is the bot name
       config.botName = arg;

--- a/cli/test.ts
+++ b/cli/test.ts
@@ -247,6 +247,14 @@ function parseTestArgs(args: string[]): {
         options.fileLogging = true;
         process.env.LOGGING_LEVEL = "debug";
         break;
+      case "--log":
+        if (nextArg) {
+          process.env.LOGGING_LEVEL = nextArg;
+          i++;
+        } else {
+          console.warn("--log flag requires a value (e.g., --log debug)");
+        }
+        break;
       case "--nodeSDK":
         if (nextArg) {
           process.env.NODE_VERSION = nextArg;

--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -81,7 +81,7 @@ export {
   type KeyPackageStatus,
   type PermissionUpdateType,
   ConsentEntityType,
-} from "@xmtp/node-sdk-4.0.1";
+} from "@xmtp/node-sdk-4.0.2";
 
 export const VersionList = [
   {


### PR DESCRIPTION
### Add --log flag to CLI argument parsers in bot.ts and test.ts to configure LOGGING_LEVEL environment variable
The CLI argument parsers in both [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1251/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) and [cli/test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1251/files#diff-c8ae179b9daddfdfc3e0fedd868f032dab62c38a4b05a65d61351708ac7b81c4) now accept a `--log` flag that sets the `LOGGING_LEVEL` environment variable. The `parseArgs` function in [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1251/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) also removes the explicit warning branch for the `--nodeSDK` flag, now only setting `NODE_VERSION` when a value is provided.

#### 📍Where to Start
Start with the `parseArgs` function in [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1251/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) to see the main argument parsing logic changes.

----

_[Macroscope](https://app.macroscope.com) summarized dbfe355._