### PR TITLE
Adjust cron schedules for better performance separation

### DIFF
--- a/.github/workflows/Performance-L.yml
+++ b/.github/workflows/Performance-L.yml
@@ -4,7 +4,7 @@ description: "performance of medium groups"
 on:
   #pull_request:
   schedule:
-    - cron: "0 */4 * * *" # Runs every 2 hours at 15 minutes past the hour (avoids :00 and provides separation from Performance at :30)
+    - cron: "30 */6 * * *" # Runs every 6 hours at 30 minutes past the hour (avoids :00 and provides separation from Performance at :30)
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/Performance-M.yml
+++ b/.github/workflows/Performance-M.yml
@@ -4,7 +4,7 @@ description: "performance of medium groups"
 on:
   #pull_request:
   schedule:
-    - cron: "0 */2 * * *" # Runs every 2 hours at 15 minutes past the hour (avoids :00 and provides separation from Performance at :30)
+    - cron: "15 */3 * * *" # Runs every  2 hours at 15 minutes past the hour (avoids :00 and provides separation from Performance at :30)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Adjust GitHub Actions workflow cron schedules for better performance separation by changing Performance-L workflow from every 4 hours at minute 0 to every 6 hours at minute 30 and Performance-M workflow from every 2 hours at minute 0 to every 3 hours at minute 15
This pull request modifies the scheduling of two GitHub Actions performance workflows to reduce overlap and improve resource distribution:

- [Performance-L.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1298/files#diff-63954d4ae90a082f800aab15243eca2327548a76825c6283bfce75c8d81bf64e) cron expression changes from `0 */4 * * *` to `30 */6 * * *`
- [Performance-M.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1298/files#diff-8e16839d7caa6b32c3bdc68775326a503a57cc12cb3eb55f8cdbaa4750daf00d) cron expression changes from `0 */2 * * *` to `15 */3 * * *`

#### 📍Where to Start
Start by reviewing the cron schedule changes in [Performance-L.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1298/files#diff-63954d4ae90a082f800aab15243eca2327548a76825c6283bfce75c8d81bf64e) to understand the new timing pattern.

----

_[Macroscope](https://app.macroscope.com) summarized b7e1935._