### PR TITLE
Fix dm test

### DIFF
--- a/agents/agents.ts
+++ b/agents/agents.ts
@@ -68,6 +68,12 @@ const agents: AgentConfig[] = [
   //   live: false,
   // },
   {
+    name: "fail-agent",
+    address: "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0",
+    networks: ["dev"],
+    live: false,
+  },
+  {
     name: "echo",
     address: "0xc832b862fde939e8ba29b80b62e28a2e3c022d5a",
     networks: ["dev"],


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix dm test by instantiating a shared `agents/monitoring/agents-dms.test.ts` suite `Agent` and adjusting response timing to use `AGENT_RESPONSE_TIMEOUT` when `result.responseTime` is undefined
Add a `fail-agent` entry to the agents list in [agents.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1719/files#diff-d575a3a12813607841d7938e5d125e4377637bc22531a7a163a18c20d08194ca). Refactor the DM test to create one `Agent` in a suite `beforeAll` and record timeout when no response time is present in [agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1719/files#diff-dc07e51c8a1c9966b6553a8dec33b9f7db7077911ee60663ffb27a7aa23edb96).

#### 📍Where to Start
Start with the suite `beforeAll` and `Agent` usage in [agents-dms.test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1719/files#diff-dc07e51c8a1c9966b6553a8dec33b9f7db7077911ee60663ffb27a7aa23edb96).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 32318ac.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->