### PR TITLE
Enable pull request trigger for manual verification workflow

### DIFF
--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -2,7 +2,7 @@ name: Wildcard
 description: "Manual PR verification workflow - supports functional and performance tests"
 
 on:
-  pull_request:
+  #pull_request:
   schedule:
     - cron: "0 0 1 1 *"
   workflow_dispatch:

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -45,8 +45,8 @@ jobs:
           env: ${{ matrix.env }}
           save-to-cache: true
 
-      - name: Trigger test failure
-        run: exit 1
+      # - name: Trigger test failure
+      #   run: exit 1
 
       - name: Send Slack notification on failure
         if: failure() || cancelled()

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         env: [production]
-        test: [delivery] # performance test with more large groups
+        test: [convos] # performance test with more large groups
         # test: [functional] # full functional test
         # test: [performance] # performance test with more large groups
         # test: [dms] # health check

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -2,7 +2,7 @@ name: Wildcard
 description: "Manual PR verification workflow - supports functional and performance tests"
 
 on:
-  #pull_request:
+  pull_request:
   schedule:
     - cron: "0 0 1 1 *"
   workflow_dispatch:

--- a/bots/helpers/xmtp-handler.ts
+++ b/bots/helpers/xmtp-handler.ts
@@ -37,8 +37,8 @@ export interface ClientOptions extends SkillOptions {
 export const DEFAULT_CORE_OPTIONS: ClientOptions = {
   walletKey: (process.env.WALLET_KEY ?? generatePrivateKey()) as `0x${string}`,
   dbEncryptionKey: process.env.ENCRYPTION_KEY ?? generateEncryptionKeyHex(),
-  loggingLevel: (process.env.LOGGING_LEVEL || "error") as LogLevel,
-  networks: ["dev"],
+  loggingLevel: (process.env.LOGGING_LEVEL || "warn") as LogLevel,
+  networks: [process.env.XMTP_ENV || "production"],
   ...DEFAULT_SKILL_OPTIONS,
 };
 

--- a/cli/bot.ts
+++ b/cli/bot.ts
@@ -10,6 +10,7 @@ interface Config {
   botName: string;
   env: string;
   nodeSDK: string;
+  logLevel: string;
 }
 
 function showHelp() {
@@ -24,7 +25,8 @@ ARGUMENTS:
 
 OPTIONS:
   --env <environment>   XMTP environment (local, dev, production) [default: production]
-  --nodeSDK <version>  XMTP Node SDK version to use [default: latest]
+  --nodeSDK <version>   XMTP Node SDK version to use [default: latest]
+  --log <level>         Logging level (info, warn, error) [default: info]
   -h, --help           Show this help message
 
 ENVIRONMENTS:
@@ -47,11 +49,7 @@ For more information, see: cli/readme.md
 
 function parseArgs(): Config {
   const args = process.argv.slice(2);
-  const config: Config = {
-    botName: "",
-    env: process.env.XMTP_ENV ?? "production",
-    nodeSDK: "latest",
-  };
+  let botName = "";
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -61,7 +59,7 @@ function parseArgs(): Config {
       showHelp();
       process.exit(0);
     } else if (arg === "--env" && nextArg) {
-      config.env = nextArg;
+      process.env.XMTP_ENV = nextArg;
       i++;
     } else if (arg === "--nodeSDK" && nextArg) {
       process.env.NODE_VERSION = nextArg;
@@ -69,13 +67,18 @@ function parseArgs(): Config {
     } else if (arg === "--log" && nextArg) {
       process.env.LOGGING_LEVEL = nextArg;
       i++;
-    } else if (!config.botName) {
+    } else if (!botName) {
       // First non-flag argument is the bot name
-      config.botName = arg;
+      botName = arg;
     }
   }
 
-  return config;
+  return {
+    botName,
+    env: process.env.XMTP_ENV as string,
+    nodeSDK: process.env.NODE_VERSION as string,
+    logLevel: process.env.LOGGING_LEVEL as string,
+  };
 }
 
 async function main() {
@@ -122,6 +125,7 @@ async function main() {
         ...process.env,
         XMTP_ENV: config.env,
         XMTP_NODE_SDK: config.nodeSDK,
+        LOGGING_LEVEL: config.logLevel,
       },
     });
 

--- a/monitoring/bugs/402restart.test.ts
+++ b/monitoring/bugs/402restart.test.ts
@@ -1,0 +1,55 @@
+import { sleep } from "@helpers/client";
+import { setupDurationTracking } from "@helpers/vitest";
+import { getWorkers } from "@workers/manager";
+import { type DecodedMessage } from "version-management/client-versions";
+import { describe, expect, it } from "vitest";
+
+const testName = "clients";
+describe(testName, () => {
+  setupDurationTracking({ testName });
+
+  it("check stream restart (prev 4.0.2 bug)", async () => {
+    const agentWorkers = await getWorkers(1);
+    const agent = agentWorkers.getCreator();
+    let messageCount = 0;
+
+    // First test
+    let talkerWorkers = await getWorkers(1);
+    let creator = talkerWorkers.getCreator();
+    let convo = await creator.client.conversations.newDm(agent.inboxId);
+
+    let stream = await agent.client.conversations.streamAllMessages({
+      onValue: (message: DecodedMessage) => {
+        if (
+          message.senderInboxId.toLowerCase() !== agent.inboxId.toLowerCase()
+        ) {
+          console.log("message", message.content);
+          messageCount++;
+          return;
+        }
+      },
+    });
+    await sleep(1000);
+
+    await convo.send("convo1");
+    await sleep(1000);
+    void stream.end();
+
+    stream = await agent.client.conversations.streamAllMessages({
+      onValue: (message: DecodedMessage) => {
+        if (
+          message.senderInboxId.toLowerCase() !== agent.inboxId.toLowerCase()
+        ) {
+          console.log("message", message.content);
+          messageCount++;
+          return;
+        }
+      },
+    });
+    // First test
+    await convo.send("convo2");
+    await sleep(1000);
+
+    expect(messageCount).toBe(2);
+  });
+});

--- a/monitoring/functional/clients.test.ts
+++ b/monitoring/functional/clients.test.ts
@@ -1,57 +1,96 @@
+import { sleep } from "@helpers/client";
 import { verifyMessageStream } from "@helpers/streams";
 import { setupDurationTracking } from "@helpers/vitest";
 import { getWorkers } from "@workers/manager";
+import {
+  getVersions,
+  type DecodedMessage,
+} from "version-management/client-versions";
 import { describe, expect, it } from "vitest";
 
 const testName = "clients";
 describe(testName, () => {
   setupDurationTracking({ testName });
 
-  // for (const version of getVersions().slice(0, 3)) {
-  //   it(`downgrade to ${version.nodeSDK}`, async () => {
-  //     try {
-  //       await new Promise((resolve) => setTimeout(resolve, 1000));
-  //       const versionWorkers = await getWorkers(["creator", "receiver"], {
-  //         nodeSDK: version.nodeSDK,
-  //       });
+  it("check stream restart (prev 4.0.2 bug)", async () => {
+    const agentWorkers = await getWorkers(1);
+    const agent = agentWorkers.getCreator();
+    let messageCount = 0;
 
-  //       const creator = versionWorkers.getCreator();
-  //       const receiver = versionWorkers.getReceiver();
-  //       let convo = await creator.client.conversations.newDm(receiver.inboxId);
-  //       const verifyResult = await verifyMessageStream(convo, [receiver]);
-  //       expect(verifyResult.receptionPercentage).toBeGreaterThanOrEqual(99);
-  //     } catch (error) {
-  //       console.error("Error downgrading to version", version.nodeSDK, error);
-  //     }
-  //   });
-  // }
-  // for (const version of getVersions().slice(0, 3).reverse()) {
-  //   it(`upgrade to ${version.nodeSDK}`, async () => {
-  //     try {
-  //       await new Promise((resolve) => setTimeout(resolve, 1000));
-  //       const versionWorkers = await getWorkers(["creator", "receiver"], {
-  //         nodeSDK: version.nodeSDK,
-  //       });
+    // First test
+    let talkerWorkers = await getWorkers(1);
+    let creator = talkerWorkers.getCreator();
+    let convo = await creator.client.conversations.newDm(agent.inboxId);
 
-  //       const creator = versionWorkers.getCreator();
-  //       const receiver = versionWorkers.getReceiver();
-  //       let convo = await creator.client.conversations.newDm(receiver.inboxId);
-  //       const verifyResult = await verifyMessageStream(convo, [receiver]);
-  //       expect(verifyResult.receptionPercentage).toBeGreaterThanOrEqual(99);
-  //     } catch (error) {
-  //       console.error("Error upgrading to version", version.nodeSDK, error);
-  //     }
-  //   });
-  // }
-  it("check client restart", async () => {
-    const versionWorkers = await getWorkers(2);
-    const creator = versionWorkers.getCreator();
-    const receiver = versionWorkers.getReceiver();
-    let convo = await creator.client.conversations.newDm(receiver.inboxId);
-    const verifyResult = await verifyMessageStream(convo, [receiver]);
-    expect(verifyResult.receptionPercentage).toBeGreaterThanOrEqual(99);
-    await versionWorkers.terminateAll();
-    const verifyResult2 = await verifyMessageStream(convo, [receiver]);
-    expect(verifyResult2.receptionPercentage).toBeGreaterThanOrEqual(99);
+    let stream = await agent.client.conversations.streamAllMessages({
+      onValue: (message: DecodedMessage) => {
+        if (
+          message.senderInboxId.toLowerCase() !== agent.inboxId.toLowerCase()
+        ) {
+          console.log("message", message.content);
+          messageCount++;
+          return;
+        }
+      },
+    });
+    await sleep(1000);
+
+    await convo.send("convo1");
+    await sleep(1000);
+    void stream.end();
+
+    stream = await agent.client.conversations.streamAllMessages({
+      onValue: (message: DecodedMessage) => {
+        if (
+          message.senderInboxId.toLowerCase() !== agent.inboxId.toLowerCase()
+        ) {
+          console.log("message", message.content);
+          messageCount++;
+          return;
+        }
+      },
+    });
+    // First test
+    await convo.send("convo2");
+    await sleep(1000);
+
+    expect(messageCount).toBe(2);
   });
+
+  for (const version of getVersions().slice(0, 3)) {
+    it(`downgrade to ${version.nodeSDK}`, async () => {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        const versionWorkers = await getWorkers(["creator", "receiver"], {
+          nodeSDK: version.nodeSDK,
+        });
+
+        const creator = versionWorkers.getCreator();
+        const receiver = versionWorkers.getReceiver();
+        let convo = await creator.client.conversations.newDm(receiver.inboxId);
+        const verifyResult = await verifyMessageStream(convo, [receiver]);
+        expect(verifyResult.receptionPercentage).toBeGreaterThanOrEqual(99);
+      } catch (error) {
+        console.error("Error downgrading to version", version.nodeSDK, error);
+      }
+    });
+  }
+  for (const version of getVersions().slice(0, 3).reverse()) {
+    it(`upgrade to ${version.nodeSDK}`, async () => {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        const versionWorkers = await getWorkers(["creator", "receiver"], {
+          nodeSDK: version.nodeSDK,
+        });
+
+        const creator = versionWorkers.getCreator();
+        const receiver = versionWorkers.getReceiver();
+        let convo = await creator.client.conversations.newDm(receiver.inboxId);
+        const verifyResult = await verifyMessageStream(convo, [receiver]);
+        expect(verifyResult.receptionPercentage).toBeGreaterThanOrEqual(99);
+      } catch (error) {
+        console.error("Error upgrading to version", version.nodeSDK, error);
+      }
+    });
+  }
 });

--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -113,7 +113,7 @@ export const VersionList = [
     Group: Group402,
     nodeSDK: "4.0.2",
     nodeBindings: "1.3.5",
-    auto: true,
+    auto: false,
   },
   {
     Client: Client401,

--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -113,7 +113,7 @@ export const VersionList = [
     Group: Group402,
     nodeSDK: "4.0.2",
     nodeBindings: "1.3.5",
-    auto: false,
+    auto: true,
   },
   {
     Client: Client401,

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -545,7 +545,6 @@ export async function getWorkers(
           : getFixedNames(workers)
         : workers;
     descriptors = names;
-    console.log(`Preparing to create ${descriptors.length} workers...`);
     workerPromises = descriptors.map((descriptor) =>
       manager.createWorker(
         descriptor,
@@ -557,7 +556,6 @@ export async function getWorkers(
     let entries = Object.entries(workers);
 
     descriptors = entries.map(([descriptor]) => descriptor);
-    console.log(`Preparing to create ${descriptors.length} workers...`);
     workerPromises = entries.map(([descriptor, apiUrl]) =>
       manager.createWorker(descriptor, sdkVersions[0], apiUrl),
     );


### PR DESCRIPTION
### Enable pull request trigger for manual verification workflow by updating GitHub Actions configuration and modifying bot configuration handling
This pull request modifies the GitHub Actions workflow configuration and bot setup to support manual verification workflows:

- Updates [.github/workflows/Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1272/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085) to change the matrix test from 'delivery' to 'convos' and removes the forced test failure step
- Modifies [bots/helpers/xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1272/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19) to change the default logging level from 'error' to 'warn' and use dynamic environment selection via `process.env.XMTP_ENV`
- Refactors [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1272/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) to add a `logLevel` property to the Config interface, update argument parsing to set environment variables directly, and pass `LOGGING_LEVEL` to spawned bot processes

#### 📍Where to Start
Start with the `parseArgs` function in [cli/bot.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1272/files#diff-501974a5a9d7626c38a57d0541736d683bc57f9729a1c10784ac4a403ec9cd5d) to understand how the configuration changes flow through the system.

----

_[Macroscope](https://app.macroscope.com) summarized 3fed5f9._