### PR TITLE
stream pm2 logs

### DIFF
--- a/cli/pm2.ts
+++ b/cli/pm2.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 import { spawn } from "child_process";
+import { mkdirSync } from "fs";
 import { join } from "path";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = join(__filename, "..");
+const projectRoot = join(__dirname, "..");
 
 const botName = process.argv[2] || "gm";
 
@@ -17,16 +19,44 @@ const ecosystemPath = join(
   "ecosystem.config.cjs",
 );
 
-const child = spawn("pm2", ["start", ecosystemPath], {
+const logsDir = join(projectRoot, "logs");
+try {
+  mkdirSync(logsDir, { recursive: true });
+} catch (error) {
+  // Directory might already exist, ignore
+}
+
+const appName = `${botName}-bot`;
+
+const startProcess = spawn("pm2", ["start", ecosystemPath], {
   stdio: "inherit",
-  cwd: join(__dirname, ".."),
+  cwd: projectRoot,
 });
 
-child.on("error", (error) => {
+startProcess.on("error", (error) => {
   console.error(`Failed to start bot: ${error.message}`);
   process.exit(1);
 });
 
-child.on("exit", (code) => {
-  process.exit(code || 0);
+startProcess.on("exit", (code) => {
+  if (code !== 0) {
+    process.exit(code || 1);
+  }
+
+  console.log(`\n[PM2] Starting log stream for ${appName}...\n`);
+
+  const logsProcess = spawn("pm2", ["logs", appName, "--lines", "1000"], {
+    stdio: "inherit",
+    cwd: projectRoot,
+  });
+
+  logsProcess.on("error", (error) => {
+    console.error(`Failed to stream logs: ${error.message}`);
+    process.exit(1);
+  });
+
+  process.on("SIGINT", () => {
+    logsProcess.kill();
+    process.exit(0);
+  });
 });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Stream PM2 logs after starting the app and create projectRoot/logs in [cli/pm2.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1724/files#diff-ccf877e9342a903a6d90804a1eaac44702690fdc442250e24757828b85724edd)
Add log streaming via `pm2 logs --lines 1000` for `appName`, set `cwd` to `projectRoot`, create `projectRoot/logs`, exit with code 1 on start failure, and handle `SIGINT` to stop the logs process in [cli/pm2.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1724/files#diff-ccf877e9342a903a6d90804a1eaac44702690fdc442250e24757828b85724edd).

#### 📍Where to Start
Start with the PM2 start and logs spawning logic in [cli/pm2.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1724/files#diff-ccf877e9342a903a6d90804a1eaac44702690fdc442250e24757828b85724edd), focusing on the `startProcess` creation and subsequent `pm2 logs` process setup.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized ce85b86.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->