### PR TITLE
Update XMTP SDK version for compatibility improvements

### DIFF
--- a/version-management/client-versions.ts
+++ b/version-management/client-versions.ts
@@ -52,7 +52,7 @@ export {
   type KeyPackageStatus,
   type PermissionUpdateType,
   ConsentEntityType,
-} from "@xmtp/node-sdk-4.1.0rc1";
+} from "@xmtp/node-sdk-4.1.0";
 export const VersionList = [
   {
     Client: Client410,


### PR DESCRIPTION
### Update XMTP SDK version from '@xmtp/node-sdk-4.1.0rc1' to '@xmtp/node-sdk-4.1.0' in client-versions module for compatibility improvements
The `client-versions` module updates its re-export source from the release candidate package `@xmtp/node-sdk-4.1.0rc1` to the stable release `@xmtp/node-sdk-4.1.0` in [version-management/client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1346/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00).

#### 📍Where to Start
Start with the re-export statements in [version-management/client-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1346/files#diff-bbd7ee899dc502d45a823fc3665c89dba0605f8274e71ba2891420f9c7b5ba00).

----

_[Macroscope](https://app.macroscope.com) summarized c7223e8._