### PR TITLE
Reduce default stream timeout for improved performance

### DIFF
--- a/helpers/client.ts
+++ b/helpers/client.ts
@@ -502,7 +502,7 @@ export const browserTimeout = 10000;
 export const streamColdStartTimeout = 1000; // 1 second
 export const streamTimeout = process.env.DEFAULT_STREAM_TIMEOUT_MS
   ? parseInt(process.env.DEFAULT_STREAM_TIMEOUT_MS)
-  : 8000; // 8 seconds
+  : 6000; // 8 seconds
 
 export const formatBytes = (bytes: number): string => {
   if (bytes === 0) return "0 B";

--- a/monitoring/browser/browser.test.ts
+++ b/monitoring/browser/browser.test.ts
@@ -11,7 +11,7 @@ const testName = "browser";
 describe(testName, () => {
   setupDurationTracking({ testName });
   let groupId: string;
-  const headless = true;
+  const headless = false;
   let xmtpTester: playwright;
   let creator: Worker;
   let xmtpChat: Worker;


### PR DESCRIPTION
### Reduce the fallback `streamTimeout` default in `helpers/client.ts` from 8000 ms to 6000 ms when `DEFAULT_STREAM_TIMEOUT_MS` is unset for improved performance.
- Update the fallback `streamTimeout` default to 6000 ms in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1364/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1) when `DEFAULT_STREAM_TIMEOUT_MS` is not set.
- Set the Playwright `headless` flag to `false` in [monitoring/browser/browser.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1364/files#diff-1495ed8d64f2006013e8e3736f3f13ed03ff6f8da6609c3c5504a538f6c1b7e9).

#### 📍Where to Start
Start with the exported `streamTimeout` constant in [helpers/client.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1364/files#diff-3eab4c764ec1969fbd1c629bf5508332cf02f59becf1b4c61242888cdee026e1).

----

_[Macroscope](https://app.macroscope.com) summarized e916cd7._