### PR TITLE
Update default log level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 # MAIN
 XMTP_ENV="dev" # xmtp environment (dev,production,local,multinode)
 LOGGING_LEVEL="error" # rust library logs
-LOG_LEVEL="debug" # JS logs level

--- a/.github/workflows/Browser.yml
+++ b/.github/workflows/Browser.yml
@@ -18,8 +18,6 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
-      LOGGING_LEVEL: "off"
-      LOG_LEVEL: "info"
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ yarn install
 ```bash
 XMTP_ENV="dev" #  environment (dev, production, local, multinode)
 LOGGING_LEVEL="error" # Rust library logs
-LOG_LEVEL="debug" # JS logs level
+LOG_LEVEL="info" # JS logs level
 ```
 
 ### Running tests

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -192,10 +192,7 @@ All commands support:
 
 ## Environment Variables
 
-- `TARGET` - Default target address
 - `XMTP_ENV` - Default environment (local/dev/production)
-- `LOG_LEVEL` - JS logger level (default: info)
-- `LOGGING_LEVEL` - Rust library logger level (default: off)
 - `WALLET_KEY` - Wallet private key (for revoke)
 - `ENCRYPTION_KEY` - Encryption key (for revoke)
 

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -130,7 +130,7 @@ export const createLogger = () => {
   );
 
   const logger = winston.createLogger({
-    level: process.env.LOG_LEVEL || "silly",
+    level: process.env.LOG_LEVEL || "info",
     format: combinedFormat,
     transports: [new winston.transports.Console()],
   });


### PR DESCRIPTION
### Set default logger level to info in `helpers/logger.createLogger` to update default log level
- Change the default level in `helpers/logger.createLogger` from `silly` to `info` when `process.env.LOG_LEVEL` is unset in [logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1392/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597)
- Remove `LOG_LEVEL` from the example environment file in [.env.example](https://github.com/xmtp/xmtp-qa-tools/pull/1392/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c)
- Delete `LOGGING_LEVEL` and `LOG_LEVEL` from the Browser workflow in [Browser.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1392/files#diff-f40bdad9c7e38e785fca7315a56007cd25ada68d6627f4f3dac772afadcbe4a7)
- Update the README example to show `LOG_LEVEL=info` in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1392/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
- Remove `TARGET`, `LOG_LEVEL`, and `LOGGING_LEVEL` env var docs in [readme.md](https://github.com/xmtp/xmtp-qa-tools/pull/1392/files#diff-342f32409d54083a9538f9a50e990595e78bfee7aa292f316b1602eed8a938f8)

#### 📍Where to Start
Start with the default level logic in `createLogger` in [helpers/logger.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1392/files#diff-ef23901adf6f51cfdaacf953660f6cb1e39979f959f2b6c199a9d562fab01597).

----

_[Macroscope](https://app.macroscope.com) summarized 83e0a46._