### PR TITLE
Improve debugging in XMTP client initialization process

### DIFF
--- a/bots/helpers/xmtp-handler.ts
+++ b/bots/helpers/xmtp-handler.ts
@@ -118,23 +118,16 @@ export const initializeClient = async (
           strictCommandFiltering: option.strictCommandFiltering,
           codecs: option.codecs,
         };
-        console.log(
-          "entra1",
-          dbEncryptionKey,
-          env,
-          "debug",
-          getDbPath(`${env}-${signerIdentifier}`),
-          skillOptions.codecs,
-        );
+
         // @ts-expect-error - TODO: fix this
         const client = await getActiveVersion().Client.create(signer, {
           dbEncryptionKey,
           env: env as XmtpEnv,
-          loggingLevel: "debug",
+          loggingLevel: option.loggingLevel,
           dbPath: getDbPath(`${env}-${signerIdentifier}`),
           codecs: skillOptions.codecs ?? [],
         });
-        console.log("entra2", client);
+
         // @ts-expect-error - TODO: fix this
         clients.push(client);
 


### PR DESCRIPTION
### Add debug logging and force debug level in XMTP client initialization process
The `initializeClient` function in [bots/helpers/xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1322/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19) now includes console.log statements before and after client creation to log initialization parameters and the created client object. The function also hard-codes the `loggingLevel` to "debug" instead of using the provided option value. The package version is bumped from 0.3.9 to 0.3.10 in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1322/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

#### 📍Where to Start
Start with the `initializeClient` function in [bots/helpers/xmtp-handler.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1322/files#diff-d5ac68ef371f12bc4e1ad34b9e8b53887fb534f1a6f2e62c690ab84d80628a19).

----

_[Macroscope](https://app.macroscope.com) summarized a862051._