### PR TITLE
Point the CI perf suites at the perf gateway (nearest-node selection strategy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ LOGGING_LEVEL="error" # rust library logs
 # XMTP_D14N="true"                                              # Enable D14N mode
 # XMTP_API_URL="https://grpc.testnet-staging.xmtp.network:443"  # D14N gateway URL
 
+# GATEWAY HOST (D14N payer gateway for writes)
+# For performance testing, use the perf gateway with closest-node selection:
+# XMTP_GATEWAY_HOST="https://payer-perf.testnet-dev.xmtp.network:443"
+# For standard testing, use the default gateway:
+# XMTP_GATEWAY_HOST="https://payer.testnet-dev.xmtp.network:443"
+
 # V3 MODE (default)
 # Set only XMTP_API_URL without XMTP_D14N to use custom V3 endpoint:
 # XMTP_API_URL="https://custom-v3-endpoint.example.com"

--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,9 @@ LOGGING_LEVEL="error" # rust library logs
 
 # GATEWAY HOST (D14N payer gateway for writes)
 # For performance testing, use the perf gateway with closest-node selection:
-# XMTP_GATEWAY_HOST="https://payer-perf.testnet-dev.xmtp.network:443"
+# XMTP_GATEWAY_HOST="https://payer-perf.testnet-staging.xmtp.network:443"
 # For standard testing, use the default gateway:
-# XMTP_GATEWAY_HOST="https://payer.testnet-dev.xmtp.network:443"
+# XMTP_GATEWAY_HOST="https://payer.testnet-staging.xmtp.network:443"
 
 # V3 MODE (default)
 # Set only XMTP_API_URL without XMTP_D14N to use custom V3 endpoint:

--- a/.github/workflows/Performance-L.yml
+++ b/.github/workflows/Performance-L.yml
@@ -21,7 +21,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && (secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST) || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env

--- a/.github/workflows/Performance-L.yml
+++ b/.github/workflows/Performance-L.yml
@@ -21,7 +21,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env

--- a/.github/workflows/Performance-M.yml
+++ b/.github/workflows/Performance-M.yml
@@ -21,7 +21,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && (secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST) || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env

--- a/.github/workflows/Performance-M.yml
+++ b/.github/workflows/Performance-M.yml
@@ -21,7 +21,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -23,7 +23,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env

--- a/.github/workflows/Performance.yml
+++ b/.github/workflows/Performance.yml
@@ -23,7 +23,7 @@ jobs:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && (secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST) || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup test env

--- a/.github/workflows/ProtocolPerformanceStats.yml
+++ b/.github/workflows/ProtocolPerformanceStats.yml
@@ -20,7 +20,7 @@ jobs:
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       GROUP_STATS_MESSAGE_COUNT: 5
-      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ProtocolPerformanceStats.yml
+++ b/.github/workflows/ProtocolPerformanceStats.yml
@@ -20,7 +20,7 @@ jobs:
       REGION: ${{ vars.REGION }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       GROUP_STATS_MESSAGE_COUNT: 5
-      XMTP_GATEWAY_HOST: ${{ secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST || '' }}
+      XMTP_GATEWAY_HOST: ${{ matrix.env == 'testnet-staging' && (secrets.XMTP_PERF_GATEWAY_HOST || secrets.XMTP_GATEWAY_HOST) || '' }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Point the CI perf suites at the perf gateway with the nearest-node selection strategy for more consistent, accurate, and useful results. Will assist greatly in regression detection as variance will be much lower.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Point CI performance suite workflows at the perf gateway for testnet-staging runs
> Updates all four CI performance workflow files ([Performance.yml](.github/workflows/Performance.yml), [Performance-L.yml](.github/workflows/Performance-L.yml), [Performance-M.yml](.github/workflows/Performance-M.yml), [ProtocolPerformanceStats.yml](.github/workflows/ProtocolPerformanceStats.yml)) to set `XMTP_GATEWAY_HOST` to `XMTP_PERF_GATEWAY_HOST` (nearest-node selection) when running against `testnet-staging`, falling back to `XMTP_GATEWAY_HOST` if the perf secret is unset. The variable remains empty for all other environments. Also adds example values for `XMTP_GATEWAY_HOST` to [.env.example](.env.example).
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1780 opened
>
> - Updated XMTP gateway host URL examples from `testnet-dev` to `testnet-staging` [237a7e1]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4d83da.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->