### PR TITLE
Refactor regression tests setup

### DIFF
--- a/.github/workflows/validate-regression.yml
+++ b/.github/workflows/validate-regression.yml
@@ -56,12 +56,6 @@ jobs:
         run: corepack prepare yarn@4.6.0 --activate
         shell: bash
 
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Run script version
-        run: yarn versions
-
       - name: Run regression tests
         run: yarn regression
 

--- a/workers/README.md
+++ b/workers/README.md
@@ -10,9 +10,8 @@ When upgrading XMTP bindings and/or node-sdk versions:
 
 1. Add `@xmtp/node-sdk-X.X.X` and `@xmtp/node-bindings-X.X.X` to package.json.
 2. Add import for new SDK version to `versions/node-sdk.ts`.
-3. Run `yarn versions` to link the new versions.
-4. Run `yarn regression` to check regression of latest 3 versions.
-5. Create and Merge PR. (so it's tested in CI)
+3. Run `yarn regression` to check regression of latest 3 versions.
+4. Create and Merge PR. (so it's tested in CI)
 
 ### Version mapping system
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refactor regression test workflow by removing `yarn install` and `yarn versions` steps from `.github/workflows/validate-regression.yml`
Update the validate-regression GitHub Actions job to skip `yarn install` and `yarn versions`, and adjust the worker docs to remove the `yarn versions` instruction and renumber steps in [workers/README.md](https://github.com/xmtp/xmtp-qa-tools/pull/1529/files#diff-7869f58a0c6c87cd3f01d427aab93e4a7d88d3566f8296b9cb181224da759a52).

#### 📍Where to Start
Start with the workflow changes in [validate-regression.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1529/files#diff-a68a3877ad1b13c641e9766ab8c47f8e7d0c9ecca79323c62a64cdfd06ce3c37), focusing on the removed steps before the `yarn regression` job.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 54d6d40. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->