### PR TITLE
Remove outdated SDK update script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "update:dev": "yarn gen --env dev --installations 2 ",
     "update:local": "yarn gen --env local --installations 2",
     "update:prod": "yarn gen --env production --installations 2 ",
-    "update:sdk": "node version-management/update-sdk.js",
     "versions": "tsx version-management/cli-versions.ts"
   },
   "dependencies": {


### PR DESCRIPTION
### Remove outdated `update:sdk` npm script from [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1366/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
Delete the npm script `update:sdk`, which runs `node version-management/update-sdk.js`, from [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1366/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

#### 📍Where to Start
Start at the `scripts` section in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1366/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized 15f3911._