### PR TITLE
Improve error handling in symlink creation process

### DIFF
--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -18,7 +18,6 @@ jobs:
         test: [browser] # performance test with more large groups
         # test: [functional] # full functional test
         # test: [performance] # performance test with more large groups
-        # test: [dms] # health check
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/version-management/cli-versions.ts
+++ b/version-management/cli-versions.ts
@@ -33,10 +33,12 @@ function createBindingsSymlinks() {
 
   if (!fs.existsSync(xmtpDir)) {
     console.error("@xmtp directory not found");
-    return;
+    process.exit(1);
   }
 
   console.log("Creating bindings symlinks...");
+
+  let hasErrors = false;
 
   for (const config of VersionList) {
     if (!config.nodeSDK) continue;
@@ -48,16 +50,18 @@ function createBindingsSymlinks() {
     );
 
     if (!fs.existsSync(sdkDir)) {
-      console.log(
-        `⚠️  SDK directory not found: ${config.nodeBindings} (${sdkDir})`,
+      console.error(
+        `❌ SDK directory not found: ${config.nodeSDK} (${sdkDir})`,
       );
+      hasErrors = true;
       continue;
     }
 
     if (!fs.existsSync(bindingsDir)) {
-      console.log(
-        `⚠️  Bindings directory not found: ${config.nodeBindings} (${bindingsDir})`,
+      console.error(
+        `❌ Bindings directory not found: ${config.nodeBindings} (${bindingsDir})`,
       );
+      hasErrors = true;
       continue;
     }
 
@@ -81,10 +85,16 @@ function createBindingsSymlinks() {
         bindingsDir,
       );
       fs.symlinkSync(relativeBindingsPath, symlinkTarget);
-      console.log(`${config.nodeBindings} -> ${config.nodeBindings}`);
+      console.log(`${config.nodeSDK} -> ${config.nodeBindings}`);
     } catch (error) {
-      console.error(`Error linking ${config.nodeBindings}: ${String(error)}`);
+      console.error(`Error linking ${config.nodeSDK}: ${String(error)}`);
+      hasErrors = true;
     }
+  }
+
+  if (hasErrors) {
+    console.error("❌ Failed to create all required symlinks");
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
### Enforce exit code 1 and route failures to `console.error` in symlink creation by `createBindingsSymlinks` in [cli-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1370/files#diff-a98a66a1f28214d9c0eea260266fa21ff7cb978c31faf133628edc7402f188fe) to improve error handling
- Update [version-management/cli-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1370/files#diff-a98a66a1f28214d9c0eea260266fa21ff7cb978c31faf133628edc7402f188fe) to introduce a `hasErrors` accumulator, exit with `process.exit(1)` when the `@xmtp` directory is missing or when any SDK/bindings directory is missing or a symlink creation fails, switch error logs to `console.error`, fix messages to reference `config.nodeSDK`, adjust the success log to print `nodeSDK -> nodeBindings`, and add a final failure summary before exiting.
- Remove a commented-out matrix test entry from [.github/workflows/Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1370/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085).

#### 📍Where to Start
Start with the `createBindingsSymlinks` function in [version-management/cli-versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1370/files#diff-a98a66a1f28214d9c0eea260266fa21ff7cb978c31faf133628edc7402f188fe).

----

_[Macroscope](https://app.macroscope.com) summarized d4f14af._