### PR TITLE
Update node SDK version retrieval for consistency

### DIFF
--- a/bots/key-check/index.ts
+++ b/bots/key-check/index.ts
@@ -13,7 +13,7 @@ import { initializeClient } from "../xmtp-skills";
 const require = createRequire(import.meta.url);
 const packageJson = require("../../package.json");
 const xmtpSdkVersion =
-  packageJson.dependencies["@xmtp/node-sdk-" + getActiveVersion(1).nodeSDK];
+  packageJson.dependencies["@xmtp/node-sdk-" + getActiveVersion().nodeSDK];
 
 // Track when the bot started
 const startTime = new Date();

--- a/bots/xmtp-skills.ts
+++ b/bots/xmtp-skills.ts
@@ -122,10 +122,8 @@ export const initializeClient = async (
           codecs: option.codecs,
         };
 
-        const client = await getActiveVersion(
-          option.indexVersion,
-          // @ts-expect-error - TODO: fix this
-        ).Client.create(signer, {
+        // @ts-expect-error - TODO: fix this
+        const client = await getActiveVersion().Client.create(signer, {
           dbEncryptionKey,
           env: env as XmtpEnv,
           loggingLevel: option.loggingLevel,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmtp-qa-tools",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -61,7 +61,7 @@ export const VersionList = [
     Group: Group410,
     nodeSDK: "4.1.0rc1",
     nodeBindings: "1.4.0rc1",
-    auto: true,
+    auto: false,
   },
   {
     Client: Client403,


### PR DESCRIPTION
### Update node SDK version retrieval to use getActiveVersion() instead of indexed version selection for consistency
This pull request modifies version selection logic across multiple files to use the auto-selected active version instead of explicit index-based version selection. The changes affect:

- [bots/key-check/index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1337/files#diff-ef019451c04a5f80460878e159c33463ac1e3333ff9cddf8854e5312406973db) replaces `getActiveVersion(1).nodeSDK` with `getActiveVersion().nodeSDK` for dependency key computation
- [bots/xmtp-skills.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1337/files#diff-0bc69f2c97d0fcb3f6e39007b122c651076f06ccb18cdddcd425ffda4fe9c8ed) removes the `indexVersion` parameter usage in the `initializeClient` handler, switching from `getActiveVersion(option.indexVersion).Client.create()` to `getActiveVersion().Client.create()`
- [version-management/client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1337/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00) sets the `auto` flag of the 4.1.0rc1 entry to `false` in the `VersionList` constant
- [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1337/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) bumps the version from 0.3.15 to 0.3.16

#### 📍Where to Start
Start with the `getActiveVersion()` function calls in [bots/xmtp-skills.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1337/files#diff-0bc69f2c97d0fcb3f6e39007b122c651076f06ccb18cdddcd425ffda4fe9c8ed) within the `initializeClient` handler to understand how the version selection logic has changed.

----

_[Macroscope](https://app.macroscope.com) summarized e5b1d21._