### PR TITLE
Add xmtp-docs agent config

### DIFF
--- a/agents/agents.ts
+++ b/agents/agents.ts
@@ -115,5 +115,11 @@ const agents: AgentConfig[] = [
     networks: ["dev", "production"],
     live: false,
   },
+  {
+    name: "xmtp-docs",
+    address: "0x212906fdbdb70771461e6cb3376a740132e56b14",
+    networks: ["production"],
+    live: false,
+  },
 ];
 export default agents;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `xmtp-docs` agent config to `agents/agents.ts` for production with address 0x212906fdbdb70771461e6cb3376a740132e56b14 and `live=false`
Append a new `xmtp-docs` entry to the exported agents array in [agents.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1657/files#diff-d575a3a12813607841d7938e5d125e4377637bc22531a7a163a18c20d08194ca) with networks set to `['production']`, address `0x212906fdbdb70771461e6cb3376a740132e56b14`, and `live=false`.

#### 📍Where to Start
Start with the new `xmtp-docs` entry in [agents.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1657/files#diff-d575a3a12813607841d7938e5d125e4377637bc22531a7a163a18c20d08194ca).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e116f65.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->