### PR TITLE
Add agents-text workflow for enhanced testing and alerts

### DIFF
--- a/.github/workflows/AgentText.yml
+++ b/.github/workflows/AgentText.yml
@@ -2,7 +2,7 @@ name: Agent health
 description: "health of the agents"
 
 on:
-  pull_request:
+  #pull_request:
   schedule:
     - cron: "*/30 * * * *" # Runs every  30 minutes for agents-text
   workflow_dispatch:

--- a/.github/workflows/AgentText.yml
+++ b/.github/workflows/AgentText.yml
@@ -1,0 +1,44 @@
+name: Agent health
+description: "health of the agents"
+
+on:
+  #pull_request:
+  schedule:
+    - cron: "*/30 * * * *" # Runs every  30 minutes for agents-text
+  workflow_dispatch:
+
+jobs:
+  agents-text:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [agents-text]
+        env: [production]
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      REGION: ${{ vars.REGION }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup test env
+        uses: ./.github/actions/xmtp-test-setup
+
+      - name: ${{ matrix.test }} ${{ matrix.env }}
+        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} --no-fail --log off
+
+      - name: Cleanup and upload artifacts
+        if: always()
+        uses: ./.github/actions/xmtp-test-cleanup
+        with:
+          test-name: ${{ matrix.test }}
+          env: ${{ matrix.env }}
+
+      - name: Send Slack notification on failure
+        if: failure() || cancelled()
+        uses: ./.github/actions/slack-notification
+        with:
+          workflow-name: "Agent health (${{ matrix.test }}, ${{ matrix.env }})"
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/AgentText.yml
+++ b/.github/workflows/AgentText.yml
@@ -2,7 +2,7 @@ name: Agent health
 description: "health of the agents"
 
 on:
-  #pull_request:
+  pull_request:
   schedule:
     - cron: "*/30 * * * *" # Runs every  30 minutes for agents-text
   workflow_dispatch:

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -74,38 +74,3 @@ jobs:
         with:
           workflow-name: "Agents (untagged, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-
-  agents-text:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        test: [agents-text]
-        env: [production]
-    env:
-      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-      REGION: ${{ vars.REGION }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup test env
-        uses: ./.github/actions/xmtp-test-setup
-
-      - name: ${{ matrix.test }} ${{ matrix.env }}
-        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} --no-fail --log off
-
-      - name: Cleanup and upload artifacts
-        if: always()
-        uses: ./.github/actions/xmtp-test-cleanup
-        with:
-          test-name: ${{ matrix.test }}
-          env: ${{ matrix.env }}
-
-      - name: Send Slack notification on failure
-        if: failure() || cancelled()
-        uses: ./.github/actions/slack-notification
-        with:
-          workflow-name: "Agent health (${{ matrix.test }}, ${{ matrix.env }})"
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/Agents.yml
+++ b/.github/workflows/Agents.yml
@@ -74,3 +74,38 @@ jobs:
         with:
           workflow-name: "Agents (untagged, ${{ matrix.env }})"
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  agents-text:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [agents-text]
+        env: [production]
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      REGION: ${{ vars.REGION }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup test env
+        uses: ./.github/actions/xmtp-test-setup
+
+      - name: ${{ matrix.test }} ${{ matrix.env }}
+        run: yarn test ${{ matrix.test }}  --env ${{ matrix.env }} --no-fail --log off
+
+      - name: Cleanup and upload artifacts
+        if: always()
+        uses: ./.github/actions/xmtp-test-cleanup
+        with:
+          test-name: ${{ matrix.test }}
+          env: ${{ matrix.env }}
+
+      - name: Send Slack notification on failure
+        if: failure() || cancelled()
+        uses: ./.github/actions/slack-notification
+        with:
+          workflow-name: "Agent health (${{ matrix.test }}, ${{ matrix.env }})"
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/helpers/streams.ts
+++ b/helpers/streams.ts
@@ -508,6 +508,7 @@ export async function verifyAgentMessageStream(
   receivers: Worker[],
   triggerMessage: string,
   maxRetries: number = 1,
+  types: string[] = ["text", "reply", "reaction", "actions"],
   customTimeout?: number,
 ): Promise<VerifyStreamResult | undefined> {
   receivers.forEach((worker) => {
@@ -524,7 +525,7 @@ export async function verifyAgentMessageStream(
         r.worker.collectMessages(
           group.id,
           1,
-          ["text", "reply", "reaction", "actions"],
+          types,
           customTimeout ?? undefined,
         ),
       // @ts-expect-error - TODO: fix this

--- a/monitoring/agents/agents-text.test.ts
+++ b/monitoring/agents/agents-text.test.ts
@@ -57,9 +57,6 @@ describe(testName, async () => {
       const responseTime = Math.abs(
         result?.averageEventTiming ?? streamTimeout,
       );
-      console.log("result.averageEventTiming", result?.averageEventTiming);
-      console.log("streamTimeout", streamTimeout);
-      console.log("responseTime", responseTime);
 
       // dont do ?? streamTimeout because it will be 0 and it will be ignored by datadog
       sendMetric("response", responseTime, {

--- a/monitoring/agents/agents-text.test.ts
+++ b/monitoring/agents/agents-text.test.ts
@@ -1,0 +1,79 @@
+import { streamTimeout } from "@helpers/client";
+import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
+import { verifyAgentMessageStream } from "@helpers/streams";
+import { setupDurationTracking } from "@helpers/vitest";
+import { getWorkers } from "@workers/manager";
+import {
+  IdentifierKind,
+  type Conversation,
+  type XmtpEnv,
+} from "version-management/client-versions";
+import { describe, expect, it } from "vitest";
+import productionAgents from "./agents.json";
+import { type AgentConfig } from "./helper";
+
+const testName = "agents-dms";
+describe(testName, async () => {
+  setupDurationTracking({ testName, initDataDog: true });
+  const env = process.env.XMTP_ENV as XmtpEnv;
+  const workers = await getWorkers(["randomguy"]);
+
+  const filteredAgents = (productionAgents as AgentConfig[]).filter((agent) => {
+    return agent.networks.includes(env) && agent.live;
+  });
+
+  // Handle case where no agents are configured for the current environment
+  if (filteredAgents.length === 0) {
+    it(`${testName}: No agents configured for this environment`, () => {
+      console.log(`No agents found for env: ${env}`);
+      expect(true).toBe(true); // Pass the test
+    });
+    return;
+  }
+
+  // Test each agent in DMs
+  for (const agent of filteredAgents) {
+    it(`${testName}: ${agent.name} DM : ${agent.address}`, async () => {
+      console.log(
+        `sending ${agent.sendMessage} to agent`,
+        agent.name,
+        agent.address,
+      );
+      const conversation = await workers
+        .getCreator()
+        .client.conversations.newDmWithIdentifier({
+          identifier: agent.address,
+          identifierKind: IdentifierKind.Ethereum,
+        });
+
+      const result = await verifyAgentMessageStream(
+        conversation as Conversation,
+        [workers.getCreator()],
+        agent.sendMessage,
+        3,
+        ["text", "reply"],
+      );
+
+      const responseTime = Math.abs(
+        result?.averageEventTiming ?? streamTimeout,
+      );
+      console.log("result.averageEventTiming", result?.averageEventTiming);
+      console.log("streamTimeout", streamTimeout);
+      console.log("responseTime", responseTime);
+
+      // dont do ?? streamTimeout because it will be 0 and it will be ignored by datadog
+      sendMetric("response", responseTime, {
+        test: testName,
+        metric_type: "agent",
+        metric_subtype: "text",
+        agent: agent.name,
+        address: agent.address,
+        sdk: workers.getCreator().sdk,
+      } as ResponseMetricTags);
+
+      if (result?.receptionPercentage === 0)
+        console.error(agent.name, "no response");
+      expect(result?.receptionPercentage).toBeGreaterThanOrEqual(0);
+    });
+  }
+});


### PR DESCRIPTION
### Add 'Agent health' GitHub Actions workflow in [AgentText.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1379/files#diff-83e380521997523c0e40c0882a60adc33094cb486612305b77b40880aee1abd9) to run agents-text tests every 30 minutes, on pull_request, and via manual dispatch for enhanced testing and alerts
- Add workflow in [AgentText.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1379/files#diff-83e380521997523c0e40c0882a60adc33094cb486612305b77b40880aee1abd9) that checks out the repo, runs a local setup action, executes `yarn test agents-text --env production --no-fail --log off`, uploads artifacts, and posts Slack notifications on failure or cancellation using `DATADOG_API_KEY`, `REGION`, and `SLACK_BOT_TOKEN` from secrets/vars.
- Add Vitest suite in [monitoring/agents/agents-text.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1379/files#diff-3c235557fb4986998579ffeb6dae1d80d6eceb0c5f78d8ff724d0222a26be692) that opens DMs to live production agents for the current XMTP environment, calls `helpers/streams.verifyAgentMessageStream` with `retries=3` and `types=["text","reply"]`, and emits a Datadog `response` metric.
- Extend `helpers/streams.verifyAgentMessageStream` in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1379/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) to accept a `types: string[]` parameter defaulting to `["text","reply","reaction","actions"]`.

#### 📍Where to Start
Start with the workflow definition in [AgentText.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1379/files#diff-83e380521997523c0e40c0882a60adc33094cb486612305b77b40880aee1abd9) to see triggers and steps, then review the test logic in [monitoring/agents/agents-text.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1379/files#diff-3c235557fb4986998579ffeb6dae1d80d6eceb0c5f78d8ff724d0222a26be692) and the updated `helpers/streams.verifyAgentMessageStream` in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1379/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a).

----

_[Macroscope](https://app.macroscope.com) summarized b639bb7._