### PR TITLE
Do not send metrics to datadog when --no-datadog option is provided

### DIFF
--- a/cli/test.ts
+++ b/cli/test.ts
@@ -281,6 +281,7 @@ function parseTestArgs(args: string[]): {
         break;
       case "--no-datadog":
         options.sendToDatadog = false;
+        process.env.DISABLE_DATADOG = "true";
         break;
       case "--no-fail":
         options.noFail = true;

--- a/helpers/datadog.ts
+++ b/helpers/datadog.ts
@@ -130,6 +130,9 @@ function getOperationKey(tags: MetricTags, metricName: string): string {
 }
 
 export function initializeDatadog(): boolean {
+  if (process.env.DISABLE_DATADOG === "true") {
+    return false;
+  }
   if (!process.env.DATADOG_API_KEY) {
     console.warn("⚠️ DATADOG_API_KEY not found - metrics will not be sent");
     return false;
@@ -159,6 +162,9 @@ export function sendMetric(
   metricValue: number,
   tags: MetricTags,
 ): void {
+  if (process.env.DISABLE_DATADOG === "true") {
+    return;
+  }
   try {
     if (metricValue <= 0) {
       console.error(`${metricName} Metric value is ${metricValue}`);
@@ -220,6 +226,9 @@ export function sendHistogramMetric(
   metricValue: number,
   tags: MetricTags,
 ): void {
+  if (process.env.DISABLE_DATADOG === "true") {
+    return;
+  }
   try {
     if (metricValue <= 0) {
       console.error(`${metricName} Histogram metric value is ${metricValue}`);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Disable DataDog metrics across the CLI when `--no-datadog` is provided by setting `process.env.DISABLE_DATADOG="true"` and short-circuiting in `helpers/datadog.ts`
Add a process-wide `DISABLE_DATADOG="true"` when the CLI is run with `--no-datadog`, and guard `initializeDatadog`, `sendMetric`, and `sendHistogramMetric` to no-op when this env var is set. Key changes are in [cli/test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1748/files#diff-c8ae179b9daddfdfc3e0fedd868f032dab62c38a4b05a65d61351708ac7b81c4) and [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1748/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3).

#### 📍Where to Start
Start with `parseTestArgs` in [cli/test.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1748/files#diff-c8ae179b9daddfdfc3e0fedd868f032dab62c38a4b05a65d61351708ac7b81c4), then review the early-return guards in `initializeDatadog`, `sendMetric`, and `sendHistogramMetric` in [helpers/datadog.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1748/files#diff-4b45992af40883b9294685042f6973083076dbf4a72b1c6cdc8fa9bb0cea82f3).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 42d3722.
<!-- Macroscope's review summary ends here -->
<!-- Macroscope's pull request summary ends here -->