### PR TITLE
Added freysa, neurobro agents

### DIFF
--- a/monitoring/agents/agents.json
+++ b/monitoring/agents/agents.json
@@ -80,6 +80,29 @@
     "respondOnTagged": false
   },
   {
+    "name": "freysa",
+    "baseName": "freysa.base.eth",
+    "address": "0x6461bf53ddb33b525c84bf60d6bb31fa10828474",
+    "sendMessage": "hola",
+    "expectedMessage": ["chat", "invalid"],
+    "networks": [],
+    "live": false,
+    "slackChannel": "#freysa-alerts",
+    "respondOnTagged": false
+  },
+  {
+    "name": "neurobro",
+    "baseName": "neurobro.base.eth",
+    "address": "0x9D2B24b027F4732BB87cD6531E16ce4Dc571c30c",
+    "sendMessage": "hola",
+    "expectedMessage": ["chat", "invalid"],
+    "networks": [],
+    "live": false,
+    "slackChannel": "#neurobro-alerts",
+    "respondOnTagged": false
+  },
+
+  {
     "name": "gang",
     "baseName": "gang.base.eth",
     "address": "0x6461bf53ddb33b525c84bf60d6bb31fa10828474",

--- a/monitoring/agents/agents.json
+++ b/monitoring/agents/agents.json
@@ -101,7 +101,6 @@
     "slackChannel": "#neurobro-alerts",
     "respondOnTagged": false
   },
-
   {
     "name": "gang",
     "baseName": "gang.base.eth",


### PR DESCRIPTION
### Add freysa and neurobro agent configurations to monitoring/agents/agents.json for agent onboarding
This change updates [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/1433/files#diff-6cfbb02eced9da988d4ee962ef9330ddfba79ddc4cf1d131bab63ae6a6e45379) by adding two agent entries named `freysa` and `neurobro`. Each entry defines `name`, `baseName`, `address`, `sendMessage` set to `hola`, `expectedMessage` set to `["chat", "invalid"]`, `networks` as an empty array, `live` set to `false`, `slackChannel` set to `#freysa-alerts` and `#neurobro-alerts` respectively, and `respondOnTagged` set to `false`.

#### 📍Where to Start
Start with the new agent objects in [agents.json](https://github.com/xmtp/xmtp-qa-tools/pull/1433/files#diff-6cfbb02eced9da988d4ee962ef9330ddfba79ddc4cf1d131bab63ae6a6e45379) to verify field values and formatting.

----

_[Macroscope](https://app.macroscope.com) summarized eaa4915._