### PR TITLE
Cursor: Apply local changes for cloud agent

### DIFF
--- a/agents/monitoring/agents-dms.test.ts
+++ b/agents/monitoring/agents-dms.test.ts
@@ -16,7 +16,7 @@ const testName = "agents-dms";
 describe(testName, async () => {
   setupDurationTracking({ testName, initDataDog: true });
   const env = process.env.XMTP_ENV as XmtpEnv;
-  const workers = await getWorkers(["randomguy"]);
+  const workers = await getWorkers(["bob"]);
 
   const filteredAgents = (productionAgents as AgentConfig[]).filter((agent) => {
     return agent.networks.includes(env as string);

--- a/agents/monitoring/agents.ts
+++ b/agents/monitoring/agents.ts
@@ -110,7 +110,7 @@ const agents: AgentConfig[] = [
     name: "key-check",
     address: "0x235017975ed5F55e23a71979697Cd67DcAE614Fa",
     sendMessage: "/kc",
-    networks: ["dev", "production"],
+    networks: ["production"],
     live: false,
   },
   {

--- a/copilot/.claude/data/agents.ts
+++ b/copilot/.claude/data/agents.ts
@@ -115,7 +115,7 @@ const agents: AgentConfig[] = [
     name: "key-check",
     address: "0x235017975ed5F55e23a71979697Cd67DcAE614Fa",
     sendMessage: "/kc",
-    networks: ["dev", "production"],
+    networks: ["production"],
     live: false,
   },
   {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Exclude self-sent messages in `workers.WorkerClient.collectMessages` and remove `dev` from `key-check` agent networks to apply local cloud agent changes
Filters out client-originated messages during collection and restricts `key-check` to `production` only. Adds message stream debug logging and adjusts `verifyAgentMessageStream` to derive `conversationId` per event and await trigger sends. Updates a test seed from "randomguy" to "bob".

#### 📍Where to Start
Start with `collectMessages` in [workers/main.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1614/files#diff-b0850cab810c868972ef29a309756178e0352f3451e172e5fafb65696616e7a1), then review `verifyAgentMessageStream` in [helpers/streams.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1614/files#diff-3f411bd459665f6d4d59e9ecf3f77b64a7c1dbef042b8dcd67fa869c08d8bb1a) for event filtering and `conversationId` handling.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ea6241b. 4 files reviewed, 8 issues evaluated, 5 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>helpers/streams.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 528](https://github.com/xmtp/xmtp-qa-tools/blob/ea6241bb7b4a5fa8c66ba2d0e0cb5a30b5a9c4bc/helpers/streams.ts#L528): If `collectAndTimeEventsWithStats` throws or rejects, the function exits without stopping the streams started earlier, since there is no `try/finally` around the `await` at line 528. This leaks active streams and can cause subsequent tests/runs to observe unexpected messages or resource usage. Wrap the start/collect/stop flow in `try/finally` to ensure `worker.worker.stopStreams()` is always called. <b>[ Out of scope ]</b>
- [line 558](https://github.com/xmtp/xmtp-qa-tools/blob/ea6241bb7b4a5fa8c66ba2d0e0cb5a30b5a9c4bc/helpers/streams.ts#L558): Message streams started with `worker.worker.startStream(typeofStream.Message)` are not stopped on the early-success path. If `collectAndTimeEventsWithStats` returns a `result` with `averageEventTiming` defined, the function returns at line 558 without calling `worker.worker.stopStreams()`, leaking active streams and associated resources for all `receivers`. Move the stop logic into a `finally` or explicitly stop streams before returning. <b>[ Out of scope ]</b>
</details>

<details>
<summary>workers/main.ts — 0 comments posted, 5 evaluated, 3 filtered</summary>

- [line 588](https://github.com/xmtp/xmtp-qa-tools/blob/ea6241bb7b4a5fa8c66ba2d0e0cb5a30b5a9c4bc/workers/main.ts#L588): Stream may not be properly closed on loop exit: `streamReferences.set(type, { end: streamRef.end || (() => controller.abort()) })` captures an `end` method, but the function never calls it when breaking the `for await` loop (e.g., due to `!this.activeStreamTypes.has(type)` or `controller.signal.aborted`). In `for await`, `break` only calls the iterator’s `return()` if implemented; if the underlying stream requires `end()` for proper teardown, the connection may remain open. Ensure the stream is explicitly ended/returned on all early exits. <b>[ Low confidence ]</b>
- [line 603](https://github.com/xmtp/xmtp-qa-tools/blob/ea6241bb7b4a5fa8c66ba2d0e0cb5a30b5a9c4bc/workers/main.ts#L603): Possible runtime crash: `message?.senderInboxId.toLowerCase()` is invoked without null/undefined guarding the `toLowerCase()` call. If `message.senderInboxId` is `undefined` or `null`, accessing `.toLowerCase()` will throw. Use `message?.senderInboxId?.toLowerCase()` (or validate the type) before comparing to `this.client.inboxId.toLowerCase()`. <b>[ Low confidence ]</b>
- [line 688](https://github.com/xmtp/xmtp-qa-tools/blob/ea6241bb7b4a5fa8c66ba2d0e0cb5a30b5a9c4bc/workers/main.ts#L688): Unhandled rejection and premature stream termination: inside the `while` loop, the `catch` block logs then `throw error;`. Because the async IIFE is invoked and its promise is deliberately ignored via `void (...)`, this rethrow results in an unhandled promise rejection and aborts the entire stream loop rather than retrying or performing graceful shutdown/cleanup. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->