### PR TITLE
Enable PR in AgentText.yml

### DIFF
--- a/.github/workflows/AgentText.yml
+++ b/.github/workflows/AgentText.yml
@@ -2,7 +2,7 @@ name: Agent text health
 description: "health of the agents"
 
 on:
-  #pull_request:
+  pull_request:
   schedule:
     - cron: "*/30 * * * *" # Runs every  30 minutes for agents-text
   workflow_dispatch:

--- a/.github/workflows/Wildcard.yml
+++ b/.github/workflows/Wildcard.yml
@@ -2,7 +2,7 @@ name: Wildcard
 description: "Manual PR verification workflow - supports functional and performance tests"
 
 on:
-  pull_request:
+  #pull_request:
   schedule:
     - cron: "0 0 1 1 *"
   workflow_dispatch:

--- a/monitoring/agents/agents-dms.test.ts
+++ b/monitoring/agents/agents-dms.test.ts
@@ -56,7 +56,7 @@ describe(testName, async () => {
       const responseTime = Math.abs(
         result?.averageEventTiming ?? streamTimeout,
       );
-      console.log("result.averageEventTiming", result?.averageEventTiming);
+      console.log("averageEventTiming", result?.averageEventTiming);
       console.log("streamTimeout", streamTimeout);
       console.log("responseTime", responseTime);
 

--- a/monitoring/agents/agents-health.test.ts
+++ b/monitoring/agents/agents-health.test.ts
@@ -1,70 +1,70 @@
-import { streamTimeout } from "@helpers/client";
-import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
-import { setupDurationTracking } from "@helpers/vitest";
-import { getActiveVersion } from "version-management/client-versions";
-import { describe, expect, it } from "vitest";
-import productionAgents from "./agents.json";
-import { type AgentConfig } from "./helper";
+// import { streamTimeout } from "@helpers/client";
+// import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
+// import { setupDurationTracking } from "@helpers/vitest";
+// import { getActiveVersion } from "version-management/client-versions";
+// import { describe, expect, it } from "vitest";
+// import productionAgents from "./agents.json";
+// import { type AgentConfig } from "./helper";
 
-const testName = "agents-health";
-describe(testName, () => {
-  setupDurationTracking({ testName, initDataDog: true });
-  const env = process.env.XMTP_ENV as string;
+// const testName = "agents-health";
+// describe(testName, () => {
+//   setupDurationTracking({ testName, initDataDog: true });
+//   const env = process.env.XMTP_ENV as string;
 
-  const API_ENDPOINT =
-    process.env.API_ENDPOINT ||
-    "https://agents-synthetic-production.up.railway.app/api/ping";
+//   const API_ENDPOINT =
+//     process.env.API_ENDPOINT ||
+//     "https://agents-synthetic-production.up.railway.app/api/ping";
 
-  const filteredAgents = (productionAgents as AgentConfig[]).filter((agent) => {
-    return agent.networks.includes(env);
-  });
+//   const filteredAgents = (productionAgents as AgentConfig[]).filter((agent) => {
+//     return agent.networks.includes(env);
+//   });
 
-  if (filteredAgents.length === 0) {
-    it(`${testName}: No agents configured for this environment`, () => {
-      expect(true).toBe(true);
-    });
-    return;
-  }
+//   if (filteredAgents.length === 0) {
+//     it(`${testName}: No agents configured for this environment`, () => {
+//       expect(true).toBe(true);
+//     });
+//     return;
+//   }
 
-  for (const agent of filteredAgents) {
-    it(`${testName}: ${agent.name} API ping : ${agent.address}`, async () => {
-      const response = await fetch(API_ENDPOINT, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          address: agent.address,
-          network: env,
-          message: agent.sendMessage,
-        }),
-      });
-      console.log(response);
+//   for (const agent of filteredAgents) {
+//     it(`${testName}: ${agent.name} API ping : ${agent.address}`, async () => {
+//       const response = await fetch(API_ENDPOINT, {
+//         method: "POST",
+//         headers: {
+//           "Content-Type": "application/json",
+//         },
+//         body: JSON.stringify({
+//           address: agent.address,
+//           network: env,
+//           message: agent.sendMessage,
+//         }),
+//       });
+//       console.log(response);
 
-      const result = (await response.json()) as {
-        success: boolean;
-        address: string;
-        responseTime: number;
-        timestamp: string;
-        message: string;
-      };
+//       const result = (await response.json()) as {
+//         success: boolean;
+//         address: string;
+//         responseTime: number;
+//         timestamp: string;
+//         message: string;
+//       };
 
-      const responseTime = Math.abs(result?.responseTime ?? streamTimeout);
-      console.log("responseTime", responseTime);
-      console.log("streamTimeout", streamTimeout);
-      console.log("responseTime", responseTime);
+//       const responseTime = Math.abs(result?.responseTime ?? streamTimeout);
 
-      sendMetric("response", responseTime, {
-        test: testName,
-        metric_type: "agent",
-        metric_subtype: "dm",
-        live: agent.live ? "true" : "false",
-        slackChannel: agent.slackChannel,
-        agent: agent.name,
-        address: agent.address,
-        sdk: getActiveVersion().nodeBindings,
-      } as ResponseMetricTags);
-      expect(result.success).toBe(true);
-    });
-  }
-});
+//       console.log("streamTimeout", streamTimeout);
+//       console.log("responseTime", responseTime);
+
+//       sendMetric("response", responseTime, {
+//         test: testName,
+//         metric_type: "agent",
+//         metric_subtype: "dm",
+//         live: agent.live ? "true" : "false",
+//         slackChannel: agent.slackChannel,
+//         agent: agent.name,
+//         address: agent.address,
+//         sdk: getActiveVersion().nodeBindings,
+//       } as ResponseMetricTags);
+//       expect(result.success).toBe(true);
+//     });
+//   }
+// });

--- a/monitoring/agents/agents-health.test.ts
+++ b/monitoring/agents/agents-health.test.ts
@@ -50,7 +50,7 @@ describe(testName, () => {
       };
 
       const responseTime = Math.abs(result?.responseTime ?? streamTimeout);
-      console.log("result.responseTime", result?.responseTime);
+      console.log("responseTime", responseTime);
       console.log("streamTimeout", streamTimeout);
       console.log("responseTime", responseTime);
 

--- a/monitoring/agents/agents-text.test.ts
+++ b/monitoring/agents/agents-text.test.ts
@@ -50,7 +50,7 @@ describe(testName, async () => {
         conversation as Conversation,
         [workers.getCreator()],
         agent.sendMessage,
-        3,
+        1,
         ["text", "reply", "actions", "intent"],
       );
 

--- a/monitoring/agents/agents-text.test.ts
+++ b/monitoring/agents/agents-text.test.ts
@@ -57,7 +57,7 @@ describe(testName, async () => {
       const responseTime = Math.abs(
         result?.averageEventTiming ?? streamTimeout,
       );
-      console.log("responseTime", responseTime);
+      console.log("averageEventTiming", result?.averageEventTiming);
       console.log("streamTimeout", streamTimeout);
       console.log("responseTime", responseTime);
 

--- a/monitoring/agents/agents-text.test.ts
+++ b/monitoring/agents/agents-text.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it } from "vitest";
 import productionAgents from "./agents.json";
 import { type AgentConfig } from "./helper";
 
-const testName = "agents-dms";
+const testName = "agents-text";
 describe(testName, async () => {
   setupDurationTracking({ testName, initDataDog: true });
   const env = process.env.XMTP_ENV as XmtpEnv;
@@ -57,6 +57,9 @@ describe(testName, async () => {
       const responseTime = Math.abs(
         result?.averageEventTiming ?? streamTimeout,
       );
+      console.log("responseTime", responseTime);
+      console.log("streamTimeout", streamTimeout);
+      console.log("responseTime", responseTime);
 
       // dont do ?? streamTimeout because it will be 0 and it will be ignored by datadog
       sendMetric("response", responseTime, {

--- a/workers/main.ts
+++ b/workers/main.ts
@@ -983,15 +983,15 @@ export class WorkerClient extends Worker implements IWorkerClient {
     types: string[] = ["text"],
     customTimeout?: number,
   ): Promise<StreamTextMessage[]> {
-    // console.debug(
-    //   `[${this.nameId}] Starting collectMessages for conversationId: ${groupId}, expecting ${count} messages`,
-    // );
+    console.debug(
+      `[${this.nameId}] Starting collectMessages for conversationId: ${groupId}, expecting ${count} messages`,
+    );
     return this.collectStreamEvents<StreamTextMessage>({
       type: typeofStream.Message,
       filterFn: (msg) => {
-        // console.debug(
-        //   `[${this.nameId}] Filtering message: type=${msg.type}, expected=${StreamCollectorType.Message}`,
-        // );
+        console.debug(
+          `[${this.nameId}] Filtering message: type=${msg.type}, expected=${StreamCollectorType.Message}`,
+        );
 
         if (msg.type !== StreamCollectorType.Message) {
           return false;
@@ -1001,8 +1001,9 @@ export class WorkerClient extends Worker implements IWorkerClient {
         const conversationId = streamMsg.message.conversationId;
         const contentType = streamMsg.message.contentType;
         const idsMatch = groupId === conversationId;
-        const typeIsText = types.includes(contentType?.typeId as string);
-        const shouldAccept = idsMatch && typeIsText;
+        const typeIsMatch = types.includes(contentType?.typeId as string);
+        console.warn(typeIsMatch, types, contentType?.typeId);
+        const shouldAccept = idsMatch && typeIsMatch;
         return shouldAccept;
       },
       count,


### PR DESCRIPTION
### Enable `pull_request` trigger for the Agent text health workflow in [AgentText.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-83e380521997523c0e40c0882a60adc33094cb486612305b77b40880aee1abd9)
This change updates workflow triggers and adjusts agent test suites and logs across the repository.

- Comment out the entire agent health test suite in [agents-health.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-e8d17d0171c2f5f7274784029ab98cf0ba86c8b63f8008dbe381a39f7940baef)
- Enable the `pull_request` trigger in [AgentText.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-83e380521997523c0e40c0882a60adc33094cb486612305b77b40880aee1abd9)
- Disable the `pull_request` trigger in [Wildcard.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-5c0e1eb285856b720977c318f2453be6f55234657e486d254a1ecc8e6909c085)
- Update `testName` to `agents-text` and add debug logs in [agents-text.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-3c235557fb4986998579ffeb6dae1d80d6eceb0c5f78d8ff724d0222a26be692)
- Adjust a console log label in [agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-686c3ff2fc6315950504d530b5724419a502eb6e8cc53324fa3038894c5575e9)

#### 📍Where to Start
Start by reviewing the `on` triggers in [AgentText.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-83e380521997523c0e40c0882a60adc33094cb486612305b77b40880aee1abd9), then confirm the test suite removal in [agents-health.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1383/files#diff-e8d17d0171c2f5f7274784029ab98cf0ba86c8b63f8008dbe381a39f7940baef).

----

_[Macroscope](https://app.macroscope.com) summarized cbd8b42._