### PR TITLE
Add env value sanitization

### DIFF
--- a/scripts/revokeInstallations.ts
+++ b/scripts/revokeInstallations.ts
@@ -79,6 +79,19 @@ async function main() {
     process.exit(1);
   }
 
+  // Sanitize environment variable value by removing surrounding quotes
+  const sanitizeEnvValue = (value: string): string => {
+    const trimmed = value.trim();
+    // Remove surrounding quotes (single or double) if present
+    if (
+      (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    ) {
+      return trimmed.slice(1, -1);
+    }
+    return trimmed;
+  };
+
   // Read and parse .env file
   const envContent = await readFile(envPath, "utf-8");
   const envVars: Record<string, string> = {};
@@ -86,7 +99,7 @@ async function main() {
   envContent.split("\n").forEach((line) => {
     const [key, value] = line.split("=");
     if (key && value && !key.startsWith("#")) {
-      envVars[key.trim()] = value.trim();
+      envVars[key.trim()] = sanitizeEnvValue(value);
     }
   });
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Sanitize .env values in `scripts/revokeInstallations.ts` to remove surrounding single or double quotes for safer env parsing
Introduce `sanitizeEnvValue` and apply it when parsing .env lines in [scripts/revokeInstallations.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1590/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c) to strip one pair of surrounding quotes and trim values.

#### 📍Where to Start
Start with the `sanitizeEnvValue` helper and its usage in the main parsing flow in [scripts/revokeInstallations.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1590/files#diff-bf0e556baf581d074f8cb757e8a877da305b51d29a6202bef357c9cb22421c0c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4af639a.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->