### PR TITLE
Fix averageEventTiming handling for accurate metrics

### DIFF
--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -194,7 +194,7 @@ async function collectAndTimeEventsWithStats<TSent, TReceived>(options: {
 
   const allResults = {
     averageEventTiming:
-      averageEventTiming === 0 ? undefined : Math.abs(averageEventTiming),
+      averageEventTiming === 0 ? undefined : averageEventTiming,
     receptionPercentage: stats?.receptionPercentage,
     orderPercentage: stats?.orderPercentage,
   };

--- a/monitoring/agents/agents-dms.test.ts
+++ b/monitoring/agents/agents-dms.test.ts
@@ -52,10 +52,16 @@ describe(testName, async () => {
         agent.sendMessage,
         3,
       );
-      console.log(JSON.stringify(result, null, 2));
+
+      const responseTime = Math.abs(
+        result?.averageEventTiming ?? streamTimeout,
+      );
+      console.log("result.averageEventTiming", result?.averageEventTiming);
+      console.log("streamTimeout", streamTimeout);
+      console.log("responseTime", responseTime);
 
       // dont do ?? streamTimeout because it will be 0 and it will be ignored by datadog
-      sendMetric("response", result?.averageEventTiming || streamTimeout, {
+      sendMetric("response", responseTime, {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",

--- a/monitoring/agents/agents-health.test.ts
+++ b/monitoring/agents/agents-health.test.ts
@@ -49,7 +49,12 @@ describe(testName, () => {
         message: string;
       };
 
-      sendMetric("response", result.responseTime ?? streamTimeout, {
+      const responseTime = Math.abs(result?.responseTime ?? streamTimeout);
+      console.log("result.responseTime", result?.responseTime);
+      console.log("streamTimeout", streamTimeout);
+      console.log("responseTime", responseTime);
+
+      sendMetric("response", responseTime, {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",

--- a/monitoring/agents/agents-tagged.test.ts
+++ b/monitoring/agents/agents-tagged.test.ts
@@ -63,8 +63,15 @@ describe(testName, async () => {
 
       // If the agent didn't respond, log the timeout value instead of 0
 
+      const responseTime = Math.abs(
+        result?.averageEventTiming ?? streamTimeout,
+      );
+      console.log("result.averageEventTiming", result?.averageEventTiming);
+      console.log("streamTimeout", streamTimeout);
+      console.log("responseTime", responseTime);
+
       // dont do ?? streamTimeout because it will be 0 and it will be ignored by datadog
-      sendMetric("response", result?.averageEventTiming || streamTimeout, {
+      sendMetric("response", responseTime, {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",

--- a/monitoring/agents/agents-untagged.test.ts
+++ b/monitoring/agents/agents-untagged.test.ts
@@ -62,8 +62,15 @@ describe(testName, async () => {
         "hi",
       );
 
+      const responseTime = Math.abs(
+        result?.averageEventTiming ?? streamTimeout,
+      );
+      console.log("result.averageEventTiming", result?.averageEventTiming);
+      console.log("streamTimeout", streamTimeout);
+      console.log("responseTime", responseTime);
+
       // dont do ?? streamTimeout because it will be 0 and it will be ignored by datadog
-      sendMetric("response", result?.averageEventTiming || streamTimeout, {
+      sendMetric("response", responseTime, {
         test: testName,
         metric_type: "agent",
         metric_subtype: "dm",


### PR DESCRIPTION
### Fix averageEventTiming handling to return raw values instead of absolute values in collectAndTimeEventsWithStats helper and update monitoring agents to use absolute values for accurate metrics
The `collectAndTimeEventsWithStats` helper in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1336/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) now returns raw `averageEventTiming` values without applying `Math.abs`, while monitoring agent test files compute absolute values locally for metric reporting:

- Modified `collectAndTimeEventsWithStats` to assign `averageEventTiming` directly when non-zero, removing `Math.abs` application
- Updated monitoring agent tests in [monitoring/agents/agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1336/files#diff-686c3ff2fc6315950504d530b5724419a502eb6e8cc53324fa3038894c5575e9), [monitoring/agents/agents-health.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1336/files#diff-e8d17d0171c2f5f7274784029ab98cf0ba86c8b63f8008dbe381a39f7940baef), [monitoring/agents/agents-tagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1336/files#diff-aa26347f63bd3e0967ebfcee8f326be082719750afea7160ab353dd0c46d7a76), and [monitoring/agents/agents-untagged.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1336/files#diff-517b8b34b08794da34e384a7e280e9ed87763442a3444ac35538641e3a04c839) to compute `responseTime` as `Math.abs(result?.averageEventTiming ?? streamTimeout)` before sending metrics
- Changed metric reporting to use computed `responseTime` values instead of raw timing values or `streamTimeout` defaults

#### 📍Where to Start
Start with the `collectAndTimeEventsWithStats` helper function in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1336/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to understand how the raw timing values are now returned without absolute value conversion.

----

_[Macroscope](https://app.macroscope.com) summarized abc0f19._