### PR TITLE
Reorder script execution for better workflow clarity

### DIFF
--- a/.github/workflows/validate-regression.yml
+++ b/.github/workflows/validate-regression.yml
@@ -62,11 +62,11 @@ jobs:
           restore-keys: |
             deps-
 
-      - name: Run script version
-        run: yarn versions
-
       - name: Run yarn
         run: yarn
+
+      - name: Run script version
+        run: yarn versions
 
       - name: Run regression tests
         run: yarn regression


### PR DESCRIPTION
### Reorder steps in the GitHub Actions validate-regression workflow to run `Run yarn` before `Run script version` for better workflow clarity
Modify the step sequence in [validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1367/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37) by changing the order of two existing steps within the workflow.

#### 📍Where to Start
Start in the steps section of [validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1367/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37), focusing on the ordering of `Run yarn` and `Run script version`.

----

_[Macroscope](https://app.macroscope.com) summarized 5e21ade._