### PR TITLE
Enable agent sync start

### DIFF
--- a/agents/bots/gm/index.ts
+++ b/agents/bots/gm/index.ts
@@ -32,6 +32,4 @@ agent.on("start", () => {
   getSDKVersionInfo(agent, agent.client);
 });
 
-await agent.start({
-  disableSync: true,
-});
+await agent.start();

--- a/agents/bots/key-check/index.ts
+++ b/agents/bots/key-check/index.ts
@@ -425,6 +425,4 @@ agent.on("start", () => {
   getSDKVersionInfo(agent, agent.client);
 });
 
-await agent.start({
-  disableSync: true,
-});
+await agent.start();


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Enable agent sync on gm and key-check startups by removing `Agent.start` options that set `disableSync: true` in [agents/bots/gm/index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1629/files#diff-09ffc7ef3e67c3ce320f1d1827b281089babbece0d5989a9789125903aa983f1) and [agents/bots/key-check/index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1629/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7)
Remove the `disableSync: true` option from `Agent.start` calls so both agents start with default sync behavior.

#### 📍Where to Start
Start at the `agent.start()` invocation in [agents/bots/gm/index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1629/files#diff-09ffc7ef3e67c3ce320f1d1827b281089babbece0d5989a9789125903aa983f1), then review the matching change in [agents/bots/key-check/index.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1629/files#diff-6a616f6ebfc4a1430ba1722347636c49173a8b12a375ea8f537a4c0feecff3a7).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized feb4e6e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->