### PR TITLE
Increase worker count to 10

### DIFF
--- a/monitoring/performance.test.ts
+++ b/monitoring/performance.test.ts
@@ -55,7 +55,7 @@ describe(testName, () => {
   let receiver: Worker | undefined;
   let dm: Dm | undefined;
   it(`create: measure creating a client`, async () => {
-    workers = await getWorkers(5);
+    workers = await getWorkers(10);
     creator = workers.getCreator();
     receiver = workers.getReceiver();
     setCustomDuration(creator.initializationTime);


### PR DESCRIPTION
### Increase worker initialization in `monitoring/performance.test.ts` from 5 to 10 to align with the purpose to increase worker count to 10
Update the test setup in [performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1442/files#diff-aff39dac951484583ac130da3ca93c458531496cc8efe52c86075b72d555f07d) to call `getWorkers(10)` instead of `getWorkers(5)` within the create-client measurement test.

#### 📍Where to Start
Start with the test setup that initializes workers in [performance.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1442/files#diff-aff39dac951484583ac130da3ca93c458531496cc8efe52c86075b72d555f07d).

----

_[Macroscope](https://app.macroscope.com) summarized 368ae48._