### PR TITLE
Update key-check

### DIFF
--- a/agents/bots/key-check/index.ts
+++ b/agents/bots/key-check/index.ts
@@ -1,4 +1,4 @@
-import { APP_VERSION } from "@helpers/client";
+import { APP_VERSION, createSigner } from "@helpers/client";
 import {
   ContentTypeMarkdown,
   MarkdownCodec,
@@ -58,8 +58,8 @@ const appConfig: AppConfig = {
     "main-menu": {
       id: "main-menu",
       title:
-        "🔧 **Hey, this is the Key-Check Bot** 🔑\n\n- *if appears greyed out, please go back to the conversation list and open the conversation again*",
-      markdownTitle: true,
+        "Hey, this is the Key-Check Bot** 🔑\n*if appears greyed out, please go back to the conversation list and open the conversation again",
+
       actions: [
         { id: "key-packages-menu", label: "🔑 Key Packages", style: "primary" },
         { id: "group-tools-menu", label: "👥 Group Tools" },
@@ -249,7 +249,7 @@ async function showInboxInputMenu(ctx: MessageContext) {
     "inbox-input-menu",
     "🔍 Check by Inbox ID",
   )
-    .add("back-to-main", "⬅️ Back to Main Menu")
+    .add("back-to-main", "⬅️ Go back")
     .build();
 
   await sendActions(ctx, inputMenu);
@@ -263,7 +263,7 @@ async function showAddressInputMenu(ctx: MessageContext) {
     "address-input-menu",
     "📧 Check by Address",
   )
-    .add("back-to-main", "⬅️ Back to Main Menu")
+    .add("back-to-main", "⬅️ Go back")
     .build();
 
   await sendActions(ctx, inputMenu);
@@ -277,7 +277,7 @@ async function showCustomLoadTestMenu(ctx: MessageContext) {
     "custom-load-test-menu",
     "⚙️ Custom Load Test",
   )
-    .add("back-to-main", "⬅️ Back to Main Menu")
+    .add("back-to-main", "⬅️ Go back")
     .build();
 
   await sendActions(ctx, customMenu);
@@ -290,9 +290,15 @@ async function showCustomLoadTestMenu(ctx: MessageContext) {
       "• `3 50` = 3 groups × 50 messages",
   );
 }
-
-// 2. Spin up the agent with UX demo codecs and inline actions
-const agent = await Agent.createFromEnv({
+const signer = createSigner(process.env.XMTP_WALLET_KEY as `0x${string}`);
+const encryptionKey = Buffer.from(
+  process.env.XMTP_DB_ENCRYPTION_KEY as string,
+  "hex",
+);
+const env = process.env.XMTP_ENV as "local" | "dev" | "production";
+const agent = await Agent.create(signer, {
+  env,
+  dbEncryptionKey: encryptionKey,
   appVersion: APP_VERSION,
   dbPath: (inboxId) =>
     (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".") +

--- a/agents/utils/inline-actions/README.md
+++ b/agents/utils/inline-actions/README.md
@@ -107,8 +107,7 @@ const config: AppConfig = {
   menus: {
     "main-menu": {
       id: "main-menu",
-      title: "**Main Menu**\n\nChoose an option below:",
-      markdownTitle: true, // Enable markdown for this menu's title
+      title: "Main Menu\nChoose an option below:",
       actions: [
         { id: "sub-menu", label: "Go to Sub Menu" },
         { id: "action-1", label: "Do Something", handler: myHandler },

--- a/agents/utils/inline-actions/inline-actions.ts
+++ b/agents/utils/inline-actions/inline-actions.ts
@@ -46,8 +46,8 @@ export async function showLastMenu(
     console.log(`🔄 Showing last menu: ${lastShownMenu.menuId}`);
     await showMenu(ctx, lastShownMenu.config, lastShownMenu.menuId);
   } else {
-    console.warn("⚠️ No last menu to show, falling back to main menu");
-    // Fallback to main menu if no last menu is tracked
+    console.warn("⚠️ No last menu to show, falling Go back");
+    // FallGo back if no last menu is tracked
     if (fallbackConfig) {
       console.log("🔄 Showing main menu as fallback");
       await showMenu(ctx, fallbackConfig, "main-menu");
@@ -155,7 +155,6 @@ export class ActionBuilder {
       id: this.actionId,
       description: this.actionDescription,
       actions: this.actions,
-      ...(this.useMarkdown && { markdownTitle: true }),
     };
   }
 
@@ -270,7 +269,6 @@ export type Menu = {
   id: string;
   title: string;
   actions: MenuAction[];
-  markdownTitle?: boolean;
 };
 
 export type AppConfig = {
@@ -315,7 +313,7 @@ export async function showMenu(
   }
 
   // Use a stable action ID without timestamp to prevent conflicts
-  const builder = ActionBuilder.create(menuId, menu.title, menu.markdownTitle);
+  const builder = ActionBuilder.create(menuId, menu.title);
 
   menu.actions.forEach((action) => {
     builder.add(action.id, action.label, action.style);

--- a/agents/utils/inline-actions/types/ActionsContent.ts
+++ b/agents/utils/inline-actions/types/ActionsContent.ts
@@ -44,8 +44,6 @@ export type ActionsContent = {
   actions: Action[];
   /** Optional ISO-8601 expiration timestamp */
   expiresAt?: string;
-  /** Optional flag to indicate if description should be rendered as markdown */
-  markdownTitle?: boolean;
 };
 
 /**


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove markdown menu titles and initialize the key-check agent with `Agent.create` using `createSigner` and environment and DB encryption from `XMTP_ENV` and `XMTP_DB_ENCRYPTION_KEY`
This PR removes markdown-based menu title handling and updates the key-check agent bootstrap to use an explicit signer and environment-specific configuration.

- Replace `Agent.createFromEnv` with `Agent.create` and construct a signer via `createSigner` using `XMTP_WALLET_KEY`; add DB encryption via `XMTP_DB_ENCRYPTION_KEY` and set environment from `XMTP_ENV` in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1514/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7)
- Drop the `markdownTitle` field from Actions content and menu types; stop propagating markdown title flags in inline action builders in [inline-actions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1514/files#diff-22d09cdf2ad55936b9e39699ed7db7e4a8cfd84e676f28c168c6af5b8c513772) and [ActionsContent.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1514/files#diff-79bc0ba13dab4d9064c98badecb3a41a08e2d1c9d0046f12b9413f6a7f4956b3)
- Update UI copy: change main menu title to plain text and standardize back action labels to "⬅️ Go back" in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1514/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7); adjust README example in [README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1514/files#diff-c2994f8978c8b5b07bef17967b57c4e16244abf22be90281feb94ead50d76a88)

#### 📍Where to Start
Start with the agent bootstrap changes in `Agent.create` and `createSigner` in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1514/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7). Review the removal of `markdownTitle` in the inline actions flow beginning at `ActionBuilder.create` in [inline-actions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1514/files#diff-22d09cdf2ad55936b9e39699ed7db7e4a8cfd84e676f28c168c6af5b8c513772).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d8357f9. 3 files reviewed, 9 issues evaluated, 9 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>agents/bots/key-check/index.ts — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 293](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/bots/key-check/index.ts#L293): Unvalidated environment variable `process.env.XMTP_WALLET_KEY` is passed to `createSigner` and used immediately with `key.startsWith("0x")`. If `XMTP_WALLET_KEY` is undefined or not a string at runtime, this will throw a `TypeError` (cannot read properties of undefined) during process initialization. Add an explicit presence/type check with a clear error before calling `createSigner`. <b>[ Low confidence ]</b>
- [line 294](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/bots/key-check/index.ts#L294): Unvalidated environment variable `process.env.XMTP_DB_ENCRYPTION_KEY` is passed directly to `Buffer.from(..., "hex")`. If the env var is undefined, this will throw a `TypeError` at runtime. If it is not valid hex or of an unexpected length, it can produce an incorrect key, leading to later decryption/DB access failures. Add explicit checks for presence, valid hex format, and expected byte length (e.g., 32 bytes) before constructing the buffer. <b>[ Low confidence ]</b>
- [line 298](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/bots/key-check/index.ts#L298): The `env` variable is derived from `process.env.XMTP_ENV` via a type assertion (`as "local" | "dev" | "production"`) without runtime validation. If the env var is undefined or contains an unexpected value, it may propagate an invalid environment to `Agent.create`, causing connection failures or undefined behavior. Add a runtime default and/or validate the value against the allowed set, failing fast with a clear message if invalid. <b>[ Low confidence ]</b>
- [line 303](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/bots/key-check/index.ts#L303): The `dbPath` callback uses `inboxId.slice(0, 8)` without validating that `inboxId` is a non-empty string. If `Agent.create` invokes `dbPath` with an undefined/null or non-string value due to an upstream error, this will throw at runtime. Add a guard to ensure `inboxId` is a string and non-empty, or handle the fallback path safely. <b>[ Low confidence ]</b>
</details>

<details>
<summary>agents/utils/inline-actions/inline-actions.ts — 0 comments posted, 5 evaluated, 5 filtered</summary>

- [line 45](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/utils/inline-actions/inline-actions.ts#L45): Global `lastShownMenu` is shared across all calls/contexts, causing cross-session data leakage and incorrect behavior under concurrent or multi-user usage. `showLastMenu` reads `lastShownMenu` (a module-level mutable variable) and uses its `config` and `menuId` to show a menu for the current `ctx`. If multiple users/sessions/threads share this module, one user's last menu can be shown to another user when they invoke `showLastMenu`, leaking menu identifiers and potentially context-specific configuration. This also creates race conditions: calls from different contexts can overwrite `lastShownMenu` between actions, leading to non-deterministic behavior. The state should be tracked per-context (e.g., keyed by a user/session/conversation identifier available on `MessageContext`) rather than as a single global. <b>[ Low confidence ]</b>
- [line 49](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/utils/inline-actions/inline-actions.ts#L49): Misleading log and comment text: `console.warn("⚠️ No last menu to show, falling Go back");` and `// FallGo back if no last menu is tracked` contain a typo that changes the meaning from "fallback" to an unclear phrase. While not a crash, this can hinder diagnosis and log-based monitoring. If the intended behavior is to fallback to the main menu when `fallbackConfig` is provided, the log should reflect that. Currently, it may cause confusion during incident investigation. <b>[ Code style ]</b>
- [line 153](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/utils/inline-actions/inline-actions.ts#L153): The `markdown` argument to `ActionBuilder.create()` and the internal `useMarkdown` flag are no longer reflected in the built payload. In `build()`, the returned `ActionsContent` omits any markdown indicator, and the previously present spread `...(this.useMarkdown && { markdownTitle: true })` has been removed. This creates a functional regression: callers passing `markdown = true` will not see the description rendered as markdown by downstream consumers that expect a `markdownTitle` (or equivalent) flag in the content payload. This is a silent behavior change with no error, leading to incorrect rendering. <b>[ Low confidence ]</b>
- [line 155](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/utils/inline-actions/inline-actions.ts#L155): `build()` does not validate `id` (`this.actionId`) or `description` (`this.actionDescription`). Since the constructor is public and `build()` can be invoked without calling `create()`, both fields may be empty strings. This can yield malformed or invalid `ActionsContent` for downstream consumers (e.g., `ContentTypeActions`) that expect a non-empty unique identifier and descriptive text, causing runtime handling or rendering issues. <b>[ Low confidence ]</b>
- [line 157](https://github.com/xmtp/xmtp-qa-tools/blob/d8357f97b2bfdaaf971458e5aa57b3474def8ef7/agents/utils/inline-actions/inline-actions.ts#L157): `build()` returns the internal `actions` array reference (`actions: this.actions`) directly. This leaks mutable internal state to external consumers. If any downstream code mutates the `actions` array in the built `ActionsContent` (e.g., adding/removing actions), it will also mutate the builder’s internal `actions`. This can cause subtle runtime bugs if the builder is reused or if subsequent operations rely on the original set of actions. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->