### PR TITLE
Enable auto versioning for improved client updates

### DIFF
--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -61,7 +61,7 @@ export const VersionList = [
     Group: Group410,
     nodeSDK: "4.1.0rc1",
     nodeBindings: "1.4.0rc2",
-    auto: false,
+    auto: true,
   },
   {
     Client: Client403,


### PR DESCRIPTION
### Enable auto versioning for nodeSDK version 4.1.0rc1 in the VersionList constant to improve client updates
The `auto` flag for the nodeSDK version 4.1.0rc1 entry in the `VersionList` constant is changed from `false` to `true` in [client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1343/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00).

#### 📍Where to Start
Start with the `VersionList` constant in [client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1343/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00).

----

_[Macroscope](https://app.macroscope.com) summarized d31ba8d._