### PR TITLE
Update nodeBindings version

### DIFF
--- a/helpers/versions.ts
+++ b/helpers/versions.ts
@@ -89,7 +89,7 @@ export const VersionList = [
     Dm: Dm450,
     Group: Group450,
     nodeSDK: "4.5.0",
-    nodeBindings: "1.6.1",
+    nodeBindings: "1.6.2",
     auto: true,
   },
   {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@xmtp/node-bindings-1.3.6": "npm:@xmtp/node-bindings@1.3.6",
     "@xmtp/node-bindings-1.4.0": "npm:@xmtp/node-bindings@1.4.0",
     "@xmtp/node-bindings-1.5.4": "npm:@xmtp/node-bindings@1.5.4",
-    "@xmtp/node-bindings-1.6.1": "npm:@xmtp/node-bindings@1.6.1-rc3",
+    "@xmtp/node-bindings-1.6.2": "npm:@xmtp/node-bindings@1.6.2",
     "@xmtp/node-bindings-1.7.0": "npm:@xmtp/node-bindings@1.7.0-dev.9bc470b",
     "@xmtp/node-sdk-3.2.2": "npm:@xmtp/node-sdk@3.2.2",
     "@xmtp/node-sdk-4.0.1": "npm:@xmtp/node-sdk@4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1696,10 +1696,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings-1.6.1@npm:@xmtp/node-bindings@1.6.1-rc3, @xmtp/node-bindings@npm:1.6.1-rc3":
-  version: 1.6.1-rc3
-  resolution: "@xmtp/node-bindings@npm:1.6.1-rc3"
-  checksum: 10/64e72da74c0552758c360a0f4596c04a0e091017fa07471d454bb25da4e36293005c830c1adc09974333e3d073f2fb164c922ce59ced15fce99389848a16e71f
+"@xmtp/node-bindings-1.6.2@npm:@xmtp/node-bindings@1.6.2":
+  version: 1.6.2
+  resolution: "@xmtp/node-bindings@npm:1.6.2"
+  checksum: 10/6b9a6132217e8758945cdbf50a6a55d07097ebaa8a9109762d8ec4fb720c0c31bed639164c83be56667bccf2fe7d8f9b46113bdbb1313b146638da4a84ad2a5e
   languageName: node
   linkType: hard
 
@@ -1728,6 +1728,13 @@ __metadata:
   version: 1.3.5
   resolution: "@xmtp/node-bindings@npm:1.3.5"
   checksum: 10/7cfdb95de5ec511961a2754c3aca3a96c68e6fababc754aa359f8b222cac20a86689010ccc28e4f5c175cbd87f7d3a01083289993fbe8e1ff8ffb4751b645508
+  languageName: node
+  linkType: hard
+
+"@xmtp/node-bindings@npm:1.6.1-rc3":
+  version: 1.6.1-rc3
+  resolution: "@xmtp/node-bindings@npm:1.6.1-rc3"
+  checksum: 10/64e72da74c0552758c360a0f4596c04a0e091017fa07471d454bb25da4e36293005c830c1adc09974333e3d073f2fb164c922ce59ced15fce99389848a16e71f
   languageName: node
   linkType: hard
 
@@ -5376,7 +5383,7 @@ __metadata:
     "@xmtp/node-bindings-1.3.6": "npm:@xmtp/node-bindings@1.3.6"
     "@xmtp/node-bindings-1.4.0": "npm:@xmtp/node-bindings@1.4.0"
     "@xmtp/node-bindings-1.5.4": "npm:@xmtp/node-bindings@1.5.4"
-    "@xmtp/node-bindings-1.6.1": "npm:@xmtp/node-bindings@1.6.1-rc3"
+    "@xmtp/node-bindings-1.6.2": "npm:@xmtp/node-bindings@1.6.2"
     "@xmtp/node-bindings-1.7.0": "npm:@xmtp/node-bindings@1.7.0-dev.9bc470b"
     "@xmtp/node-sdk-3.2.2": "npm:@xmtp/node-sdk@3.2.2"
     "@xmtp/node-sdk-4.0.1": "npm:@xmtp/node-sdk@4.0.1"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update node bindings for SDK 4.5.0 to version 1.6.2 in `helpers/versions.ts` and `package.json`
Bump the node bindings referenced by the 4.5.0 SDK profile to `1.6.2`, and update the dependency alias to `@xmtp/node-bindings-1.6.2` targeting `npm:@xmtp/node-bindings@1.6.2` with the lockfile refreshed.

#### 📍Where to Start
Start with the `VersionList` update in [helpers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1658/files#diff-4a76eebeb21df1a039004c375f1b41865643020370ec70a15742c61e35a90160), then verify the dependency alias in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1658/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e0a9e69.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->