### PR TITLE
Fix LogLevel enum error for node-sdk-5.0.0

### DIFF
--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -2,7 +2,7 @@ name: Performance
 description: "performance "
 
 on:
-  #pull_request:
+  pull_request:
   schedule:
     - cron: "0 */2 * * *" # Runs every 2 hours
   workflow_dispatch:

--- a/helpers/versions.ts
+++ b/helpers/versions.ts
@@ -102,16 +102,7 @@ export const VersionList = [
     Dm: Dm50,
     Group: Group50,
     nodeSDK: "5.0.0",
-    nodeBindings: "1.7.0",
-    auto: true,
-  },
-  {
-    Client: Client50,
-    Conversation: Conversation50,
-    Dm: Dm50,
-    Group: Group50,
-    nodeSDK: "5.0.0",
-    nodeBindings: "1.7.0",
+    nodeBindings: "1.9.1",
     auto: true,
   },
   {


### PR DESCRIPTION
## Summary
- **Fix LogLevel crash**: Updated `nodeBindings` mapping for node-sdk-5.0.0 from `1.7.0` to `1.9.1` (the actual dependency version). This was causing `normalizeLogLevel` to lowercase the log level (`"error"`) instead of capitalizing it (`"Error"`), which the bindings 1.9.1 enum requires.
- **Remove duplicate entry**: Removed redundant second VersionList entry for node-sdk-5.0.0.
- **Enable PR trigger**: Uncommented `pull_request` trigger in Performance workflow.

## Test plan
- [ ] Run `yarn test performance` and verify no `LogLevel` enum error
- [ ] Verify performance workflow triggers on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct VersionList mapping for node-sdk 5.0.0 by setting nodeBindings to 1.9.1 and enable Performance workflow on pull_request events
> Update `VersionList` in [helpers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1772/files#diff-4a76eebeb21df1a039004c375f1b41865643020370ec70a15742c61e35a90160) to map node-sdk `5.0.0` to nodeBindings `1.9.1` and remove the duplicate `5.0.0` entry. Enable the Performance GitHub Actions workflow to run on `pull_request` events in [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1772/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3).
>
> #### 📍Where to Start
> Start with the `VersionList` changes in [helpers/versions.ts](https://github.com/xmtp/xmtp-qa-tools/pull/1772/files#diff-4a76eebeb21df1a039004c375f1b41865643020370ec70a15742c61e35a90160), then verify the workflow trigger in [Performance.yml](https://github.com/xmtp/xmtp-qa-tools/pull/1772/files#diff-bd5e7c52613f5d94ed4925b994e3f0e52c88176883f880aac2cf33ca4e8600e3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5336cb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->