### PR TITLE
Add WARN pattern to error log line matching

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -54,7 +54,7 @@ export const PATTERNS = {
   ],
 
   // Patterns to match error log lines
-  MATCH: [/ERROR/, /forked/, /FAIL/, /QA_ERROR/],
+  MATCH: [/ERROR/, /forked/, /FAIL/, /QA_ERROR/, /WARN/],
 } as const;
 
 /**


### PR DESCRIPTION
### Add WARN pattern to error log line matching in helpers.analyzer.PATTERNS configuration
The `helpers.analyzer.PATTERNS` configuration in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1286/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) adds a new regular expression `/WARN/` to the MATCH array for detecting error log lines.

#### 📍Where to Start
Start with the `helpers.analyzer.PATTERNS` configuration in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1286/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193).

----

_[Macroscope](https://app.macroscope.com) summarized 8508f0e._