### PR TITLE
Improve log readability

### DIFF
--- a/deploy-metadata.json
+++ b/deploy-metadata.json
@@ -1,1 +1,1 @@
-{"deployedAt": "2025-11-04T21:25:03Z", "version": "0.4.7"}
+{ "deployedAt": "2025-11-04T21:25:03Z", "version": "0.4.7" }

--- a/forks/config.ts
+++ b/forks/config.ts
@@ -29,4 +29,3 @@ export const network = process.env.XMTP_ENV; // Network environment setting
 export const randomInboxIdsCount = 10; // How many inboxIds to use randomly in the add/remove operations
 export const installationCount = 2; // How many installations to use randomly in the createInstallation operations
 export const testName = "forks";
-

--- a/helpers/analyzer.ts
+++ b/helpers/analyzer.ts
@@ -223,7 +223,9 @@ export async function cleanForksLogs(
         if (removeNonMatching) {
           // Skip creating cleaned version for non-fork logs
           // Raw log is always preserved
-          console.debug(`Skipping ${file} - does not contain fork content (raw log preserved)`);
+          console.debug(
+            `Skipping ${file} - does not contain fork content (raw log preserved)`,
+          );
           removedCount++;
         } else {
           // Create cleaned version even if no fork content
@@ -241,7 +243,9 @@ export async function cleanForksLogs(
       const outputFileName = file.replace("raw-", "cleaned-");
       const outputPath = path.join(outputDir, outputFileName);
       await processLogFile(rawFilePath, outputPath);
-      console.debug(`Cleaned forks log: ${file} -> ${outputFileName} (raw log preserved)`);
+      console.debug(
+        `Cleaned forks log: ${file} -> ${outputFileName} (raw log preserved)`,
+      );
       processedCount++;
     } catch (error) {
       console.error(`Failed to process ${file}:`, error);
@@ -253,7 +257,9 @@ export async function cleanForksLogs(
       `Skipped creating cleaned versions for ${removedCount} files that did not contain fork content (raw logs preserved)`,
     );
   }
-  console.debug(`Processed ${processedCount} forks log files (all raw logs preserved)`);
+  console.debug(
+    `Processed ${processedCount} forks log files (all raw logs preserved)`,
+  );
 }
 
 /**


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Reformat deploy metadata JSON and restructure `helpers/analyzer.ts` `cleanForksLogs` debug output to improve log readability
Reformat `deploy-metadata.json` spacing and convert `console.debug` calls in `helpers/analyzer.ts` `cleanForksLogs` to multi-line invocations.

#### 📍Where to Start
Start with the `cleanForksLogs` debug call updates in [helpers/analyzer.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1525/files#diff-2500289fbd8a6ab1f5d1f99dbb3061ecec578fef49512f65a04574a8441a8193).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a3c4465. 2 files reviewed, 5 issues evaluated, 5 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>forks/config.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 27](https://github.com/xmtp/xmtp-qa-tools/blob/a3c4465f5c5cc3e11038a3f2ef7dce2bf23cf744/forks/config.ts#L27): Comment on line 27 explicitly states "The target epoch to stop the test", implying an exported `targetEpoch` configuration, but the implementation exports `network` on the following line instead and does not define `targetEpoch`. This contradicts the comment and creates uncertainty about the intended configuration, increasing the risk of misconfiguration at runtime if callers rely on the documented intent. <b>[ Out of scope ]</b>
- [line 28](https://github.com/xmtp/xmtp-qa-tools/blob/a3c4465f5c5cc3e11038a3f2ef7dce2bf23cf744/forks/config.ts#L28): `network` is assigned from `process.env.XMTP_ENV` without a default or validation. If the environment variable is unset, `network` will be `undefined`, which is reachable and could lead to misconfiguration or runtime errors in consumers that expect a non-empty string. This module provides no guard or fallback to ensure a defined value. <b>[ Low confidence ]</b>
</details>

<details>
<summary>helpers/analyzer.ts — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 175](https://github.com/xmtp/xmtp-qa-tools/blob/a3c4465f5c5cc3e11038a3f2ef7dce2bf23cf744/helpers/analyzer.ts#L175): The header comment `Clean forks logs and remove non-forks logs` contradicts the implementation. The function never removes any logs; it only skips creating cleaned versions for non-fork logs while always preserving raw logs. This mismatch creates uncertainty for callers about the intended behavior and side effects (actual removal vs. skipping). <b>[ Low confidence ]</b>
- [line 188](https://github.com/xmtp/xmtp-qa-tools/blob/a3c4465f5c5cc3e11038a3f2ef7dce2bf23cf744/helpers/analyzer.ts#L188): The function creates the `outputDir` (`logs/cleaned`) before determining whether there are any forks log files to process. If `fs.promises.readdir(logsDir)` finds no matching files, the function returns without processing, but the `cleaned` directory has already been created. This introduces an unnecessary side effect and can cause unexpected directory creation even when there is nothing to clean. <b>[ Low confidence ]</b>
- [line 188](https://github.com/xmtp/xmtp-qa-tools/blob/a3c4465f5c5cc3e11038a3f2ef7dce2bf23cf744/helpers/analyzer.ts#L188): Unhandled errors during directory operations can cause the function to reject and potentially crash the caller. Specifically, `fs.promises.mkdir(outputDir, { recursive: true })` and `fs.promises.readdir(logsDir)` are not wrapped in `try/catch`. If either fails (e.g., due to permissions, I/O errors, or transient filesystem issues), the function throws and does not reach defined terminal logging states. In contrast, per-file processing is guarded by a `try/catch`, indicating intent to continue on errors for individual files. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->