### PR TITLE
Update SLOs and agent data

### DIFF
--- a/measurements/README.md
+++ b/measurements/README.md
@@ -154,10 +154,11 @@ Storage utilization comparison between sender and receiver across varying inbox 
 
 Weekly SLO performance tracking for critical XMTP SDK metrics.
 
-| SLO Name                      | Target | JUL-7    | JUL-14  | JUL-21   | WTD      |
-| ----------------------------- | ------ | -------- | ------- | -------- | -------- |
-| Network uptime                | 99%    | 100.000% | 99.900% | 100.000% | 100.000% |
-| Messages ordered              | 99%    | 100.000% | 99.205% | 100.000% | 100.000% |
-| New group under 1.5 seconds   | 99%    | 100.000% | 99.503% | 100.000% | 100.000% |
-| Response times under 1 second | 99%    | 100.000% | 99.602% | 100.000% | 100.000% |
-| Messages delivered            | 99%    | 96.079%  | 95.086% | 99.106%  | 95.066%  |
+| SLO Name                       | Target | AUG-11   | AUG-18   | AUG-25   | WTD      |
+| ------------------------------ | ------ | -------- | -------- | -------- | -------- |
+| Network uptime                 | 99%    | 100.000% | 100.000% | 100.000% | 100.000% |
+| Agent response under 3 seconds | 99%    | 81.042%  | 75.384%  | 85.062%  | 80.320%  |
+| Messages ordered               | 99%    | 100.000% | 100.000% | 100.000% | 100.000% |
+| Messages delivered             | 99%    | 100.000% | 100.000% | 99.950%  | 100.000% |
+| New group under 1.5 seconds    | 99%    | 99.851%  | 99.950%  | 99.900%  | 99.771%  |
+| Response times under 1 second  | 99%    | 100.000% | 100.000% | 100.000% | 100.000% |

--- a/monitoring/agents/README.md
+++ b/monitoring/agents/README.md
@@ -94,3 +94,41 @@ Link to test code [../monitoring/agents/agents-untagged.test.ts](../monitoring/a
 ```
 
 See agents [configuration](agents.json)
+
+### Agent uptime SLOs
+
+Individual agent uptime performance tracking over 7-day periods.
+
+| Agent Name | Target | Status   | Error Budget Left | Tags                   |
+| ---------- | ------ | -------- | ----------------- | ---------------------- |
+| Bitte      | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Mamo       | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Flaunchy   | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Elsa       | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Byte       | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Arma       | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Bankr      | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Onit       | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Squabble   | 99%    | 100.000% | 100%              | qa-agents, reliability |
+| Clanker    | 99%    | 100.000% | 100%              | qa-agents, reliability |
+
+_Note: All agent uptime SLOs are performing optimally with 100% uptime and full error budget remaining._
+
+### Agent response time SLOs
+
+Individual agent response time performance tracking over 7-day periods.
+
+| Agent Name | Target | Status   | Error Budget Left | Tags      |
+| ---------- | ------ | -------- | ----------------- | --------- |
+| Byte       | 99%    | 100.000% | 100%              | performan |
+| Squabble   | 99%    | 99.950%  | 95%               | performan |
+| Arma       | 99%    | 99.900%  | 90%               | performan |
+| Bitte      | 99%    | 99.751%  | 75%               | performan |
+| Onit       | 99%    | 99.503%  | 50%               | performan |
+| Elsa       | 99%    | 99.355%  | 36%               | performan |
+| Bankr      | 99%    | 94.097%  | -490%             | performan |
+| Mamo       | 99%    | 91.617%  | -738%             | performan |
+| Clanker    | 99%    | 77.083%  | -2192%            | performan |
+| Flaunchy   | 99%    | 64.682%  | -3432%            | performan |
+
+_Note: Top 6 agents are meeting or close to target, while bottom 4 agents show significant performance degradation with negative error budgets._

--- a/monitoring/agents/agents.json
+++ b/monitoring/agents/agents.json
@@ -104,7 +104,7 @@
   {
     "name": "bracky",
     "baseName": "bracky.base.eth",
-    "address": "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0",
+    "address": "0x62db4c5A8fdF004754b9EFe92dF39927aB68920d",
     "sendMessage": "hi",
     "live": true,
     "networks": ["production"]


### PR DESCRIPTION
### Change one agent `address` in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/1386/files#diff-6cfbb02eced9da988d4ee962ef9330ddfba79ddc4cf1d131bab63ae6a6e45379) and update SLO documentation to a 3-week August range with a 3-second response metric and 7-day agent tracking
- Modify one `address` field for an agent entry in [monitoring/agents/agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/1386/files#diff-6cfbb02eced9da988d4ee962ef9330ddfba79ddc4cf1d131bab63ae6a6e45379).
- Append two sections, 'Agent uptime SLOs' and 'Agent response time SLOs', each with tables and notes, in [monitoring/agents/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1386/files#diff-15daff2bfb52c0606ffdf0e59bc21e4167a5ff44c0b15944458e670fea5afc27).
- Rewrite the weekly SLO performance table for August, update headers, reorder and rename rows (including a new response metric), and replace metric values in [measurements/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1386/files#diff-1fdf3bc4aa3e65ae2a5cd8535d62663871fd557fd8ffc61e524e3df754fa8af8).

#### 📍Where to Start
Start with the updated agent entry in [monitoring/agents/agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/1386/files#diff-6cfbb02eced9da988d4ee962ef9330ddfba79ddc4cf1d131bab63ae6a6e45379).

----

_[Macroscope](https://app.macroscope.com) summarized 2cca672._