### PR TITLE
Update node-sdk to 4.5.0-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@xmtp/node-sdk-4.2.6": "npm:@xmtp/node-sdk@4.2.6",
     "@xmtp/node-sdk-4.3.0-dev": "npm:@xmtp/node-sdk@4.3.0-dev.395f798c",
     "@xmtp/node-sdk-4.4.0": "npm:@xmtp/node-sdk@4.4.0",
-    "@xmtp/node-sdk-4.5.0": "npm:@xmtp/node-sdk@4.5.0-rc1",
+    "@xmtp/node-sdk-4.5.0": "npm:@xmtp/node-sdk@4.5.0-rc2",
     "axios": "^1.8.2",
     "datadog-metrics": "^0.12.1",
     "dotenv": "^16.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,10 +1731,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:1.6.1-rc3":
-  version: 1.6.1-rc3
-  resolution: "@xmtp/node-bindings@npm:1.6.1-rc3"
-  checksum: 10/64e72da74c0552758c360a0f4596c04a0e091017fa07471d454bb25da4e36293005c830c1adc09974333e3d073f2fb164c922ce59ced15fce99389848a16e71f
+"@xmtp/node-bindings@npm:1.6.2-rc1":
+  version: 1.6.2-rc1
+  resolution: "@xmtp/node-bindings@npm:1.6.2-rc1"
+  checksum: 10/42e4995b532883d7ee35e05f8caa262f2556bd9be3cd2288eff6cf7217c087091f0828374c1d7814b986f62a7e693a986264eaf82296867ff3a91c56ad0ddd09
   languageName: node
   linkType: hard
 
@@ -1846,15 +1846,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk-4.5.0@npm:@xmtp/node-sdk@4.5.0-rc1":
-  version: 4.5.0-rc1
-  resolution: "@xmtp/node-sdk@npm:4.5.0-rc1"
+"@xmtp/node-sdk-4.5.0@npm:@xmtp/node-sdk@4.5.0-rc2":
+  version: 4.5.0-rc2
+  resolution: "@xmtp/node-sdk@npm:4.5.0-rc2"
   dependencies:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.6.1-rc3"
-  checksum: 10/3df3027cc189cf2c31a83ad47b0a917081046522e3bca8761672d2850f122f87c5b5ea4dc430a59498c02074183f510b2f599f1a15653788a365c160b1423f67
+    "@xmtp/node-bindings": "npm:1.6.2-rc1"
+  checksum: 10/654ef67fd8a5cbff6d5077bb8cff89f1388e1dda28247610fc26b4f357f7352feac62de9154becd4ab822c2d28bc24482a9a71a036c39fae5517f6391ba05315
   languageName: node
   linkType: hard
 
@@ -5394,7 +5394,7 @@ __metadata:
     "@xmtp/node-sdk-4.2.6": "npm:@xmtp/node-sdk@4.2.6"
     "@xmtp/node-sdk-4.3.0-dev": "npm:@xmtp/node-sdk@4.3.0-dev.395f798c"
     "@xmtp/node-sdk-4.4.0": "npm:@xmtp/node-sdk@4.4.0"
-    "@xmtp/node-sdk-4.5.0": "npm:@xmtp/node-sdk@4.5.0-rc1"
+    "@xmtp/node-sdk-4.5.0": "npm:@xmtp/node-sdk@4.5.0-rc2"
     axios: "npm:^1.8.2"
     datadog-metrics: "npm:^0.12.1"
     dotenv: "npm:^16.5.0"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update dependency alias to resolve `@xmtp/node-sdk-4.5.0` to 4.5.0-rc2 in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1660/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)
Change the alias for `@xmtp/node-sdk-4.5.0` to `npm:@xmtp/node-sdk@4.5.0-rc2` and refresh `yarn.lock` to lock the new version.

#### 📍Where to Start
Start with the dependency alias change in [package.json](https://github.com/xmtp/xmtp-qa-tools/pull/1660/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519); then verify lockfile updates in [yarn.lock](https://github.com/xmtp/xmtp-qa-tools/pull/1660/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b23aa23.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->