### PR TITLE
Allow averageEventTiming to be undefined when zero

### DIFF
--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -542,7 +542,7 @@ export async function verifyAgentMessageStream(
       membersForStats: receivers,
     });
 
-    if (result.averageEventTiming !== undefined) {
+    if (result && result.averageEventTiming !== undefined) {
       // Check if averageEventTiming is defined
       return result;
     }

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -11,7 +11,7 @@ import {
 
 // Define the expected return type of verifyMessageStream
 export type VerifyStreamResult = {
-  averageEventTiming: number;
+  averageEventTiming: number | undefined;
   receptionPercentage: number;
   orderPercentage: number;
 };
@@ -193,7 +193,8 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
   );
 
   const allResults = {
-    averageEventTiming,
+    averageEventTiming:
+      averageEventTiming === 0 ? undefined : averageEventTiming,
     receptionPercentage: stats?.receptionPercentage,
     orderPercentage: stats?.orderPercentage,
   };


### PR DESCRIPTION
### Allow averageEventTiming to be undefined when zero in VerifyStreamResult type and collectAndTimeEventsWithStats util
The `VerifyStreamResult` type alias in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1331/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) changes `averageEventTiming` from `number` to `number | undefined`, and the `collectAndTimeEventsWithStats` util now returns `undefined` for `averageEventTiming` when the computed value equals 0.

#### 📍Where to Start
Start with the `collectAndTimeEventsWithStats` util function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1331/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to see how the `averageEventTiming` value is computed and conditionally set to undefined.

----

_[Macroscope](https://app.macroscope.com) summarized 2d738ad._