### PR TITLE
Improve error logging for metric values in Datadog helper

### DIFF
--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -17,6 +17,7 @@ export const PATTERNS = {
   max_error_logs: 20,
 
   DEDUPE: [
+    "xmtp_mls::groups::commit_log_key",
     "sqlcipher_mlock",
     "Collector timed out.",
     "KeyPackageCleaner worker error:",

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -156,7 +156,7 @@ export function sendMetric(
 ): void {
   try {
     if (metricValue <= 0) {
-      console.error(`❌ Metric value is 0 or negative: ${metricName}`);
+      console.error(`${metricName} Metric value is ${metricValue}`);
       return;
     }
     const enrichedTags = enrichTags(tags);
@@ -217,9 +217,7 @@ export function sendHistogramMetric(
 ): void {
   try {
     if (metricValue <= 0) {
-      console.error(
-        `❌ Histogram metric value is 0 or negative: ${metricName}`,
-      );
+      console.error(`${metricName} Histogram metric value is ${metricValue}`);
       return;
     }
     const enrichedTags = enrichTags(tags);


### PR DESCRIPTION
### Improve error logging for metric values in Datadog helper by modifying `sendMetric` and `sendHistogramMetric` functions to include metric names and values in error messages
- Modifies error logging in `sendMetric` and `sendHistogramMetric` functions in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1340/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to include metric names and actual values when metricValue <= 0
- Adds "xmtp_mls::groups::commit_log_key" pattern to PATTERNS.DEDUPE in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1340/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193) for log deduplication

#### 📍Where to Start
Start with the `sendMetric` function in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1340/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3) to review the error logging changes for non-positive metric values.

----

_[Macroscope](https://app.macroscope.com) summarized e3303e6._