### PR TITLE
bump version to 0.3.6 for new feature release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
### Bump version to 0.3.6 in package.json for new feature release
Updates the version number in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1277/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from the previous version to 0.3.6.

#### 📍Where to Start
Start with the version field in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1277/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized c9ee7c5._