### PR TITLE
Enable Corepack in CI workflows for package management

### DIFF
--- a/.github/workflows/validate-package-compatibility.yml
+++ b/.github/workflows/validate-package-compatibility.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           git clone https://github.com/xmtp/gm-bot.git
 
+      - name: Enable Corepack
+        run: corepack enable
+        shell: bash
+
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/validate-qa-repo.yml
+++ b/.github/workflows/validate-qa-repo.yml
@@ -38,6 +38,10 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Enable Corepack
+        run: corepack enable
+        shell: bash
+
       - name: Install dependencies
         run: |
           cd qa-tools-test


### PR DESCRIPTION
### Enable Corepack in CI workflows for package management by adding 'Enable Corepack' steps to validate-package-compatibility.yml and validate-qa-repo.yml
Two GitHub Actions workflow files are modified to include new 'Enable Corepack' steps that execute `corepack enable` with bash shell before existing package management operations:

- [validate-package-compatibility.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1301/files#diff-859b27b0dff6a609acf47d647a8bfd71042e7d2e26da73fca48be4b1cf70a6af) adds the step before the 'Set up Node.js' step
- [validate-qa-repo.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1301/files#diff-7647026c62b2e39496d4200d606fbc70bc8bd2634da9d4cdd11edfec5cfd2029) adds the step before the 'Install dependencies' step

#### 📍Where to Start
Start with the 'Enable Corepack' step addition in [validate-package-compatibility.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1301/files#diff-859b27b0dff6a609acf47d647a8bfd71042e7d2e26da73fca48be4b1cf70a6af) to understand the workflow modification pattern.

----

_[Macroscope](https://app.macroscope.com) summarized ccb3dc4._