### PR TITLE
Fix: Make agents-text and agents-tagged tests fail on timeout while still logging metrics

### DIFF
--- a/agents/monitoring/agents-text.test.ts
+++ b/agents/monitoring/agents-text.test.ts
@@ -10,7 +10,7 @@ import { sendMetric, type ResponseMetricTags } from "@helpers/datadog";
 import { setupDurationTracking } from "@helpers/vitest";
 import { ActionsCodec } from "agents/utils/inline-actions/types/ActionsContent";
 import { IntentCodec } from "agents/utils/inline-actions/types/IntentContent";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const testName = "agents-text";
 
@@ -46,30 +46,39 @@ describe(testName, () => {
           `📤 Sending "${PING_MESSAGE}" to ${agentConfig.name} (${agentConfig.address})`,
         );
 
-        const result = await waitForResponse({
-          client: agent.client as any,
-          conversation: {
-            send: (content: string) => conversation.send(content),
-          },
-          conversationId: conversation.id,
-          senderInboxId: agent.client.inboxId,
-          timeout: AGENT_RESPONSE_TIMEOUT,
-          messageText: PING_MESSAGE,
-          messageFilter: (message) => {
-            return message.contentType?.typeId === "text";
-          },
-        });
+        let result;
+        try {
+          result = await waitForResponse({
+            client: agent.client as any,
+            conversation: {
+              send: (content: string) => conversation.send(content),
+            },
+            conversationId: conversation.id,
+            senderInboxId: agent.client.inboxId,
+            timeout: AGENT_RESPONSE_TIMEOUT,
+            messageText: PING_MESSAGE,
+            messageFilter: (message) => {
+              return message.contentType?.typeId === "text";
+            },
+          });
+        } catch {
+          result = {
+            success: false,
+            sendTime: 0,
+            responseTime: AGENT_RESPONSE_TIMEOUT,
+            responseMessage: null,
+          };
+        }
 
         const responseTime = Math.max(result.responseTime || 0, 0.0001);
         sendMetric("response", responseTime, createMetricTags(agentConfig));
 
-        if (result.success && result.responseMessage) {
-          console.log(
-            `✅ ${agentConfig.name} responded in ${responseTime.toFixed(2)}ms`,
-          );
-        } else {
-          console.error(`❌ ${agentConfig.name} - NO RESPONSE within timeout`);
-        }
+        expect(result.success).toBe(true);
+        expect(result.responseMessage).toBeTruthy();
+
+        console.log(
+          `✅ ${agentConfig.name} responded in ${responseTime.toFixed(2)}ms`,
+        );
       } finally {
         await agent.stop();
       }


### PR DESCRIPTION
This PR applies the same fix to agents-text and agents-tagged tests that was applied to agents-dms test. It ensures that tests fail when agents timeout (as expected), while still logging timeout metrics to Datadog. Added expect assertions to fail the test when result.success is false, after metrics are sent.