### PR TITLE
Refactor version import path

### DIFF
--- a/.cursor/rules/testing-framework.mdc
+++ b/.cursor/rules/testing-framework.mdc
@@ -428,8 +428,8 @@ Use predefined names from the 61 available:
 ```typescript
 import { verifyMessageStream } from "@helpers/streams";
 import { setupDurationTracking } from "@helpers/vitest";
+import { IdentifierKind } from "@version-management/client-versions";
 import { getWorkerNames, getWorkers } from "@workers/manager";
-import { IdentifierKind } from "@workers/versions";
 ```
 
 ## Quick Snippets
@@ -495,8 +495,8 @@ const workers = await getWorkers(["alice", "bob"], {});
 
 ```typescript
 import { setupDurationTracking } from "@helpers/vitest";
+import { IdentifierKind } from "@version-management/client-versions";
 import { getWorkerNames, getWorkers } from "@workers/manager";
-import { IdentifierKind } from "@workers/versions";
 
 // Start message streaming
 workers.getReceiver().worker.startStream(typeofStream.Message);

--- a/.cursor/rules/version-management.mdc
+++ b/.cursor/rules/version-management.mdc
@@ -5,13 +5,13 @@
 When upgrading XMTP node-sdk versions, update these 3 files:
 
 1. Add `@xmtp/node-sdk-X.X.X` and `@xmtp/node-bindings-X.X.X` to package.json.
-2. Add import for new SDK version to `workers/versions.ts`.
+2. Add import for new SDK version to `version-management/client-versions.ts`.
 3. Run `yarn versions` to link the new versions.
 4. Run `yarn regression` to check regression of latest 3 versions.
 
 ### Version mapping system
 
-Versions are mapped in `workers/versions.ts`:
+Versions are mapped in `version-management/client-versions.ts`:
 
 ```typescript
 export const VersionList = [

--- a/version-management/README.md
+++ b/version-management/README.md
@@ -5,13 +5,13 @@
 When upgrading XMTP bindings and/or node-sdk versions:
 
 1. Add `@xmtp/node-sdk-X.X.X` and `@xmtp/node-bindings-X.X.X` to package.json.
-2. Add import for new SDK version to `workers/versions.ts`.
+2. Add import for new SDK version to `version-management/client-versions.ts`.
 3. Run `yarn versions` to link the new versions.
 4. Run `yarn regression` to check regression of latest 3 versions.
 
 ### Version mapping system
 
-Versions are mapped in `workers/versions.ts`:
+Versions are mapped in `version-management/client-versions.ts`:
 
 ```typescript
 export const VersionList = [


### PR DESCRIPTION
### Refactor documentation to update version import paths in testing framework rules and version-management README to use `@version-management/client-versions` and `version-management/client-versions.ts`
This change updates documentation to reference the new version import path and file locations. It replaces `@workers/versions` with `@version-management/client-versions` in the testing framework rules and updates file path references from `workers/versions.ts` to `version-management/client-versions.ts` across version-management docs.

- Update testing framework rules to import `IdentifierKind` from `@version-management/client-versions` in [testing-framework.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/1467/files#diff-6cb7d5467068aef81ad7c4b1470eb736dae13ba1b56523e17a6901a834507738)
- Replace references to `workers/versions.ts` with `version-management/client-versions.ts` in [version-management.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/1467/files#diff-d43e65c123d0814cf0b06c49d60712b7aebc13f806418303a68d2aa15d031553)
- Update upgrade steps and mapping description to point to `version-management/client-versions.ts` in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1467/files#diff-570c5dc8167586c7aefee3320091036611c22d74e4c281e0052df064475881e8)

#### 📍Where to Start
Start with the path updates in [testing-framework.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/1467/files#diff-6cb7d5467068aef81ad7c4b1470eb736dae13ba1b56523e17a6901a834507738), then verify consistency in [version-management.mdc](https://github.com/xmtp/xmtp-qa-tools/pull/1467/files#diff-d43e65c123d0814cf0b06c49d60712b7aebc13f806418303a68d2aa15d031553) and [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1467/files#diff-570c5dc8167586c7aefee3320091036611c22d74e4c281e0052df064475881e8).

----

_[Macroscope](https://app.macroscope.com) summarized 3bb4e5b._