### PR TITLE
Add red background to xmtp.chat

### DIFF
--- a/monitoring/browser/playwright.ts
+++ b/monitoring/browser/playwright.ts
@@ -352,12 +352,34 @@ export class playwright {
         maxRetries--;
       }
       console.debug("Logged in");
+      
+      // Add red background to xmtp.chat
+      await this.addRedBackground(page);
+      
       this.page = page;
       this.browser = browser;
       return { browser, page };
     } catch (error) {
       await this.takeSnapshot("startPage-error");
       throw error;
+    }
+  }
+
+  /**
+   * Injects custom CSS to add a red background to xmtp.chat
+   */
+  private async addRedBackground(page: Page): Promise<void> {
+    try {
+      await page.addStyleTag({
+        content: `
+          body {
+            background-color: red !important;
+          }
+        `,
+      });
+      console.debug("Added red background to xmtp.chat");
+    } catch (error) {
+      console.error("Failed to add red background:", error);
     }
   }
 


### PR DESCRIPTION
Add a red background to xmtp.chat by injecting custom CSS via Playwright.

---
[Slack Thread](https://xmtp-labs.slack.com/archives/D091N9BBA0L/p1764004267319259?thread_ts=1764004267.319259&cid=D091N9BBA0L)

<a href="https://cursor.com/background-agent?bcId=bc-f234ec4d-7eff-49ab-afa0-95f801de55b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f234ec4d-7eff-49ab-afa0-95f801de55b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

