### PR TITLE
Add streams to fork test

### DIFF
--- a/forks/README.md
+++ b/forks/README.md
@@ -61,6 +61,7 @@ The main approach creates intentional conflicts by running parallel operations o
 - **installationCount**: `5` - How many installations to use randomly in the createInstallation operations
 - **typeofStreamForTest**: `typeofStream.None` - No streams started by default (configured on-demand)
 - **typeOfSyncForTest**: `typeOfSync.None` - No automatic syncing (configured on-demand)
+- **streams**: `false` - Enable message streams on all workers (configured via `--streams` CLI flag)
 
 ### Test setup in local network
 
@@ -91,6 +92,9 @@ yarn fork --clean-all
 
 # Run on a specific environment
 yarn fork --count 200 --env local
+
+# Enable message streams on all workers
+yarn fork --streams
 
 # Show help
 yarn fork --help

--- a/forks/config.ts
+++ b/forks/config.ts
@@ -1,7 +1,7 @@
 import { getActiveVersion } from "@helpers/versions";
 
 // Fork matrix parameters - shared between test and CLI
-export const groupCount = 5;
+export const groupCount = 1;
 export const parallelOperations = 5; // How many operations to perform in parallel
 export const NODE_VERSION = getActiveVersion().nodeBindings; // default to latest version, can be overridden with --nodeBindings=3.1.1
 // By calling workers with prefix random1, random2, etc. we guarantee that creates a new key each run
@@ -23,10 +23,11 @@ export const epochRotationOperations = {
 export const otherOperations = {
   createInstallation: false, // creates a new installation for a random worker
   sendMessage: true, // sends a message to the group
+  sync: true, // syncs the group
 };
 export const targetEpoch = 30n; // The target epoch to stop the test (epochs are when performing forks to the group)
 export const network = process.env.XMTP_ENV; // Network environment setting
-export const randomInboxIdsCount = 10; // How many inboxIds to use randomly in the add/remove operations
+export const randomInboxIdsCount = 50; // How many inboxIds to use randomly in the add/remove operations
 export const installationCount = 2; // How many installations to use randomly in the createInstallation operations
 export const testName = "forks";
 
@@ -68,7 +69,7 @@ export const chaosPresets: Record<ChaosLevel, ChaosPreset> = {
     jitterMin: 50,
     jitterMax: 200,
     lossMin: 0,
-    lossMax: 10,
+    lossMax: 25,
     interval: 10000, // 10 seconds
   },
 };
@@ -83,6 +84,9 @@ export const chaosConfig: ChaosConfig = {
   enabled: process.env.CHAOS_ENABLED === "true",
   level: (process.env.CHAOS_LEVEL as ChaosLevel) || "medium",
 };
+
+// Parse streams config from environment
+export const streamsEnabled = process.env.STREAMS_ENABLED === "true";
 
 // Multinode container names for local environment chaos testing
 export const multinodeContainers = [

--- a/forks/utils.ts
+++ b/forks/utils.ts
@@ -1,0 +1,68 @@
+import { type DockerContainer } from "network-stability/container";
+import { type ChaosPreset } from "./config";
+
+const applyPresetToNode = (node: DockerContainer, preset: ChaosPreset) => {
+  const delay = Math.floor(
+    preset.delayMin + Math.random() * (preset.delayMax - preset.delayMin),
+  );
+  const jitter = Math.floor(
+    preset.jitterMin + Math.random() * (preset.jitterMax - preset.jitterMin),
+  );
+  const loss =
+    preset.lossMin + Math.random() * (preset.lossMax - preset.lossMin);
+
+  try {
+    node.addJitter(delay, jitter);
+    node.addLoss(loss);
+  } catch (err) {
+    console.warn(`[chaos] Error applying netem on ${node.name}:`, err);
+  }
+};
+
+const validateContainers = (allNodes: DockerContainer[]) => {
+  for (const node of allNodes) {
+    try {
+      // Test if container exists by trying to get its IP
+      if (!node.ip || !node.veth) {
+        throw new Error(`Container ${node.name} has no IP address`);
+      }
+    } catch {
+      throw new Error(
+        `Docker container ${node.name} is not running. Network chaos requires local multinode setup (./dev/up).`,
+      );
+    }
+  }
+};
+
+export const startChaos = (
+  allNodes: DockerContainer[],
+  preset: ChaosPreset,
+): NodeJS.Timeout => {
+  validateContainers(allNodes);
+  console.log(`[chaos] Initialized ${allNodes.length} Docker containers`);
+  // Function to apply chaos to all nodes
+  const applyChaos = () => {
+    console.log(
+      "[chaos] Applying jitter, delay, and drop rules to all nodes...",
+    );
+    for (const node of allNodes) {
+      applyPresetToNode(node, preset);
+    }
+  };
+
+  // Apply chaos immediately
+  applyChaos();
+
+  return setInterval(applyChaos, preset.interval);
+};
+
+export const clearChaos = (allNodes: DockerContainer[]) => {
+  // Clear network rules
+  for (const node of allNodes) {
+    try {
+      node.clearLatency();
+    } catch (err) {
+      console.warn(`[chaos] Error clearing latency on ${node.name}:`, err);
+    }
+  }
+};

--- a/workers/manager.ts
+++ b/workers/manager.ts
@@ -354,7 +354,7 @@ export class WorkerManager implements IWorkerManager {
 
     if (baseName in this.keysCache) {
       //They persist in memory in the same test run
-      console.debug(`Using cached keys for ${baseName}`);
+      console.log(`Using cached keys for ${baseName}`);
       return this.keysCache[baseName];
     }
 
@@ -435,7 +435,7 @@ export class WorkerManager implements IWorkerManager {
 
     // Check if the worker already exists in our production storage
     if (providedInstallId && this.workers[baseName]?.[providedInstallId]) {
-      console.debug(`Reusing existing worker for ${descriptor}`);
+      console.log(`Reusing existing worker for ${descriptor}`);
       return this.workers[baseName][providedInstallId];
     }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add a `--streams` flag to the forks CLI and pass `STREAMS_ENABLED=true` to tests to start worker message streams
Introduce a `--streams` CLI flag, plumb `options.streams` through to set `process.env.STREAMS_ENABLED`, expose `config.streamsEnabled`, and start `worker.worker.startStream(typeofStream.Message)` in tests when streams are enabled. Update help and README accordingly.

#### 📍Where to Start
Start with `main` and flag parsing in [forks/cli.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1574/files#diff-8400a0e6291a6e667738b1b4e79b6f4f19a80f7ba2dc7b34dcffa45e7bb2dda1), then review `runForkTest` for environment propagation and `streamsEnabled` in [forks/config.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1574/files#diff-2cec05d28b0009902fc165e63362ed5ace51406f9bd25555ce29b4ad5a39eb9b), followed by the test setup in [forks/forks.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1574/files#diff-3271b43f44b9a9c2db6a3cc7d478db9f2c8ed7fe212a13e3c2916fb44ab29be6).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 24c219c. 4 files reviewed, 8 issues evaluated, 7 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>forks/cli.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 187](https://github.com/xmtp/xmtp-qa-tools/blob/24c219cdda4be8def399f4ca940cb209e92c88dd/forks/cli.ts#L187): `console.debug` is temporarily overridden to suppress output during `cleanForksLogs`, but it is restored only on the success path. If `cleanForksLogs` throws, the restoration line is skipped, leaving `console.debug` permanently muted for the remainder of the process. Use a try/finally to restore `console.debug` on all paths. <b>[ Out of scope ]</b>
- [line 193](https://github.com/xmtp/xmtp-qa-tools/blob/24c219cdda4be8def399f4ca940cb209e92c88dd/forks/cli.ts#L193): Per-run fork counting is incorrect and cumulative. `getForkCount()` returns the total number of files currently in `logs/cleaned`, and in the test loop this value is added to `stats.forksDetected` and used to classify the current run. This causes double-counting across runs and marks subsequent runs as having forks even if the current run produced none. Fix by counting only new files produced in the current run (delta since previous count), or by isolating/clearing the cleaned directory per run, or by deriving the count directly from the current run’s output files rather than the global directory total. <b>[ Out of scope ]</b>
</details>

<details>
<summary>forks/utils.ts — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 5](https://github.com/xmtp/xmtp-qa-tools/blob/24c219cdda4be8def399f4ca940cb209e92c88dd/forks/utils.ts#L5): `applyPresetToNode` does not validate or clamp the preset ranges. If `preset.delayMax < preset.delayMin` or `preset.jitterMax < preset.jitterMin`, the computed `delay`/`jitter` can be negative. If `preset.lossMin`/`lossMax` are outside 0–100 or `lossMax < lossMin`, the computed `loss` can be negative or >100. These values are then passed to `node.addJitter(delay, jitter)` and `node.addLoss(loss)`, which can produce invalid netem rules or throw at runtime. <b>[ Low confidence ]</b>
- [line 24](https://github.com/xmtp/xmtp-qa-tools/blob/24c219cdda4be8def399f4ca940cb209e92c88dd/forks/utils.ts#L24): `validateContainers` throws inside the `try` when `!node.ip || !node.veth`, but immediately catches its own throw and rethrows a different error. This masks the original, more specific message ("has no IP address") and any other underlying errors, always reporting "is not running". Also, the constructed message mentions IP even when `veth` is missing, which is misleading. Net effect: incorrect error reporting and loss of diagnostic detail. <b>[ Low confidence ]</b>
- [line 56](https://github.com/xmtp/xmtp-qa-tools/blob/24c219cdda4be8def399f4ca940cb209e92c88dd/forks/utils.ts#L56): `startChaos` uses `preset.interval` directly in `setInterval` without validation. If `interval <= 0`, negative, `NaN`, or extremely small, Node will schedule the callback as quickly as possible (effectively 0 ms), causing excessive CPU usage and log spam; `NaN` coerces to 0 as well. There is no guard to prevent this. <b>[ Low confidence ]</b>
- [line 63](https://github.com/xmtp/xmtp-qa-tools/blob/24c219cdda4be8def399f4ca940cb209e92c88dd/forks/utils.ts#L63): `clearChaos` only calls `node.clearLatency()` but `startChaos` applies both jitter/delay (`addJitter`) and loss (`addLoss`). If `clearLatency` does not clear loss rules, packet loss persists after clearing, violating teardown symmetry and leaving residual effects. <b>[ Low confidence ]</b>
</details>

<details>
<summary>workers/manager.ts — 0 comments posted, 2 evaluated, 1 filtered</summary>

- [line 402](https://github.com/xmtp/xmtp-qa-tools/blob/24c219cdda4be8def399f4ca940cb209e92c88dd/workers/manager.ts#L402): Unhandled promise rejection risk: the call to `appendFile(...)` is fire-and-forget using `void` and has no `.catch` or `await`. If the write fails (invalid path, permissions, disk full), Node may emit an unhandled rejection and the failure is silently ignored, leaving the `.env` file inconsistent. Add explicit `await` with try/catch or attach a `.catch` handler to ensure failures are handled and reported. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->