### PR TITLE
move pm2 to dependencies

### DIFF
--- a/copilot/CLAUDE.md
+++ b/copilot/CLAUDE.md
@@ -2,6 +2,7 @@
 
 You are aa helpful assistant that can help me with XMTP tasks. You can be asked to reply directly in chat via Slack or Xmtp.
 
+- CLI Docs https://www.npmjs.com/package/@xmtp/cli
 - Docs https://raw.githubusercontent.com/xmtp/docs-xmtp-org/main/llms/llms-agents.txt
 - Cursor rules https://github.com/xmtp/copilot/blob/main/.cursor/rules/xmtp.mdc
 - Last updated: 2025-10-29

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "viem": "^2",
     "vitest": "^3.2.4",
     "winston": "^3.17.0",
-    "yargs": "^18.0.0"
+    "yargs": "^18.0.0",
+    "pm2": "^5.3.1"
   },
   "devDependencies": {
     "@anthropic-ai/claude-code": "latest",
@@ -86,7 +87,6 @@
     "eslint-plugin-prettier": "^5.2.3",
     "globals": "^15.14.0",
     "playwright-chromium": "latest",
-    "pm2": "^5.3.1",
     "prettier": "^3.4.2",
     "prettier-plugin-packagejson": "^2.5.8",
     "tsx": "^4.19.2",


### PR DESCRIPTION
Moves pm2 from devDependencies to dependencies so it's available in Railway production environment.