### PR TITLE
fix: update gm bot address

### DIFF
--- a/agents/agents.ts
+++ b/agents/agents.ts
@@ -81,7 +81,7 @@ const agents: AgentConfig[] = [
   },
   {
     name: "gm",
-    address: "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0",
+    address: "0x4796C95DDACb0A29c3b2c8295a8b2fB94d5046e9",
     networks: ["dev", "production"],
     live: false,
   },

--- a/agents/monitoring/README.md
+++ b/agents/monitoring/README.md
@@ -88,7 +88,7 @@ Link to test code [agents-tagged.test.ts](./agents-tagged.test.ts)
 ```json
 {
   "name": "gm",
-  "address": "0x194c31cae1418d5256e8c58e0d08aee1046c6ed0",
+  "address": "0x4796C95DDACb0A29c3b2c8295a8b2fB94d5046e9",
   "sendMessage": "hola",
   "live": false,
   "networks": ["dev", "production"],


### PR DESCRIPTION
## Summary
- Add `customText` to agent config for monitoring tests (e.g. xmtp-docs uses `/ask hi`)
- Update gm agent address in config and README

Tests use `agentConfig.customText || PING_MESSAGE` when sending the first message to agents.

Made with [Cursor](https://cursor.com)