### PR TITLE
Disable pull_request trigger

### DIFF
--- a/.github/workflows/AgentGroups.yml
+++ b/.github/workflows/AgentGroups.yml
@@ -2,7 +2,7 @@ name: Agents groups
 description: "performance of the library in the production network"
 
 on:
-  pull_request:
+  #pull_request:
   schedule:
     - cron: "0 */4 * * *" # Runs every 4 hours
   workflow_dispatch:


### PR DESCRIPTION
### Disable the pull_request trigger for the AgentGroups GitHub Actions workflow in [.github/workflows/AgentGroups.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1463/files#diff-1a39ca42a10e32bfeee4f685f317172521ef7b3b5467673c5b3bba35b1cc35d2)
This change updates the AgentGroups GitHub Actions workflow to stop running on pull_request events and to use matrix-driven values for test execution, artifact naming, and Slack notifications. It also replaces fixed test and label strings with `${{ matrix.test }}` and includes environment data in notification names.

- Comment out the `pull_request` trigger in [.github/workflows/AgentGroups.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1463/files#diff-1a39ca42a10e32bfeee4f685f317172521ef7b3b5467673c5b3bba35b1cc35d2)
- Update the test step to run `yarn test ${{ matrix.test }}` instead of a fixed test name
- Pass a dynamic `test-name` of `${{ matrix.test }}` to the cleanup/upload step
- Update Slack notification `workflow-name` to include `${{ matrix.test }}` and environment values

#### 📍Where to Start
Start with the workflow triggers and matrix usage in [.github/workflows/AgentGroups.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1463/files#diff-1a39ca42a10e32bfeee4f685f317172521ef7b3b5467673c5b3bba35b1cc35d2).

----

_[Macroscope](https://app.macroscope.com) summarized cfe4f9c._