### PR TITLE
Add markdown support to key-check

### DIFF
--- a/agents/bots/key-check/index.ts
+++ b/agents/bots/key-check/index.ts
@@ -58,8 +58,8 @@ const appConfig: AppConfig = {
     "main-menu": {
       id: "main-menu",
       title:
-        "🔧 Hey, this is the Key-Check Bot 🔑\n\n* if appears greyed out, please go back to the conversation list and open the conversation again",
-
+        "🔧 **Hey, this is the Key-Check Bot** 🔑\n\n- *if appears greyed out, please go back to the conversation list and open the conversation again*",
+      markdownTitle: true,
       actions: [
         { id: "key-packages-menu", label: "🔑 Key Packages", style: "primary" },
         { id: "group-tools-menu", label: "👥 Group Tools" },

--- a/agents/utils/inline-actions/README.md
+++ b/agents/utils/inline-actions/README.md
@@ -37,6 +37,11 @@ await ActionBuilder.create("menu-id", "Description")
   .add("action-id", "Button Label", "primary") // primary|secondary|danger
   .add("action-id-2", "Another Button")
   .send(ctx);
+
+// With markdown support for the title
+await ActionBuilder.create("menu-id", "**Bold Title**\n\n*Italic text*", true)
+  .add("action-id", "Button Label")
+  .send(ctx);
 ```
 
 ### Helper Functions
@@ -49,6 +54,15 @@ await sendConfirmation(
   "Delete this item?",
   async (ctx) => await ctx.sendText("Deleted!"),
   async (ctx) => await ctx.sendText("Cancelled"),
+);
+
+// With markdown support
+await sendConfirmation(
+  ctx,
+  "**Are you sure?**\n\nThis action cannot be undone.",
+  async (ctx) => await ctx.sendText("Deleted!"),
+  async (ctx) => await ctx.sendText("Cancelled"),
+  true, // Enable markdown
 );
 ```
 
@@ -71,6 +85,16 @@ await sendSelection(ctx, "Pick a color:", [
     },
   },
 ]);
+
+// With markdown support
+await sendSelection(
+  ctx,
+  "**Select an option:**\n\n- Choose carefully\n- This is important",
+  [
+    /* options */
+  ],
+  true, // Enable markdown
+);
 ```
 
 ### App Configuration
@@ -83,7 +107,8 @@ const config: AppConfig = {
   menus: {
     "main-menu": {
       id: "main-menu",
-      title: "Main Menu",
+      title: "**Main Menu**\n\nChoose an option below:",
+      markdownTitle: true, // Enable markdown for this menu's title
       actions: [
         { id: "sub-menu", label: "Go to Sub Menu" },
         { id: "action-1", label: "Do Something", handler: myHandler },

--- a/agents/utils/inline-actions/types/ActionsContent.ts
+++ b/agents/utils/inline-actions/types/ActionsContent.ts
@@ -44,6 +44,8 @@ export type ActionsContent = {
   actions: Action[];
   /** Optional ISO-8601 expiration timestamp */
   expiresAt?: string;
+  /** Optional flag to indicate if description should be rendered as markdown */
+  markdownTitle?: boolean;
 };
 
 /**


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add markdown rendering to key-check bot main-menu title and inline action messages to support markdown-formatted bot output
Introduce a `markdownTitle` flag across inline action types and update the key-check bot menu configuration to render titles and prompts using markdown. The change adds optional markdown parameters to inline action builders and helpers and updates type definitions and menu handling to pass through markdown configuration.

- Add `useMarkdown` storage and optional `markdown` argument to `ActionBuilder.create` and propagate into `build()` as `markdownTitle: true` in [inline-actions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1501/files#diff-22d09cdf2ad55936b9e39699ed7db7e4a8cfd84e676f28c168c6af5b8c513772)
- Add optional `markdown` parameters to `sendConfirmation`, `sendSelection`, and `showNavigationOptions` in [inline-actions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1501/files#diff-22d09cdf2ad55936b9e39699ed7db7e4a8cfd84e676f28c168c6af5b8c513772) and pass through to `ActionBuilder.create`
- Update `showMenu` in [inline-actions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1501/files#diff-22d09cdf2ad55936b9e39699ed7db7e4a8cfd84e676f28c168c6af5b8c513772) to forward `menu.markdownTitle` into `ActionBuilder.create`
- Extend `types.Menu` and `types.ActionsContent` with optional `markdownTitle?: boolean` in [ActionsContent.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1501/files#diff-79bc0ba13dab4d9064c98badecb3a41a08e2d1c9d0046f12b9413f6a7f4956b3)
- Update key-check bot `appConfig` main-menu title to markdown and add `markdownTitle: true` in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1501/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7)
- Add documentation with examples for enabling markdown in inline actions and app config in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1501/files#diff-c2994f8978c8b5b07bef17967b57c4e16244abf22be90281feb94ead50d76a88)

#### 📍Where to Start
Start with the `ActionBuilder.create` and `ActionBuilder.build` flow in [inline-actions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1501/files#diff-22d09cdf2ad55936b9e39699ed7db7e4a8cfd84e676f28c168c6af5b8c513772), then follow how `markdown` and `markdownTitle` propagate through helpers like `sendConfirmation`, `sendSelection`, `showMenu`, and `showNavigationOptions`.

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e470436. 3 files reviewed, 13 issues evaluated, 12 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>agents/bots/key-check/index.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 83](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/bots/key-check/index.ts#L83): The action handler for `keycheck-sender` passes `ctx.message.senderInboxId as string` to `debugHandlers.handleKeyPackageCheck`. The `as string` assertion does not coerce at runtime; if `senderInboxId` is `undefined` or `null` (reachable when the message lacks a `senderInboxId`), the callee will receive `undefined`, which can lead to downstream runtime errors when the value is used (e.g., length checks, string operations, lookups). The code should guard for presence or fall back to `ctx.client.inboxId` or return a clear error before invoking the handler. <b>[ Low confidence ]</b>
- [line 228](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/bots/key-check/index.ts#L228): Actions in `load-test-menu` (`load-test-10x10`, `load-test-50x10`, `load-test-1x100`, `load-test-custom`) have no `handler`. Depending on the framework’s contract for `Menu` actions, clicking these may result in a no-op, an error, or user confusion. If handlers are required for actionable items, this is a runtime UX/behavior bug: users can select actions that do nothing or potentially throw. Provide handlers or explicitly mark them as navigation-only or disabled so the menu preserves contract parity and avoids silent acceptance. <b>[ Code style ]</b>
</details>

<details>
<summary>agents/utils/inline-actions/inline-actions.ts — 0 comments posted, 7 evaluated, 7 filtered</summary>

- [line 149](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/inline-actions.ts#L149): `ActionBuilder.add` does not enforce uniqueness of `action.id` values. The `ActionsContent` contract comments state each action’s `id` must be unique, but `add` blindly pushes `{ id, label, style }` into `this.actions` without checking for duplicates. This allows callers (e.g., `sendSelection`) to create multiple buttons with the same `id`, and combined with `registerAction` overwriting handlers for duplicate IDs, yields ambiguous UI and mismatched handler invocation at runtime. <b>[ Low confidence ]</b>
- [line 191](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/inline-actions.ts#L191): `sendConfirmation` constructs action IDs using `Date.now()` (e.g., `yes-<timestamp>`, `no-<timestamp>`). Under concurrent calls within the same millisecond, IDs can collide, causing `registerAction` to overwrite previously registered handlers and the new confirmation to steal handlers from another prompt. This leads to incorrect handler execution for user clicks. <b>[ Low confidence ]</b>
- [line 221](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/inline-actions.ts#L221): `sendSelection` uses `Date.now()` to build the `ActionsContent.id` (`selection-<timestamp>`). If multiple selection prompts are sent within the same millisecond, content IDs can collide. Given the contract comment "Unique identifier for these actions", reusing IDs risks clients conflating messages, mis-associating replies, or performing deduplication incorrectly. <b>[ Low confidence ]</b>
- [line 227](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/inline-actions.ts#L227): `sendSelection` registers handlers and adds actions without validating for duplicate `id`s in `options`. Since `registerAction` overwrites existing handlers for the same `actionId` and `ActionBuilder.add` accepts duplicates, two or more options with the same `id` will result in multiple buttons with the same `id` but only the last handler being active. This creates ambiguous UI and misroutes clicks at runtime. <b>[ Low confidence ]</b>
- [line 344](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/inline-actions.ts#L344): `showNavigationOptions` ignores the `markdown` parameter when `autoShowMenuAfterAction` is disabled and sends plain text via `ctx.sendText(message)`. Callers passing `markdown = true` expect the message to be rendered with markdown (via `ActionsContent.markdownTitle`), but the early-return path bypasses that rendering, creating inconsistent message formatting across execution paths. <b>[ Low confidence ]</b>
- [line 350](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/inline-actions.ts#L350): `showNavigationOptions` uses a fixed `ActionsContent.id` of `"navigation-options"` for every menu sent. The `ActionsContent` contract comment indicates the `id` should be unique per actions payload. Reusing the same `id` across multiple sends can cause client-side confusion (e.g., deduplication, reply association errors) when multiple navigation menus are present in conversation history. <b>[ Low confidence ]</b>
- [line 356](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/inline-actions.ts#L356): `showNavigationOptions` creates a navigation menu with `customActions` but does not register handlers for those IDs. If a caller supplies `customActions` whose IDs are not already registered elsewhere, the resulting buttons will have no associated handler, leading to clicks that do nothing. There is no guard or error reporting for unregistered IDs. <b>[ Low confidence ]</b>
</details>

<details>
<summary>agents/utils/inline-actions/types/ActionsContent.ts — 0 comments posted, 4 evaluated, 3 filtered</summary>

- [line 41](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/types/ActionsContent.ts#L41): Potential unsafe access of `EncodedContent.parameters.encoding` during decode: `const encoding = content.parameters.encoding;` will throw if `parameters` is absent/undefined. Many content codecs treat `parameters` as optional and guard access (e.g., via optional chaining). If `parameters` is not guaranteed to exist, this is a runtime crash path. The code should read `const encoding = content.parameters?.encoding;` or guard against `parameters` being undefined. <b>[ Low confidence ]</b>
- [line 51](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/types/ActionsContent.ts#L51): Optional string fields are not validated at runtime: `Action.imageUrl` (from the referenced `Action` type) and the new `ActionsContent.markdownTitle` are both susceptible to malformed JSON values (e.g., non-string, null). While TypeScript types constrain compile-time construction, decoded wire content bypasses TS type safety. The validator should ensure that when present, these fields are of type string (for `imageUrl`) or boolean (for `markdownTitle`) to avoid downstream rendering errors or unexpected behavior. <b>[ Low confidence ]</b>
- [line 51](https://github.com/xmtp/xmtp-qa-tools/blob/e470436fa4e5f6b6a7a904e1c5012ebf3a1c84da/agents/utils/inline-actions/types/ActionsContent.ts#L51): New field `markdownTitle` is introduced on `ActionsContent` ("Optional flag to indicate if description should be rendered as markdown"), but there is no corresponding runtime validation to ensure it is a boolean when present. Because decoding uses `JSON.parse` and then asserts the type at compile time without enforcing it at runtime, a malformed payload (e.g., `{ markdownTitle: "yes" }` or `{ markdownTitle: 1 }`) will pass through `encode`/`decode` and `validateContent` without error. Downstream renderers that assume boolean semantics may misbehave. The validator should explicitly check `if (content.markdownTitle !== undefined && typeof content.markdownTitle !== "boolean")` and reject invalid values. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->