### PR TITLE
Refactor key-check bot tags

### DIFF
--- a/bots/key-check/index.ts
+++ b/bots/key-check/index.ts
@@ -338,11 +338,11 @@ initializeAppFromConfig(appConfig);
 agent.on("text", async (ctx) => {
   const message = ctx.message;
   const content = message.content;
-
-  if (
-    (ctx.isDm() && content.trim().startsWith("/kc")) ||
-    (ctx.isGroup() && content.trim().startsWith("@kc"))
-  ) {
+  const isTagged =
+    content.trim().startsWith("@kc") ||
+    content.trim().startsWith("/kc") ||
+    content.trim().startsWith("@key-check.eth");
+  if (isTagged) {
     console.log(`Showing main menu for: ${content}`);
     await showMenu(ctx, appConfig, "main-menu");
     return;
@@ -399,6 +399,9 @@ agent.on("text", async (ctx) => {
     }
     return;
   }
+
+  if (ctx.isDm() && !isTagged)
+    await ctx.sendText("Please send /kc to see the main menu");
 });
 
 // 4. Log when we're ready


### PR DESCRIPTION
### Refactor key-check bot text handling to trigger the main menu when messages start with '@kc', '/kc', or '@key-check.eth' in DMs and groups
This change introduces a single tag-based trigger for the key-check bot text handler. It adds an `isTagged` check that treats messages starting with `@kc`, `/kc`, or `@key-check.eth` as menu triggers across DMs and groups, and adds a DM-only fallback prompt when messages are untagged. The primary modifications are in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1420/files#diff-ef019451c04a5f80460878e159c33463ac1e3333ff9cddf8854e5312406973db).

#### 📍Where to Start
Start with the text message handler logic in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1420/files#diff-ef019451c04a5f80460878e159c33463ac1e3333ff9cddf8854e5312406973db), focusing on the introduction of the `isTagged` flag and the DM-only fallback branch.

----

_[Macroscope](https://app.macroscope.com) summarized 7a391a3._