### PR TITLE
Increase agent timeout

### DIFF
--- a/monitoring/agents/agents-text.test.ts
+++ b/monitoring/agents/agents-text.test.ts
@@ -52,6 +52,7 @@ describe(testName, async () => {
         agent.sendMessage,
         1,
         ["text", "reply", "actions", "intent"],
+        16000,
       );
 
       const responseTime = Math.abs(


### PR DESCRIPTION
### Increase the agent DM test timeout by passing 16000 as the sixth argument to `verifyAgentMessageStream` in [agents-text.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1406/files#diff-3c235557fb4986998579ffeb6dae1d80d6eceb0c5f78d8ff724d0222a26be692)
Update the per-agent DM test in [agents-text.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1406/files#diff-3c235557fb4986998579ffeb6dae1d80d6eceb0c5f78d8ff724d0222a26be692) to call `verifyAgentMessageStream` with an additional sixth parameter set to `16000`.

#### 📍Where to Start
Start in the DM test block that invokes `verifyAgentMessageStream` in [agents-text.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1406/files#diff-3c235557fb4986998579ffeb6dae1d80d6eceb0c5f78d8ff724d0222a26be692).

----

_[Macroscope](https://app.macroscope.com) summarized f498092._