### PR TITLE
Update README formatting

### DIFF
--- a/monitoring/agents/README.md
+++ b/monitoring/agents/README.md
@@ -8,12 +8,12 @@
 
 **Purpose**: Validates health, responsiveness, and behavioral patterns of live XMTP agents across production and development environments.
 
-### Core tests:
+## Core tests:
 
-- `agents-dms: dm first reaction`
-- `agents-text: first meaningful response`
-- `agents-tagged: group chat message and slash command response`
-- `agents-untagged: negative testing ensuring proper filtering`
+- 1. `agents-dms: dm first reaction`
+- 2. `agents-text: first meaningful response`
+- 3. `agents-tagged: group chat message and slash command response`
+- 4. `agents-untagged: negative testing ensuring proper filtering`
 
 **Measurements**:
 
@@ -33,7 +33,7 @@ Link to test code [../monitoring/agents/agents-dms.test.ts](../monitoring/agents
 
 ## 2. Meaningful response testing
 
-Link to test code [../monitoring/agents/agents-tagged.test.ts](../monitoring/agents/agents-tagged.test.ts)
+Link to test code [../monitoring/agents/agents-text.test.ts](../monitoring/agents/agents-tagged.test.ts)
 
 ### Test flow:
 


### PR DESCRIPTION
### Update monitoring/agents README formatting to adjust 'Core tests' header level and convert its four bullets to an ordinal list, and change link text in 'Meaningful response testing' to 'agents-text.test.ts'
This change updates the formatting of [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1436/files#diff-15daff2bfb52c0606ffdf0e59bc21e4167a5ff44c0b15944458e670fea5afc27). It adjusts the 'Core tests' section header from level 3 to level 2, converts its four bullets into an ordered-style list numbered 1–4, and updates the displayed link text in the 'Meaningful response testing' section to `agents-text.test.ts` while keeping the target URL unchanged.

#### 📍Where to Start
Start by reviewing the 'Core tests' and 'Meaningful response testing' sections in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1436/files#diff-15daff2bfb52c0606ffdf0e59bc21e4167a5ff44c0b15944458e670fea5afc27).

----

_[Macroscope](https://app.macroscope.com) summarized 3257f7a._