### PR TITLE
Refactor version detection code

### DIFF
--- a/helpers/versions.ts
+++ b/helpers/versions.ts
@@ -307,52 +307,11 @@ export function detectNodeSDKVersion(client: any): {
         `node-bindings-${version.nodeBindings}`,
       );
       if (fs.existsSync(bindingsDir)) {
-        const versionJsonPath = path.join(bindingsDir, "dist", "version.json");
-        if (fs.existsSync(versionJsonPath)) {
-          try {
-            const versionInfo = JSON.parse(
-              fs.readFileSync(versionJsonPath, "utf8"),
-            );
-            // Check if this bindings version matches what the client might be using
-            // by checking the client's internal structure or by checking which node-sdk
-            // is linked to this bindings
-            const nodeSDKDir = path.join(
-              xmtpDir,
-              `node-sdk-${version.nodeSDK}`,
-            );
-            const sdkNodeModulesXmtpDir = path.join(
-              nodeSDKDir,
-              "node_modules",
-              "@xmtp",
-            );
-            const symlinkTarget = path.join(
-              sdkNodeModulesXmtpDir,
-              "node-bindings",
-            );
-
-            if (fs.existsSync(symlinkTarget)) {
-              try {
-                const stats = fs.lstatSync(symlinkTarget);
-                if (stats.isSymbolicLink()) {
-                  const target = fs.readlinkSync(symlinkTarget);
-                  if (
-                    path.resolve(sdkNodeModulesXmtpDir, target) === bindingsDir
-                  ) {
-                    return {
-                      nodeSDK: version.nodeSDK,
-                      nodeBindings: version.nodeBindings,
-                      bindingsVersion: versionInfo,
-                    };
-                  }
-                }
-              } catch {
-                // Ignore symlink read errors
-              }
-            }
-          } catch {
-            // Ignore version.json read errors
-          }
-        }
+        return {
+          nodeSDK: version.nodeSDK,
+          nodeBindings: version.nodeBindings,
+          bindingsVersion: getBindingsVersion(version.nodeBindings),
+        };
       }
     }
   } catch {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refactor `helpers/versions.ts` to return detected Node SDK and bindings on existence check in `detectNodeSDKVersion` for version detection
Replace the fallback path in `helpers/versions.ts` `detectNodeSDKVersion` to return `nodeSDK`, `nodeBindings`, and `bindingsVersion` via `getBindingsVersion(version.nodeBindings)` when `node_modules/@xmtp/node-bindings-{version.nodeBindings}` exists, removing symlink and `dist/version.json` verification.

#### 📍Where to Start
Start with the fallback branch of `detectNodeSDKVersion` in [versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1667/files#diff-4a76eebeb21df1a039004c375f1b41865643020370ec70a15742c61e35a90160).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6cbaf1a.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->