### PR TITLE
Update auto status to true

### DIFF
--- a/agents/bots/key-check/index.ts
+++ b/agents/bots/key-check/index.ts
@@ -9,7 +9,6 @@ import {
 import { ContentTypeMarkdown } from "@xmtp/content-type-markdown";
 import {
   ActionBuilder,
-  getRegisteredActions,
   initializeAppFromConfig,
   inlineActionsMiddleware,
   sendActions,

--- a/helpers/versions.ts
+++ b/helpers/versions.ts
@@ -99,7 +99,7 @@ export const AgentVersionList = [
     MessageContext: MessageContext110,
     agentSDK: "1.1.10",
     nodeSDK: "4.3.0",
-    auto: false,
+    auto: true,
   },
   {
     Agent: Agent17,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set `AgentVersionList` entry for agentSDK `1.1.10` and nodeSDK `4.3.0` to `auto: true` to update auto status
Update the `AgentVersionList` constant to mark agentSDK `1.1.10` with nodeSDK `4.3.0` as auto-enabled and remove `getRegisteredActions` from the inline-actions import list in `index.ts`. See [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1542/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7) and [versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1542/files#diff-4a76eebeb21df1a039004c375f1b41865643020370ec70a15742c61e35a90160).

#### 📍Where to Start
Start with the `AgentVersionList` changes in [versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1542/files#diff-4a76eebeb21df1a039004c375f1b41865643020370ec70a15742c61e35a90160) to verify the `auto` flag update, then review the import adjustments in [index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1542/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 51f8b94. 2 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>helpers/versions.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 102](https://github.com/xmtp/xmtp-qa-tools/blob/51f8b947fada5400c18567d8ecbd6150b2f96bd4/helpers/versions.ts#L102): helpers/versions.ts: Multiple entries in `AgentVersionList` now have `auto: true` (line 102 changed from `false` to `true`, while other entries at lines 109 and 116 are also `true`). If the selection logic expects exactly one auto-selected version (mutual exclusion/uniqueness), this change can cause ambiguous selection, nondeterministic behavior (e.g., selecting the first or last), or a runtime error if the code validates uniqueness. This violates the uniqueness/mutual-exclusion invariant commonly required for 'default/auto' flags in version registries. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->