### PR TITLE
Update client initialization to use active version logic

### DIFF
--- a/bots/helpers/xmtp-handler.ts
+++ b/bots/helpers/xmtp-handler.ts
@@ -1,5 +1,4 @@
 import {
-  VersionList,
   type Client,
   type LogLevel,
   type XmtpEnv,
@@ -12,6 +11,7 @@ import {
   getEncryptionKeyFromHex,
   logAgentDetails,
 } from "@helpers/client";
+import { getActiveVersion } from "version-management/client-versions";
 import { generatePrivateKey } from "viem/accounts";
 import {
   DEFAULT_SKILL_OPTIONS,
@@ -119,11 +119,8 @@ export const initializeClient = async (
           codecs: option.codecs,
         };
 
-        const ClientClass = VersionList.find(
-          (v) => v.nodeSDK === process.env.NODE_VERSION,
-        )?.Client;
         // @ts-expect-error - TODO: fix this
-        const client = await ClientClass.create(signer, {
+        const client = await getActiveVersion().Client.create(signer, {
           dbEncryptionKey,
           env: env as XmtpEnv,
           loggingLevel: option.loggingLevel,

--- a/cli/mock-client.ts
+++ b/cli/mock-client.ts
@@ -1,8 +1,9 @@
 import "dotenv/config";
 import { createSigner, getEncryptionKeyFromHex } from "@helpers/client";
 import {
-  Client,
+  getActiveVersion,
   IdentifierKind,
+  type Client,
   type XmtpEnv,
 } from "version-management/client-versions";
 
@@ -31,13 +32,14 @@ class MockXmtpAgent {
     const signer = createSigner(walletKey as `0x${string}`);
     const dbEncryptionKey = getEncryptionKeyFromHex(encryptionKey);
 
-    this.client = await Client.create(signer, {
+    // @ts-expect-error - TODO: fix this
+    this.client = await getActiveVersion().Client.create(signer, {
       dbEncryptionKey,
       env: this.env,
     });
 
-    console.log(`📖 Initialized XMTP client: ${this.client.inboxId}`);
-    return this.client;
+    console.log(`📖 Initialized XMTP client: ${this.client?.inboxId}`);
+    return this.client as Client;
   }
 
   // List all conversations with details

--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -63,7 +63,14 @@ import {
   Dm as Dm401,
   Group as Group401,
 } from "@xmtp/node-sdk-4.0.1";
-import { type LogLevel, type XmtpEnv } from "@xmtp/node-sdk-4.0.2";
+import {
+  Client as Client402,
+  Conversation as Conversation402,
+  Dm as Dm402,
+  Group as Group402,
+  type LogLevel,
+  type XmtpEnv,
+} from "@xmtp/node-sdk-4.0.2";
 
 export {
   Client,
@@ -85,10 +92,10 @@ export {
 
 export const VersionList = [
   {
-    Client: Client401,
-    Conversation: Conversation401,
-    Dm: Dm401,
-    Group: Group401,
+    Client: Client402,
+    Conversation: Conversation402,
+    Dm: Dm402,
+    Group: Group402,
     nodeSDK: "4.0.2",
     nodeBindings: "1.3.5",
     auto: true,


### PR DESCRIPTION
### Update client initialization to use active version logic in xmtp-handler and mock-client components
- The `xmtp-handler.initializeClient` method replaces `VersionList.find` logic with direct calls to `getActiveVersion().Client.create` in [bots/helpers/xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1252/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19)
- The `MockXmtpAgent.initializeClient` method switches from static `Client` imports to dynamic `getActiveVersion().Client.create` calls in [cli/mock-client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1252/files#diff-9af9b66f044caa76348bf804b5259e9049972923f7881b0187509e49deeef8a5)
- The `VersionList` entry for SDK version "4.0.2" updates imports to use correct 4.0.2 client and model class aliases in [version-management/client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1252/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00)

#### 📍Where to Start
Start with the `initializeClient` method in [bots/helpers/xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1252/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19) to understand how client instantiation changes from version selection to active version logic.

----

_[Macroscope](https://app.macroscope.com) summarized 193af72._