### PR TITLE
Enhance message logging details

### DIFF
--- a/agents/helper.ts
+++ b/agents/helper.ts
@@ -1,4 +1,5 @@
 import { type DecodedMessage, type MessageContext } from "@agents/versions";
+import agents from "./agents";
 
 /**
  * Agent configuration interface
@@ -30,9 +31,19 @@ export async function getMessageBody(ctx: MessageContext, timezone?: string) {
       dateString = ctx.message.sentAt.toISOString();
     }
     const serverId = process.env.SERVER_ID || "railway";
-    const messageBody1 = `replying from ${serverId} to a message sent by ${senderAddress} on ${dateString} on converstion ${ctx.conversation.id}. Content: "${messageContent}"`;
+    const messageBody1 = `replying from ${serverId} to a message \n sent by ${senderAddress} \n on ${dateString} \n on converstion ${ctx.conversation.id}. \n \n Content: "${messageContent}"`;
 
     console.log(messageBody1);
+    console.log({
+      receiver: {
+        libxmtpVersion: ctx.client.libxmtpVersion,
+        installationId: ctx.client.installationId,
+        inboxId: ctx.client.inboxId,
+      },
+      sender: {
+        address: senderAddress,
+      },
+    });
     return messageBody1;
   } catch (error) {
     console.error("Error getting message body", error);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add line breaks to `agents/helper.getMessageBody` output and log receiver and sender metadata for message logging
Update `agents/helper.ts` to adjust `helper.getMessageBody` formatting with added line breaks and insert a `console.log` that records `ctx.client.libxmtpVersion`, `ctx.client.installationId`, `ctx.client.inboxId`, and sender address.

#### 📍Where to Start
Start with `helper.getMessageBody` in [helper.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1683/files#diff-25f07a36a2c1d2116c5ad09290bfe14f15fb49584ce66af33d11a4d7fddf3c73).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized e9a8fe6.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->