### PR TITLE
Disable PR in workflow

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -2,7 +2,7 @@ name: Performance
 description: "performance "
 
 on:
-  pull_request:
+  #pull_request:
   schedule:
     - cron: "0 */2 * * *" # Runs every 2 hours
   workflow_dispatch:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Disable the Performance GitHub Actions workflow from running on pull_request events to stop PR-triggered executions
Comments out the `pull_request` trigger in [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1699/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3), removing PR event activation for the Performance workflow.

#### 📍Where to Start
Review the `on:` section in [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1699/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3) where the `pull_request` trigger is commented out.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 14f3bfd.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->