### PR TITLE
Fix: Log timeout metrics to Datadog for failed agents in agents-dms test

### DIFF
--- a/agents/monitoring/agents-dms.test.ts
+++ b/agents/monitoring/agents-dms.test.ts
@@ -49,16 +49,26 @@ describe(testName, () => {
           `📤 Sending "${PING_MESSAGE}" to ${agentConfig.name} (${agentConfig.address})`,
         );
 
-        const result = await waitForResponse({
-          client: agent.client as any,
-          conversation: {
-            send: (content: string) => conversation.send(content),
-          },
-          conversationId: conversation.id,
-          senderInboxId: agent.client.inboxId,
-          timeout: AGENT_RESPONSE_TIMEOUT,
-          messageText: PING_MESSAGE,
-        });
+        let result;
+        try {
+          result = await waitForResponse({
+            client: agent.client as any,
+            conversation: {
+              send: (content: string) => conversation.send(content),
+            },
+            conversationId: conversation.id,
+            senderInboxId: agent.client.inboxId,
+            timeout: AGENT_RESPONSE_TIMEOUT,
+            messageText: PING_MESSAGE,
+          });
+        } catch {
+          result = {
+            success: false,
+            sendTime: 0,
+            responseTime: AGENT_RESPONSE_TIMEOUT,
+            responseMessage: null,
+          };
+        }
 
         sendMetric(
           "response",


### PR DESCRIPTION
When agents timeout in the agents-dms test, the timeout metrics were not being logged to Datadog because the error was thrown before sendMetric could be called. This PR wraps waitForResponse in a try-catch block to ensure metrics are always sent, matching the pattern used in agents-untagged.test.ts.