### PR TITLE
Update agent SDK version

### DIFF
--- a/agents/bots/key-check/index.ts
+++ b/agents/bots/key-check/index.ts
@@ -290,15 +290,8 @@ async function showCustomLoadTestMenu(ctx: MessageContext) {
       "• `3 50` = 3 groups × 50 messages",
   );
 }
-const signer = createSigner(process.env.XMTP_WALLET_KEY as `0x${string}`);
-const encryptionKey = Buffer.from(
-  process.env.XMTP_DB_ENCRYPTION_KEY as string,
-  "hex",
-);
-const env = process.env.XMTP_ENV as "local" | "dev" | "production";
-const agent = await Agent.create(signer, {
-  env,
-  dbEncryptionKey: encryptionKey,
+
+const agent = await Agent.createFromEnv({
   appVersion: APP_VERSION,
   dbPath: (inboxId) =>
     (process.env.RAILWAY_VOLUME_MOUNT_PATH ?? ".") +

--- a/agents/versions/agent-sdk.ts
+++ b/agents/versions/agent-sdk.ts
@@ -9,7 +9,7 @@ import {
 import {
   Agent as Agent115,
   MessageContext as MessageContext115,
-} from "@xmtp/agent-sdk-1.1.7";
+} from "@xmtp/agent-sdk-1.1.9";
 
 // Export the latest version as default
 export {
@@ -19,15 +19,15 @@ export {
   type Group,
   type IdentifierKind,
   type PermissionLevel,
-} from "@xmtp/agent-sdk-1.1.7";
+} from "@xmtp/agent-sdk-1.1.9";
 
-export { getTestUrl } from "@xmtp/agent-sdk-1.1.7/debug";
+export { getTestUrl } from "@xmtp/agent-sdk-1.1.9/debug";
 
 export const AgentVersionList = [
   {
     Agent: Agent115,
     MessageContext: MessageContext115,
-    agentSDK: "1.1.7",
+    agentSDK: "1.1.9",
     nodeSDK: "4.2.3",
     nodeBindings: "1.5.4",
     auto: true,

--- a/agents/versions/cli.ts
+++ b/agents/versions/cli.ts
@@ -84,13 +84,6 @@ function createAgentSDKSymlinks() {
   }
 
   console.log("✅ Agent SDK version setup complete!");
-  console.log("Available versions:");
-  for (const config of AgentVersionList) {
-    const status = config.auto ? "🟢 auto" : "🟡 manual";
-    console.log(
-      `  ${config.agentSDK} ${status} (node-sdk: ${config.nodeSDK}, bindings: ${config.nodeBindings})`,
-    );
-  }
 }
 
 function cleanPackageJson() {

--- a/cli/sdk-versions.ts
+++ b/cli/sdk-versions.ts
@@ -155,13 +155,7 @@ function main() {
 
   createBindingsSymlinks();
   console.log("✅ Node SDK version setup complete!");
-  console.log("Available versions:");
-  for (const config of VersionList) {
-    const status = config.auto ? "🟢 auto" : "🟡 manual";
-    console.log(
-      `  ${config.nodeSDK} ${status} (bindings: ${config.nodeBindings})`,
-    );
-  }
+
   console.log("Done");
 }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint .",
     "monitor:yarn": "httpstat https://grpc.dev.xmtp.network:443",
     "record": "npx playwright codegen 'https://xmtp.chat/'",
-    "regression": "yarn test performance --env dev --sync all --versions 3 --size 10-100 && yarn test bugs",
+    "regression": "yarn versions && yarn test performance --env dev --sync all --versions 3 --size 10-100 && yarn test bugs",
     "send": "tsx cli/send.ts",
     "test": "tsx cli/test.ts",
     "versions": "tsx cli/sdk-versions.ts"
@@ -32,7 +32,7 @@
     "@xmtp/agent-sdk-1.0.0": "npm:@xmtp/agent-sdk@1.0.0",
     "@xmtp/agent-sdk-1.0.1": "npm:@xmtp/agent-sdk@1.0.1",
     "@xmtp/agent-sdk-1.1.2": "npm:@xmtp/agent-sdk@1.1.2",
-    "@xmtp/agent-sdk-1.1.7": "npm:@xmtp/agent-sdk@1.1.7",
+    "@xmtp/agent-sdk-1.1.9": "npm:@xmtp/agent-sdk@1.1.9",
     "@xmtp/content-type-markdown": "^1.0.0",
     "@xmtp/content-type-reaction": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",

--- a/workers/node-sdk.ts
+++ b/workers/node-sdk.ts
@@ -64,7 +64,7 @@ export {
   type KeyPackageStatus,
   type PermissionUpdateType,
   ConsentEntityType,
-} from "@xmtp/node-sdk-4.2.3";
+} from "@xmtp/node-sdk-4.3.0";
 
 export const VersionList = [
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,18 +1424,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/agent-sdk-1.1.7@npm:@xmtp/agent-sdk@1.1.7":
-  version: 1.1.7
-  resolution: "@xmtp/agent-sdk@npm:1.1.7"
+"@xmtp/agent-sdk-1.1.9@npm:@xmtp/agent-sdk@1.1.9":
+  version: 1.1.9
+  resolution: "@xmtp/agent-sdk@npm:1.1.9"
   dependencies:
     "@xmtp/content-type-reaction": "npm:^2.0.2"
     "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-sdk": "npm:^4.2.3"
-    uint8arrays: "npm:^5.1.0"
+    "@xmtp/node-sdk": "npm:^4.2.4"
     viem: "npm:^2.37.6"
-  checksum: 10/f8d76265a4cbcb32282ba75404d50779bef0f7bb9bd16298a825348b03a15f0fa290966d4eb15a71bcd3a621be279379b632ea6e448e715bdefe782e9ac99a34
+  checksum: 10/457b6bb94f387a0f6d2b61f16a172f13bae35ce2b0ad78dbf162a1777b19cf4504b872d5c8070ad9ccba995cd11ac5168ca8697aee1d58b4807dd4e16797f715
   languageName: node
   linkType: hard
 
@@ -1624,7 +1623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-4.2.3@npm:@xmtp/node-sdk@4.2.3, @xmtp/node-sdk@npm:^4.1.2, @xmtp/node-sdk@npm:^4.2.1, @xmtp/node-sdk@npm:^4.2.3":
+"@xmtp/node-sdk-4.2.3@npm:@xmtp/node-sdk@4.2.3, @xmtp/node-sdk@npm:^4.1.2, @xmtp/node-sdk@npm:^4.2.1":
   version: 4.2.3
   resolution: "@xmtp/node-sdk@npm:4.2.3"
   dependencies:
@@ -1636,7 +1635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-4.3.0@npm:@xmtp/node-sdk@4.3.0":
+"@xmtp/node-sdk-4.3.0@npm:@xmtp/node-sdk@4.3.0, @xmtp/node-sdk@npm:^4.2.4":
   version: 4.3.0
   resolution: "@xmtp/node-sdk@npm:4.3.0"
   dependencies:
@@ -4643,7 +4642,7 @@ __metadata:
     "@xmtp/agent-sdk-1.0.0": "npm:@xmtp/agent-sdk@1.0.0"
     "@xmtp/agent-sdk-1.0.1": "npm:@xmtp/agent-sdk@1.0.1"
     "@xmtp/agent-sdk-1.1.2": "npm:@xmtp/agent-sdk@1.1.2"
-    "@xmtp/agent-sdk-1.1.7": "npm:@xmtp/agent-sdk@1.1.7"
+    "@xmtp/agent-sdk-1.1.9": "npm:@xmtp/agent-sdk@1.1.9"
     "@xmtp/content-type-markdown": "npm:^1.0.0"
     "@xmtp/content-type-reaction": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update Agent initialization to use environment-driven `Agent.createFromEnv` and bump Agent SDK to 1.1.9 with Node SDK 4.3.0
Switch Agent boot to `Agent.createFromEnv` in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1527/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7), upgrade exports to `@xmtp/agent-sdk-1.1.9` in [agent-sdk.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1527/files#diff-7b184cd80dd9a1326f1564dd36c721b8640b4b721cac4c0f93c0049ac8002e90), and update Node SDK re-exports to `@xmtp/node-sdk-4.3.0` in [node-sdk.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1527/files#diff-776be999da1fb67222aa18a3fd9a70bfa6beea381e2e4e76a45de9b7750b9203).

#### 📍Where to Start
Start with the Agent initialization change in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1527/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7), focusing on the switch to `Agent.createFromEnv` and the removed signer/env/dbEncryptionKey wiring.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ceccd49. 4 files reviewed, 9 issues evaluated, 7 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>agents/bots/key-check/index.ts — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 294](https://github.com/xmtp/xmtp-qa-tools/blob/ceccd49dd447f2f658f93219d2aea323b70b7df6/agents/bots/key-check/index.ts#L294): Encryption key handling removed: previous code set `dbEncryptionKey` using `process.env.XMTP_DB_ENCRYPTION_KEY` and passed it to `Agent.create`. The new code calls `Agent.createFromEnv` without providing `dbEncryptionKey`, which may result in an unencrypted database or reliance on implicit defaults. This is a potentially serious runtime/security regression and a contract change that can alter data-at-rest protection and operational expectations. <b>[ Low confidence ]</b>
- [line 297](https://github.com/xmtp/xmtp-qa-tools/blob/ceccd49dd447f2f658f93219d2aea323b70b7df6/agents/bots/key-check/index.ts#L297): Environment isolation may break because `dbPath` uses `process.env.XMTP_ENV` directly without a guard. If `process.env.XMTP_ENV` is undefined, the constructed path becomes `"./undefined-<inboxId>.db3"`, silently collapsing all environments into the same namespace and potentially mixing data that was previously isolated by `env`. Prior code explicitly set `env` with `"local" | "dev" | "production"`, ensuring a well-defined value for environment-dependent behavior and filenames. This change removes that explicit guarantee while still embedding `process.env.XMTP_ENV` in `dbPath`, introducing a reachable runtime misbehavior and data mixing risk. <b>[ Low confidence ]</b>
- [line 298](https://github.com/xmtp/xmtp-qa-tools/blob/ceccd49dd447f2f658f93219d2aea323b70b7df6/agents/bots/key-check/index.ts#L298): Potential runtime crash in `dbPath` callback: `inboxId.slice(0, 8)` will throw if `inboxId` is `undefined`, `null`, or not a string. There is no visible guard ensuring `inboxId` is a non-empty string. Given that `dbPath` is invoked by `Agent.createFromEnv`, any unexpected or missing `inboxId` from upstream will cause a `TypeError: Cannot read properties of undefined (reading 'slice')`, causing agent initialization to fail at runtime. <b>[ Low confidence ]</b>
</details>

<details>
<summary>agents/versions/cli.ts — 0 comments posted, 4 evaluated, 2 filtered</summary>

- [line 61](https://github.com/xmtp/xmtp-qa-tools/blob/ceccd49dd447f2f658f93219d2aea323b70b7df6/agents/versions/cli.ts#L61): Non-atomic deletion of `agent-sdk` before creating the new symlink can leave the system in a broken state on error paths. The code removes the existing `agent-sdk` (either unlink or recursive delete) and then attempts `fs.symlinkSync`. If an error occurs (e.g., missing version directory or symlink creation failure), there is no rollback or restoration, and the CLI proceeds to set `hasErrors` and eventually `process.exit(1)`, potentially leaving `@xmtp/agent-sdk` missing entirely. This violates invariants after effects: no guarantee of a valid link or directory on failure paths. <b>[ Low confidence ]</b>
- [line 81](https://github.com/xmtp/xmtp-qa-tools/blob/ceccd49dd447f2f658f93219d2aea323b70b7df6/agents/versions/cli.ts#L81): The CLI treats any missing version directory as a fatal error (`hasErrors` -> `process.exit(1)`), even if at least one valid version directory exists and the symlink was successfully created. This prevents successful setup in environments where only the desired/latest version is installed. If partial setup is acceptable (and the help text suggests enabling testing across multiple versions, not requiring all), consider exiting successfully when the selected/current version is linked, or allow a mode that does not fail when some versions are missing. <b>[ Low confidence ]</b>
</details>

<details>
<summary>cli/sdk-versions.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 152](https://github.com/xmtp/xmtp-qa-tools/blob/ceccd49dd447f2f658f93219d2aea323b70b7df6/cli/sdk-versions.ts#L152): Misleading recovery path when `yarn install` fails after `node_modules` was successfully removed. In `main()`, if not running in GitHub Actions, the code first attempts to delete `node_modules` (lines 138–147). If deletion succeeds and then `execSync("yarn install")` throws (lines 149–153), it logs `"Continuing with existing installation..."` (lines 151–153). This message implies there is an existing installation to use, which is false if `node_modules` was just removed successfully. The subsequent call to `createBindingsSymlinks()` may then fail due to missing dependencies, yielding a hard exit, but the misleading message can cause confusion and hides the actual state (no installation present). A safer path would be to detect whether removal succeeded and adjust the fallback messaging and behavior (e.g., abort early or attempt an alternate install). <b>[ Out of scope ]</b>
- [line 158](https://github.com/xmtp/xmtp-qa-tools/blob/ceccd49dd447f2f658f93219d2aea323b70b7df6/cli/sdk-versions.ts#L158): The removal of the version summary output breaks the previously visible contract of the CLI. Before this change, `main()` printed a list of available SDK versions and bindings (e.g., `Available versions:` followed by each entry derived from `VersionList`). That output could be relied upon by users or scripts to verify configuration or parse available versions. The current implementation no longer prints this list and provides no alternative or deprecation notice, changing externally visible behavior without documentation. This can cause downstream automation relying on the output to fail silently or behave incorrectly. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->