### PR TITLE
Update dependency setup

### DIFF
--- a/.github/workflows/validate-regression.yml
+++ b/.github/workflows/validate-regression.yml
@@ -56,15 +56,8 @@ jobs:
         run: corepack prepare yarn@4.6.0 --activate
         shell: bash
 
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-            .yarn/cache
-          key: deps-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            deps-
+      - name: Install dependencies
+        run: yarn install
 
       - name: Run script version
         run: yarn versions


### PR DESCRIPTION
### Update the validate-regression GitHub Actions workflow to always run `yarn install` by removing dependency caching in [.github/workflows/validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1469/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37)
The CI workflow in [validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1469/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37) changes dependency handling by removing the cache step and introducing a direct installation step.

- Remove the `actions/cache@v4` step that cached `node_modules` and `.yarn/cache` keyed by `yarn.lock` in [validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1469/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37)
- Add an `Install dependencies` step that runs `yarn install` in [validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1469/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37)

#### 📍Where to Start
Start with the workflow changes in [.github/workflows/validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1469/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37), focusing on the removed `actions/cache@v4` step and the new `Install dependencies` step.

----

_[Macroscope](https://app.macroscope.com) summarized 22be2c1._