### PR TITLE
Update regression test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "monitor:yarn": "httpstat https://grpc.dev.xmtp.network:443",
     "permissions": "tsx cli/permissions.ts",
     "record": "npx playwright codegen 'https://xmtp.chat/'",
-    "regression": "yarn test performance --env dev --log off --winston info --sync all --versions 3 --size 10-100 && yarn test bugs",
+    "regression": "yarn test performance --env dev --sync all --versions 3 --size 10-100 && yarn test bugs",
     "revoke": "tsx cli/revoke.ts",
     "send": "tsx cli/send.ts",
     "test": "tsx cli/test.ts",


### PR DESCRIPTION
### Update the `regression` npm script in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1441/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to remove `--log off --winston info` options for running performance tests
This change updates the `regression` script in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1441/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to call `yarn test performance` without the `--log off --winston info` flags, relying on the default logging configuration.

#### 📍Where to Start
Start with the `scripts.regression` entry in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1441/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----

_[Macroscope](https://app.macroscope.com) summarized a05fd12._